### PR TITLE
fix(analytics): track URL slugs in case_view and entity_view events

### DIFF
--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -79,7 +79,7 @@ const CaseDetail = () => {
       return;
     }
 
-    trackEvent('case_view', { case_id: loadedCaseId });
+    trackEvent('case_view', { case_id: loadedCaseId, slug: `/case/${id}` });
     trackedCaseIdRef.current = loadedCaseId;
   }, [id, caseData?.id, isError]);
 

--- a/src/pages/EntityProfile.tsx
+++ b/src/pages/EntityProfile.tsx
@@ -48,9 +48,10 @@ export default function EntityProfile() {
     trackEvent('entity_view', {
       entity_type: jawafEntity.type || 'unknown',
       entity_id: entityId,
+      slug: `/entity/${encodedId}`,
     });
     trackedEntityIdRef.current = entityId;
-  }, [jawafEntity]);
+  }, [jawafEntity, encodedId]);
 
   return (
     <div className="min-h-screen flex flex-col bg-background">

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -18,8 +18,8 @@ declare global {
 
 // Event type definitions for type-safety
 export type AnalyticsEvent =
-  | { name: 'case_view'; params: { case_id: string } }
-  | { name: 'entity_view'; params: { entity_type: string; entity_id: string } }
+  | { name: 'case_view'; params: { case_id: string; slug: string } }
+  | { name: 'entity_view'; params: { entity_type: string; entity_id: string; slug: string } }
   | { name: 'language_switch'; params: { from_lang: string; to_lang: string } }
   | { name: 'allegation_submitted'; params?: Record<string, never> };
 
@@ -34,7 +34,7 @@ type AnalyticsEventParams<T extends AnalyticsEvent['name']> =
  * 
  * @example
  * // Track a case view
- * trackEvent('case_view', { case_id: '123' });
+ * trackEvent('case_view', { case_id: '123', slug: '/case/123' });
  * 
  * @example
  * // Track language switch


### PR DESCRIPTION
## Summary

Addresses the review feedback from #69 — adds `slug` tracking to `case_view` and `entity_view` GA4 events.

### Changes
- **`src/utils/analytics.ts`**: Added `slug: string` parameter to `case_view` and `entity_view` event type definitions
- **`src/pages/CaseDetail.tsx`**: Sends `/case/:id` slug with `case_view` events
- **`src/pages/EntityProfile.tsx`**: Sends `/entity/:id` slug with `entity_view` events

### Why
Previously, GA4 events only included numeric IDs (`case_id`, `entity_id`). The reviewer requested that we also track the URL slug so analytics reports show which specific pages were viewed in a human-readable format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking to capture page paths for case and entity views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->