### PR TITLE
feat(workflow): add workflow runs visualization dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { CaseworkerAuthProvider } from "./context/CaseworkerAuthContext";
 import CaseworkerLogin from "./pages/CaseworkerLogin";
 import CaseworkerDashboard from "./pages/CaseworkerDashboard";
 import CaseworkerSettings from "./pages/CaseworkerSettings";
+import WorkflowRuns from "./pages/WorkflowRuns";
 
 const App = () => (
   <TooltipProvider>
@@ -58,6 +59,7 @@ const App = () => (
               <Route path="login" element={<CaseworkerLogin />} />
               <Route path="dashboard" element={<CaseworkerDashboard />} />
               <Route path="settings" element={<CaseworkerSettings />} />
+              <Route path="workflow-runs" element={<WorkflowRuns />} />
             </Routes>
           </CaseworkerAuthProvider>
         }

--- a/src/components/workflow/WorkflowRunCard.tsx
+++ b/src/components/workflow/WorkflowRunCard.tsx
@@ -1,0 +1,238 @@
+/**
+ * WorkflowRunCard — expandable card for a single workflow run.
+ *
+ * Collapsed: run ID, case ID, status badge, timestamps.
+ * Expanded:  step pipeline + output file list.
+ */
+
+import { useState, useEffect } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  FileText,
+  AlertCircle,
+} from "lucide-react";
+import type { WorkflowRun, WorkflowRunDetail } from "@/types/workflow";
+import { getWorkflowRunDetail, computeStepStatuses, formatFileSize, formatDuration } from "@/services/workflow-api";
+import { WorkflowStepPipeline } from "./WorkflowStepPipeline";
+
+interface WorkflowRunCardProps {
+  run: WorkflowRun;
+}
+
+function StatusBadge({ run }: { run: WorkflowRun }) {
+  if (run.has_failed) {
+    return (
+      <Badge variant="destructive" className="gap-1">
+        <AlertCircle className="h-3 w-3" /> Failed
+      </Badge>
+    );
+  }
+  if (run.is_complete) {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-200 gap-1">
+        ✓ Complete
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-200 gap-1 animate-pulse">
+      <Clock className="h-3 w-3" /> Running
+    </Badge>
+  );
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function WorkflowRunCard({ run }: WorkflowRunCardProps) {
+  const [open, setOpen] = useState(false);
+  const [detail, setDetail] = useState<WorkflowRunDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch detail when expanded
+  useEffect(() => {
+    if (!open || detail) return;
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+    getWorkflowRunDetail(run.run_id)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e?.message ?? "Failed to load details");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, detail, run.run_id]);
+
+  const steps = detail ? computeStepStatuses(detail) : [];
+  const files = detail?.case_data?.files ?? {};
+  const fileEntries = Object.entries(files);
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="bg-white rounded-xl border border-border shadow-sm hover:shadow-md transition-shadow"
+    >
+      {/* Collapsed header */}
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="w-full flex items-center justify-between p-4 text-left cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 flex-1 min-w-0">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="font-mono text-sm font-semibold text-foreground truncate">
+                {run.run_id}
+              </span>
+              <StatusBadge run={run} />
+            </div>
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">{run.case_id}</span>
+              <span className="hidden sm:inline text-xs px-2 py-0.5 bg-muted rounded-full">
+                {run.workflow_id}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 ml-2 shrink-0">
+            <div className="hidden md:flex flex-col items-end text-xs text-muted-foreground">
+              <span>Started: {formatDate(run.started_at)}</span>
+              {run.completed_at && (
+                <span className="font-medium text-foreground">
+                  Duration: {formatDuration(run.started_at, run.completed_at)}
+                </span>
+              )}
+            </div>
+            {open ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </div>
+        </button>
+      </CollapsibleTrigger>
+
+      {/* Expanded detail */}
+      <CollapsibleContent>
+        <div className="border-t border-border px-4 pb-4 space-y-4">
+          {/* Mobile timestamps */}
+          <div className="md:hidden pt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            <span>Started: {formatDate(run.started_at)}</span>
+            {run.completed_at && (
+              <span>
+                Duration: {formatDuration(run.started_at, run.completed_at)}
+              </span>
+            )}
+          </div>
+
+          {/* Error message */}
+          {run.error_message && (
+            <div className="mt-3 p-3 rounded-lg bg-red-50 border border-red-200">
+              <p className="text-sm text-red-800 font-medium flex items-center gap-1.5">
+                <AlertCircle className="h-4 w-4 shrink-0" /> Error
+              </p>
+              <p className="text-sm text-red-700 mt-1 whitespace-pre-wrap">
+                {run.error_message}
+              </p>
+            </div>
+          )}
+
+          {/* Loading */}
+          {loading && (
+            <div className="pt-3 space-y-3">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-6 w-3/4" />
+            </div>
+          )}
+
+          {/* Error loading detail */}
+          {error && (
+            <div className="pt-3">
+              <p className="text-sm text-red-600">{error}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => {
+                  setDetail(null);
+                  setError(null);
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {/* Step pipeline */}
+          {detail && !loading && (
+            <>
+              <div className="pt-3">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                  Pipeline
+                </p>
+                <WorkflowStepPipeline steps={steps} />
+              </div>
+
+              {/* Output files */}
+              {fileEntries.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                    Output Files ({fileEntries.length})
+                  </p>
+                  <div className="grid gap-1.5">
+                    {fileEntries
+                      .sort(([a], [b]) => a.localeCompare(b))
+                      .map(([name, file]) => (
+                        <div
+                          key={name}
+                          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-muted/50 text-sm"
+                        >
+                          <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="font-mono text-xs truncate flex-1">{name}</span>
+                          <span className="text-xs text-muted-foreground shrink-0">
+                            {formatFileSize(file.size)}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/workflow/WorkflowRunFilters.tsx
+++ b/src/components/workflow/WorkflowRunFilters.tsx
@@ -1,0 +1,59 @@
+/**
+ * WorkflowRunFilters — status tabs + search input.
+ *
+ * Renders: [All] [Running] [Complete] [Failed]  🔍 Search
+ */
+
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Search } from "lucide-react";
+import type { RunStatusFilter } from "@/types/workflow";
+
+interface WorkflowRunFiltersProps {
+  status: RunStatusFilter;
+  search: string;
+  onStatusChange: (status: RunStatusFilter) => void;
+  onSearchChange: (search: string) => void;
+}
+
+const STATUS_OPTIONS: { value: RunStatusFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "running", label: "Running" },
+  { value: "complete", label: "Complete" },
+  { value: "failed", label: "Failed" },
+];
+
+export function WorkflowRunFilters({
+  status,
+  search,
+  onStatusChange,
+  onSearchChange,
+}: WorkflowRunFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+      <Tabs
+        value={status}
+        onValueChange={(v) => onStatusChange(v as RunStatusFilter)}
+        className="w-full sm:w-auto"
+      >
+        <TabsList className="grid grid-cols-4 w-full sm:w-auto">
+          {STATUS_OPTIONS.map((opt) => (
+            <TabsTrigger key={opt.value} value={opt.value} className="text-sm">
+              {opt.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <div className="relative flex-1 w-full sm:max-w-xs">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search by case ID or run ID…"
+          className="pl-9"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/workflow/WorkflowStepPipeline.tsx
+++ b/src/components/workflow/WorkflowStepPipeline.tsx
@@ -1,0 +1,169 @@
+/**
+ * WorkflowStepPipeline — horizontal step pipeline visualization.
+ *
+ * Renders each step as a colored circle connected by lines:
+ *   ✅ ─── ✅ ─── 🔵 ─── ⚪ ─── ⚪
+ *  Init   Docs  Review  Create  Update
+ */
+
+import type { StepDisplayInfo } from "@/types/workflow";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { CheckCircle2, Circle, Loader2, XCircle } from "lucide-react";
+
+interface WorkflowStepPipelineProps {
+  steps: StepDisplayInfo[];
+}
+
+const statusColors: Record<string, { node: string; line: string; text: string }> = {
+  complete: {
+    node: "text-emerald-500",
+    line: "bg-emerald-400",
+    text: "text-emerald-700",
+  },
+  "in-progress": {
+    node: "text-blue-500",
+    line: "bg-gray-200",
+    text: "text-blue-700",
+  },
+  failed: {
+    node: "text-red-500",
+    line: "bg-gray-200",
+    text: "text-red-700",
+  },
+  pending: {
+    node: "text-gray-300",
+    line: "bg-gray-200",
+    text: "text-gray-400",
+  },
+};
+
+function StepIcon({ status }: { status: string }) {
+  switch (status) {
+    case "complete":
+      return <CheckCircle2 className="h-6 w-6" />;
+    case "in-progress":
+      return <Loader2 className="h-6 w-6 animate-spin" />;
+    case "failed":
+      return <XCircle className="h-6 w-6" />;
+    default:
+      return <Circle className="h-6 w-6" />;
+  }
+}
+
+function formatTimestamp(iso?: string): string {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function WorkflowStepPipeline({ steps }: WorkflowStepPipelineProps) {
+  if (steps.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground italic">No step data available</p>
+    );
+  }
+
+  return (
+    <div className="w-full overflow-x-auto">
+      {/* Desktop: horizontal */}
+      <div className="hidden sm:flex items-start justify-between min-w-[600px] px-2 py-4">
+        {steps.map((step, idx) => {
+          const colors = statusColors[step.status] ?? statusColors.pending;
+          const isLast = idx === steps.length - 1;
+
+          return (
+            <div key={step.name} className="flex items-start flex-1">
+              {/* Node + label */}
+              <div className="flex flex-col items-center min-w-[60px]">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className={`${colors.node} cursor-default`}>
+                      <StepIcon status={step.status} />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-xs max-w-[200px]">
+                    <p className="font-semibold">{step.label}</p>
+                    {step.completedAt && (
+                      <p className="text-muted-foreground">
+                        {formatTimestamp(step.completedAt)}
+                      </p>
+                    )}
+                    {step.error && (
+                      <p className="text-red-600 mt-1">{step.error}</p>
+                    )}
+                    {step.status === "in-progress" && (
+                      <p className="text-blue-600">Running…</p>
+                    )}
+                    {step.status === "pending" && (
+                      <p className="text-muted-foreground">Pending</p>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+                <span
+                  className={`mt-1.5 text-[10px] font-medium text-center leading-tight ${colors.text}`}
+                >
+                  {step.label}
+                </span>
+              </div>
+
+              {/* Connecting line */}
+              {!isLast && (
+                <div className="flex-1 flex items-center pt-3 px-1">
+                  <div
+                    className={`h-0.5 w-full rounded ${
+                      step.status === "complete" ? colors.line : "bg-gray-200"
+                    }`}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Mobile: vertical */}
+      <div className="sm:hidden space-y-1 py-2">
+        {steps.map((step, idx) => {
+          const colors = statusColors[step.status] ?? statusColors.pending;
+          const isLast = idx === steps.length - 1;
+
+          return (
+            <div key={step.name}>
+              <div className="flex items-center gap-3">
+                <div className={colors.node}>
+                  <StepIcon status={step.status} />
+                </div>
+                <div className="flex-1">
+                  <span className={`text-sm font-medium ${colors.text}`}>
+                    {step.label}
+                  </span>
+                  {step.completedAt && (
+                    <span className="text-xs text-muted-foreground ml-2">
+                      {formatTimestamp(step.completedAt)}
+                    </span>
+                  )}
+                </div>
+              </div>
+              {!isLast && (
+                <div className="ml-3 h-4 border-l-2 border-gray-200" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CaseworkerDashboard.tsx
+++ b/src/pages/CaseworkerDashboard.tsx
@@ -6,7 +6,7 @@ import type { Skill, Draft, ChatMessage, ChatTab } from "@/types/caseworker";
 import { Header } from "@/components/Header";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { SendHorizonal, Plus, X, Settings, LogOut } from "lucide-react";
+import { SendHorizonal, Plus, X, Settings, LogOut, Activity } from "lucide-react";
 
 const CaseworkerDashboard = () => {
   const { user, isAdmin, logout } = useCaseworkerAuth();
@@ -186,11 +186,18 @@ const CaseworkerDashboard = () => {
           </div>
           <div className="flex items-center gap-2">
             {isAdmin && (
-              <Button variant="outline" size="sm" asChild>
-                <Link to="/caseworker/settings">
-                  <Settings className="h-4 w-4 mr-1" /> Settings
-                </Link>
-              </Button>
+              <>
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/caseworker/workflow-runs">
+                    <Activity className="h-4 w-4 mr-1" /> Workflows
+                  </Link>
+                </Button>
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/caseworker/settings">
+                    <Settings className="h-4 w-4 mr-1" /> Settings
+                  </Link>
+                </Button>
+              </>
             )}
             <Button
               variant="ghost"

--- a/src/pages/CaseworkerSettings.tsx
+++ b/src/pages/CaseworkerSettings.tsx
@@ -446,7 +446,7 @@ const CaseworkerSettings = () => {
       <div className="flex-1 container mx-auto px-4 py-6 max-w-4xl">
         <div className="flex items-center gap-3 mb-6">
           <Button variant="ghost" size="sm" asChild>
-            <Link to="/caseworker/dashboard"><ArrowLeft className="h-4 w-4 mr-1" /> Dashboard</Link>
+            <Link to="/caseworker/dashboard"><ArrowLeft className="h-4 w-4" /></Link>
           </Button>
           <div>
             <h1 className="text-2xl font-bold text-foreground">Settings</h1>

--- a/src/pages/WorkflowRuns.tsx
+++ b/src/pages/WorkflowRuns.tsx
@@ -1,0 +1,205 @@
+/**
+ * WorkflowRuns — main page listing case workflow runs with filters.
+ *
+ * Route: /caseworker/workflow-runs
+ * Auth:  requires caseworker JWT (redirects to login if unauthenticated)
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useCaseworkerAuth } from "@/context/CaseworkerAuthContext";
+import { listWorkflowRuns } from "@/services/workflow-api";
+import type { WorkflowRun, RunStatusFilter } from "@/types/workflow";
+import { Header } from "@/components/Header";
+import { WorkflowRunFilters } from "@/components/workflow/WorkflowRunFilters";
+import { WorkflowRunCard } from "@/components/workflow/WorkflowRunCard";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft, LogOut, RefreshCw } from "lucide-react";
+
+const AUTO_REFRESH_MS = 30_000; // 30 seconds
+
+const WorkflowRuns = () => {
+  const { user, loading: authLoading, logout } = useCaseworkerAuth();
+  const navigate = useNavigate();
+
+  const [runs, setRuns] = useState<WorkflowRun[]>([]);
+  const [status, setStatus] = useState<RunStatusFilter>("all");
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (!authLoading && !user) {
+      navigate("/caseworker/login");
+    }
+  }, [authLoading, user, navigate]);
+
+  // Fetch runs
+  const fetchRuns = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await listWorkflowRuns(status, search);
+      setRuns(data.results);
+      setTotalCount(data.count);
+    } catch (e: unknown) {
+      setError((e as Error).message ?? "Failed to load workflow runs");
+    } finally {
+      setLoading(false);
+    }
+  }, [status, search]);
+
+  // Initial load + refetch on filter change
+  useEffect(() => {
+    setLoading(true);
+    fetchRuns();
+  }, [fetchRuns]);
+
+  // Auto-refresh
+  useEffect(() => {
+    timerRef.current = setInterval(() => {
+      fetchRuns();
+    }, AUTO_REFRESH_MS);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [fetchRuns]);
+
+  // Debounce search
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search), 400);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  // Actual search uses debounced value
+  useEffect(() => {
+    setLoading(true);
+    listWorkflowRuns(status, debouncedSearch)
+      .then((data) => {
+        setRuns(data.results);
+        setTotalCount(data.count);
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        setError((e as Error).message ?? "Failed to load workflow runs");
+      })
+      .finally(() => setLoading(false));
+  }, [status, debouncedSearch]);
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-muted/20 flex items-center justify-center">
+        <Skeleton className="h-8 w-48" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/20 flex flex-col">
+      <Header />
+
+      <div className="flex-1 container mx-auto px-4 py-6 max-w-5xl">
+        {/* Top bar */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Button variant="ghost" size="sm" asChild className="p-1">
+                <Link to="/caseworker/dashboard">
+                  <ArrowLeft className="h-4 w-4" />
+                </Link>
+              </Button>
+              <h1 className="text-2xl font-bold text-foreground">
+                Workflow Runs
+              </h1>
+            </div>
+            <p className="text-sm text-muted-foreground ml-8">
+              {totalCount} run{totalCount !== 1 ? "s" : ""} total
+              {!loading && (
+                <span className="text-xs ml-2 opacity-60">
+                  (auto-refreshes every 30s)
+                </span>
+              )}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setLoading(true);
+                fetchRuns();
+              }}
+              disabled={loading}
+            >
+              <RefreshCw className={`h-4 w-4 mr-1 ${loading ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                logout();
+                navigate("/caseworker/login");
+              }}
+            >
+              <LogOut className="h-4 w-4 mr-1" /> Sign out
+            </Button>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="mb-6">
+          <WorkflowRunFilters
+            status={status}
+            search={search}
+            onStatusChange={(s) => {
+              setStatus(s);
+              setLoading(true);
+            }}
+            onSearchChange={setSearch}
+          />
+        </div>
+
+        {/* Content */}
+        {error && (
+          <div className="mb-4 p-4 rounded-xl bg-red-50 border border-red-200 text-red-800 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-20 w-full rounded-xl" />
+            ))}
+          </div>
+        ) : runs.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-lg font-medium text-muted-foreground">
+              No workflow runs found
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">
+              {status !== "all"
+                ? "Try changing the filter or clearing your search."
+                : "Workflow runs will appear here once they are triggered from the backend."}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {runs.map((run) => (
+              <WorkflowRunCard key={run.run_id} run={run} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowRuns;

--- a/src/services/auth-utils.ts
+++ b/src/services/auth-utils.ts
@@ -1,0 +1,69 @@
+import axios, { AxiosError, InternalAxiosRequestConfig, AxiosInstance } from "axios";
+
+export interface RetryableAxiosRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+let refreshPromise: Promise<string> | null = null;
+
+/**
+ * Shared refresh logic that deduplicates concurrent refresh attempts.
+ * Centralizes localStorage key access ("cw_access_token"/"cw_refresh_token").
+ */
+export async function refreshAccessToken(): Promise<string> {
+  const refresh = localStorage.getItem("cw_refresh_token");
+  if (!refresh) {
+    return Promise.reject(new Error("No refresh token available"));
+  }
+
+  if (!refreshPromise) {
+    const baseApi = import.meta.env.VITE_JDS_API_BASE_URL || "https://portal.jawafdehi.org/api";
+    refreshPromise = axios
+      .post(`${baseApi}/caseworker/auth/token/refresh/`, { refresh })
+      .then(({ data }) => {
+        localStorage.setItem("cw_access_token", data.access);
+        return data.access as string;
+      })
+      .catch((error) => {
+        localStorage.removeItem("cw_access_token");
+        localStorage.removeItem("cw_refresh_token");
+        window.location.href = "/caseworker/login";
+        return Promise.reject(error);
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
+/**
+ * Reusable interceptor rejection handler to attach to any caseworker client.
+ */
+export async function handleInterceptorError(error: AxiosError, client: AxiosInstance) {
+  const originalRequest = error.config as RetryableAxiosRequestConfig | undefined;
+
+  // Reject immediately if no config, or if the refresh request itself failed
+  if (!originalRequest || originalRequest.url?.includes("/auth/token/refresh/")) {
+    return Promise.reject(error);
+  }
+
+  // Handle 401 Unauthorized
+  if (error.response?.status === 401 && !originalRequest._retry) {
+    originalRequest._retry = true;
+    try {
+      const newAccess = await refreshAccessToken();
+      // Ensure headers exist
+      if (!originalRequest.headers) {
+        originalRequest.headers = new axios.AxiosHeaders();
+      }
+      originalRequest.headers.Authorization = `Bearer ${newAccess}`;
+      return client.request(originalRequest);
+    } catch (refreshError) {
+      return Promise.reject(refreshError);
+    }
+  }
+
+  return Promise.reject(error);
+}

--- a/src/services/auth-utils.ts
+++ b/src/services/auth-utils.ts
@@ -45,7 +45,7 @@ export async function handleInterceptorError(error: AxiosError, client: AxiosIns
   const originalRequest = error.config as RetryableAxiosRequestConfig | undefined;
 
   // Reject immediately if no config, or if the refresh request itself failed
-  if (!originalRequest || originalRequest.url?.includes("/auth/token/refresh/")) {
+  if (!originalRequest || originalRequest.url?.includes("/auth/token/")) {
     return Promise.reject(error);
   }
 

--- a/src/services/caseworker-api.ts
+++ b/src/services/caseworker-api.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import type { Skill, MCPServer, Summary, Draft, LLMProvider, CaseworkerUser } from "@/types/caseworker";
 
+import { handleInterceptorError } from "./auth-utils";
+
 const BASE_URL = `${import.meta.env.VITE_JDS_API_BASE_URL || 'https://portal.jawafdehi.org/api'}/caseworker`;
 
 const client = axios.create({ baseURL: BASE_URL });
@@ -15,24 +17,7 @@ client.interceptors.request.use((config) => {
 
 client.interceptors.response.use(
   (r) => r,
-  async (error) => {
-    if (error.response?.status === 401) {
-      const refresh = localStorage.getItem("cw_refresh_token");
-      if (refresh) {
-        try {
-          const { data } = await axios.post(`${BASE_URL}/auth/token/refresh/`, { refresh });
-          localStorage.setItem("cw_access_token", data.access);
-          error.config.headers.Authorization = `Bearer ${data.access}`;
-          return client.request(error.config);
-        } catch {
-          localStorage.removeItem("cw_access_token");
-          localStorage.removeItem("cw_refresh_token");
-          window.location.href = "/caseworker/login";
-        }
-      }
-    }
-    return Promise.reject(error);
-  }
+  (error) => handleInterceptorError(error, client)
 );
 
 // Auth

--- a/src/services/workflow-api.ts
+++ b/src/services/workflow-api.ts
@@ -6,6 +6,7 @@
  */
 
 import axios from "axios";
+import { handleInterceptorError } from "./auth-utils";
 import type {
   WorkflowRun,
   WorkflowRunDetail,
@@ -32,25 +33,7 @@ client.interceptors.request.use((config) => {
 
 client.interceptors.response.use(
   (r) => r,
-  async (error) => {
-    if (error.response?.status === 401) {
-      const refresh = localStorage.getItem("cw_refresh_token");
-      if (refresh) {
-        try {
-          const baseApi = import.meta.env.VITE_JDS_API_BASE_URL || "https://portal.jawafdehi.org/api";
-          const { data } = await axios.post(`${baseApi}/caseworker/auth/token/refresh/`, { refresh });
-          localStorage.setItem("cw_access_token", data.access);
-          error.config.headers.Authorization = `Bearer ${data.access}`;
-          return client.request(error.config);
-        } catch {
-          localStorage.removeItem("cw_access_token");
-          localStorage.removeItem("cw_refresh_token");
-          window.location.href = "/caseworker/login";
-        }
-      }
-    }
-    return Promise.reject(error);
-  },
+  (error) => handleInterceptorError(error, client)
 );
 
 // ---------------------------------------------------------------------------
@@ -177,7 +160,7 @@ export function computeStepStatuses(run: WorkflowRunDetail): StepDisplayInfo[] {
 
     if (record?.status === "complete") {
       status = "complete";
-    } else if (!foundActiveStep && !run.is_complete) {
+    } else if (!foundActiveStep) {
       foundActiveStep = true;
       status = run.has_failed ? "failed" : "in-progress";
     } else {
@@ -208,7 +191,10 @@ export function formatFileSize(bytes: number): string {
 /** Compute duration between two ISO timestamps. */
 export function formatDuration(start: string | null, end: string | null): string {
   if (!start || !end) return "—";
-  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const startMs = new Date(start).getTime();
+  const endMs = new Date(end).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return "—";
+  const ms = endMs - startMs;
   if (ms < 0) return "—";
   const totalSeconds = Math.floor(ms / 1000);
   const minutes = Math.floor(totalSeconds / 60);

--- a/src/services/workflow-api.ts
+++ b/src/services/workflow-api.ts
@@ -59,6 +59,7 @@ export async function listWorkflowRuns(
     params.has_failed = "false";
   } else if (filter === "complete") {
     params.is_complete = "true";
+    params.has_failed = "false";
   } else if (filter === "failed") {
     params.has_failed = "true";
   }

--- a/src/services/workflow-api.ts
+++ b/src/services/workflow-api.ts
@@ -1,0 +1,218 @@
+/**
+ * API client for Case Workflow Runs.
+ *
+ * Hits /api/case-workflows/runs/ on the jawafdehi-api backend.
+ * Reuses the same JWT auth token stored by caseworker-api.ts.
+ */
+
+import axios from "axios";
+import type {
+  WorkflowRun,
+  WorkflowRunDetail,
+  StepVisualStatus,
+  StepDisplayInfo,
+  RunStatusFilter,
+} from "@/types/workflow";
+
+// ---------------------------------------------------------------------------
+// Axios client (mirrors caseworker-api.ts pattern)
+// ---------------------------------------------------------------------------
+
+const BASE_URL = `${import.meta.env.VITE_JDS_API_BASE_URL || "https://portal.jawafdehi.org/api"}/case-workflows`;
+
+const client = axios.create({ baseURL: BASE_URL });
+
+client.interceptors.request.use((config) => {
+  const token = localStorage.getItem("cw_access_token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+client.interceptors.response.use(
+  (r) => r,
+  async (error) => {
+    if (error.response?.status === 401) {
+      const refresh = localStorage.getItem("cw_refresh_token");
+      if (refresh) {
+        try {
+          const baseApi = import.meta.env.VITE_JDS_API_BASE_URL || "https://portal.jawafdehi.org/api";
+          const { data } = await axios.post(`${baseApi}/caseworker/auth/token/refresh/`, { refresh });
+          localStorage.setItem("cw_access_token", data.access);
+          error.config.headers.Authorization = `Bearer ${data.access}`;
+          return client.request(error.config);
+        } catch {
+          localStorage.removeItem("cw_access_token");
+          localStorage.removeItem("cw_refresh_token");
+          window.location.href = "/caseworker/login";
+        }
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
+
+export interface WorkflowRunListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: WorkflowRun[];
+}
+
+export async function listWorkflowRuns(
+  filter: RunStatusFilter = "all",
+  search = "",
+  page = 1,
+): Promise<WorkflowRunListResponse> {
+  const params: Record<string, string> = {};
+
+  if (filter === "running") {
+    params.is_complete = "false";
+    params.has_failed = "false";
+  } else if (filter === "complete") {
+    params.is_complete = "true";
+  } else if (filter === "failed") {
+    params.has_failed = "true";
+  }
+
+  if (search.trim()) {
+    params.search = search.trim();
+  }
+
+  if (page > 1) {
+    params.page = String(page);
+  }
+
+  const { data } = await client.get("/runs/", { params });
+  return data;
+}
+
+export async function getWorkflowRunDetail(runId: string): Promise<WorkflowRunDetail> {
+  const { data } = await client.get(`/runs/${runId}/`);
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Step definitions — known steps with display labels & order
+// ---------------------------------------------------------------------------
+
+/**
+ * Known step definitions keyed by workflow_id.
+ *
+ * The order here determines the pipeline rendering order.
+ * Steps not found in this map are appended at the end with
+ * a humanised label derived from their name.
+ */
+const KNOWN_STEPS: Record<string, { name: string; label: string }[]> = {
+  ciaa_caseworker: [
+    { name: "initialize-casework", label: "Initialize" },
+    { name: "fetch-source-documents", label: "Fetch Docs" },
+    { name: "fetch-news-articles", label: "Fetch News" },
+    { name: "draft-case", label: "Draft" },
+    { name: "review-draft", label: "Review" },
+    { name: "revise-draft", label: "Revise" },
+    { name: "create-case", label: "Create Case" },
+    { name: "create-update-entities", label: "Entities" },
+    { name: "update-case-details", label: "Update" },
+  ],
+};
+
+/** Convert kebab-case step name to a human-readable label. */
+function humaniseStepName(name: string): string {
+  return name
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Step status computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the visual status of each step for the pipeline component.
+ *
+ * Logic:
+ * - Steps recorded as "complete" in case_data → complete
+ * - The first non-complete step when run is still running → in-progress
+ * - If run has_failed, the first non-complete step → failed
+ * - Everything else → pending
+ */
+export function computeStepStatuses(run: WorkflowRunDetail): StepDisplayInfo[] {
+  const caseData = run.case_data ?? { steps: {}, files: {}, is_complete: false };
+  const stepRecords = caseData.steps ?? {};
+
+  // Get the ordered step list for this workflow, or derive from case_data keys
+  const knownSteps = KNOWN_STEPS[run.workflow_id];
+  let orderedNames: { name: string; label: string }[];
+
+  if (knownSteps) {
+    // Start with known steps in order
+    orderedNames = [...knownSteps];
+    // Append any unknown steps found in case_data
+    for (const stepName of Object.keys(stepRecords)) {
+      if (!orderedNames.some((s) => s.name === stepName)) {
+        orderedNames.push({ name: stepName, label: humaniseStepName(stepName) });
+      }
+    }
+  } else {
+    // Unknown workflow — derive entirely from case_data
+    orderedNames = Object.keys(stepRecords).map((name) => ({
+      name,
+      label: humaniseStepName(name),
+    }));
+  }
+
+  // Find the first non-complete step
+  let foundActiveStep = false;
+
+  return orderedNames.map((step) => {
+    const record = stepRecords[step.name];
+    let status: StepVisualStatus;
+
+    if (record?.status === "complete") {
+      status = "complete";
+    } else if (!foundActiveStep && !run.is_complete) {
+      foundActiveStep = true;
+      status = run.has_failed ? "failed" : "in-progress";
+    } else {
+      status = "pending";
+    }
+
+    return {
+      name: step.name,
+      label: step.label,
+      status,
+      completedAt: record?.completed_at,
+      error: record?.error,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format byte sizes into human-readable strings. */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Compute duration between two ISO timestamps. */
+export function formatDuration(start: string | null, end: string | null): string {
+  if (!start || !end) return "—";
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 0) return "—";
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}

--- a/src/services/workflow-api.ts
+++ b/src/services/workflow-api.ts
@@ -72,12 +72,12 @@ export async function listWorkflowRuns(
     params.page = String(page);
   }
 
-  const { data } = await client.get("/runs/", { params });
+  const { data } = await client.get<WorkflowRunListResponse>("/runs/", { params });
   return data;
 }
 
 export async function getWorkflowRunDetail(runId: string): Promise<WorkflowRunDetail> {
-  const { data } = await client.get(`/runs/${runId}/`);
+  const { data } = await client.get<WorkflowRunDetail>(`/runs/${runId}/`);
   return data;
 }
 
@@ -161,7 +161,7 @@ export function computeStepStatuses(run: WorkflowRunDetail): StepDisplayInfo[] {
 
     if (record?.status === "complete") {
       status = "complete";
-    } else if (!foundActiveStep) {
+    } else if (!foundActiveStep && !(run.is_complete && !run.has_failed)) {
       foundActiveStep = true;
       status = run.has_failed ? "failed" : "in-progress";
     } else {

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,0 +1,70 @@
+/**
+ * TypeScript interfaces for Case Workflow Runs.
+ *
+ * Mirrors the Django REST serializers in
+ * jawafdehi-api/case_workflows/serializers.py
+ */
+
+// ---------------------------------------------------------------------------
+// API response types
+// ---------------------------------------------------------------------------
+
+/** List-level fields (CaseWorkflowRunSerializer) */
+export interface WorkflowRun {
+  run_id: string;
+  case_id: string;
+  workflow_id: string;
+  is_complete: boolean;
+  has_failed: boolean;
+  error_message: string;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+}
+
+/** Detail-level fields (CaseWorkflowRunDetailSerializer) */
+export interface WorkflowRunDetail extends WorkflowRun {
+  work_dir: string;
+  case_data: WorkflowCaseData;
+  updated_at: string;
+}
+
+export interface WorkflowCaseData {
+  is_complete: boolean;
+  steps: Record<string, WorkflowStepRecord>;
+  files: Record<string, WorkflowFileRecord>;
+}
+
+export interface WorkflowStepRecord {
+  status: string;
+  completed_at?: string;
+  error?: string;
+}
+
+export interface WorkflowFileRecord {
+  backend_path: string;
+  size: number;
+  checksum: string;
+}
+
+// ---------------------------------------------------------------------------
+// UI-derived types
+// ---------------------------------------------------------------------------
+
+/** Visual status computed for each step in the pipeline. */
+export type StepVisualStatus = "complete" | "in-progress" | "failed" | "pending";
+
+/** A step definition with display metadata + derived status. */
+export interface StepDisplayInfo {
+  name: string;
+  label: string;
+  status: StepVisualStatus;
+  completedAt?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Filter types
+// ---------------------------------------------------------------------------
+
+export type RunStatusFilter = "all" | "running" | "complete" | "failed";


### PR DESCRIPTION
## Summary

Adds a new admin page at `/caseworker/workflow-runs` that visualizes `CaseWorkflowRun` records from the API. Caseworkers can monitor the progress of automated case processing pipelines, filter by status, and search by case ID or run ID.

Addresses the task: "visualize workflow runs as a pipeline with color-coded step progress."

## What's New

### Pages
- **`WorkflowRuns.tsx`** — Full dashboard page with auto-refresh (30s polling), status filters, and search

### Components (`src/components/workflow/`)
- **`WorkflowRunCard.tsx`** — Expandable card showing run metadata (run ID, case ID, status badge, timestamps) with collapsible pipeline detail view
- **`WorkflowStepPipeline.tsx`** — Horizontal 9-step pipeline visualization with color-coded status (✅ green = complete, 🔵 blue pulsing = in-progress, 🔴 red = failed, ⚪ gray = pending)
- **`WorkflowRunFilters.tsx`** — Status tab filters (All / Running / Complete / Failed) + debounced search field

### Data Layer
- **`src/types/workflow.ts`** — TypeScript interfaces mirroring the `CaseWorkflowRunSerializer` / `CaseWorkflowRunDetailSerializer` from the backend
- **`src/services/workflow-api.ts`** — API service with JWT Bearer auth, `listWorkflowRuns()` and `getWorkflowRun()` functions

### Navigation & Routing
- **`App.tsx`** — Registered `/caseworker/workflows` route
- **`CaseworkerDashboard.tsx`** — Added navigation card linking to the new page
- **`CaseworkerSettings.tsx`** — Minor UI polish (removed redundant "Dashboard" label from back button)

## Pipeline Steps Visualized

The `ciaa_caseworker` workflow pipeline renders these 9 steps:

`Initialize → Fetch Docs → Fetch News → Draft → Review → Revise → Create Case → Entities → Update`

## Screenshots
<img width="949" height="446" alt="image" src="https://github.com/user-attachments/assets/866b1319-3f42-4590-bf1f-c95941e1d438" />

*`Added "Workflows" button to Caseworker Agent dashboard toolbar`*<br>

<img width="1895" height="787" alt="image" src="https://github.com/user-attachments/assets/c67f13b1-89fc-4f93-8662-94396a93c03e" />

## Notes
- Currently tested with seeded data. Real data will appear when connected to the production API.
- Requires the corresponding backend branch `feat/case-workflows` in `jawafdehi-api` with `JWTAuthentication` enabled on `CaseWorkflowRunViewSet`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Workflows page and route in the caseworker portal.
  * Filter tabs (All/Running/Complete/Failed) and debounced search for runs.
  * Expandable run cards showing status, step pipeline, timestamps and output files.
  * Visual pipeline view for workflow steps; per-run detail loading with retry.
  * Automatic refresh every 30s; manual Refresh and Sign out actions.

* **Improvements**
  * Centralized token refresh and unified API error handling for more reliable auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->