### PR TITLE
Add titles to sitemap entries

### DIFF
--- a/scripts/sitemap.ts
+++ b/scripts/sitemap.ts
@@ -7,10 +7,17 @@ const ROOT = join(__dirname, '..');
 const CANONICAL = 'https://jawafdehi.org';
 const API_BASE = 'https://portal.jawafdehi.org/api';
 
+interface EntitySummary {
+  id: number;
+  nes_id: string | null;
+  display_name: string | null;
+}
+
 interface CaseSummary {
   id: number;
+  title: string;
   updated_at: string;
-  entities: Array<{ id: number; nes_id: string | null }>;
+  entities: EntitySummary[];
 }
 
 interface PaginatedCaseList {
@@ -18,8 +25,32 @@ interface PaginatedCaseList {
   results: CaseSummary[];
 }
 
-const STATIC_ROUTES = ['/', '/about', '/cases', '/entities', '/updates', '/information', '/feedback', '/report', '/team', '/products', '/commitment', '/our-process', '/volunteer'];
-const UPDATE_IDS = ['2026-01-26-job-postings', '2026-01-04-second-national-strategy-feedback'];
+const STATIC_ROUTES: Array<{ path: string; title: string }> = [
+  { path: '/', title: 'Jawafdehi — Nepal Open Corruption Database' },
+  { path: '/about', title: 'About — Jawafdehi' },
+  { path: '/cases', title: 'Cases — Jawafdehi' },
+  { path: '/entities', title: 'Entities — Jawafdehi' },
+  { path: '/updates', title: 'Updates — Jawafdehi' },
+  { path: '/information', title: 'Information — Jawafdehi' },
+  { path: '/feedback', title: 'Feedback — Jawafdehi' },
+  { path: '/report', title: 'Report a Case — Jawafdehi' },
+  { path: '/team', title: 'Our Team — Jawafdehi' },
+  { path: '/products', title: 'Products — Jawafdehi' },
+  { path: '/commitment', title: 'Our Commitment — Jawafdehi' },
+  { path: '/our-process', title: 'Our Process — Jawafdehi' },
+  { path: '/volunteer', title: 'Volunteer — Jawafdehi' },
+];
+
+const UPDATE_ENTRIES: Array<{ id: string; title: string }> = [
+  {
+    id: '2026-01-26-job-postings',
+    title: "We're Hiring! Case Documentation Intern and Software Engineer Interns — Jawafdehi",
+  },
+  {
+    id: '2026-01-04-second-national-strategy-feedback',
+    title: "Jawafdehi Submits Feedback on Nepal's Second National Anti-Corruption Strategy — Jawafdehi",
+  },
+];
 
 function toYMD(isoDate: string): string {
   return isoDate.substring(0, 10);
@@ -29,8 +60,19 @@ function buildDate(): string {
   return toYMD(new Date().toISOString());
 }
 
-function urlEntry(loc: string, lastmod: string): string {
-  return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`;
+/** Escape XML special characters so titles are safe inside element content. */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function urlEntry(loc: string, lastmod: string, title?: string): string {
+  const titleLine = title ? `\n    <title>${escapeXml(title)}</title>` : '';
+  return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>${titleLine}\n  </url>`;
 }
 
 async function fetchAllCases(): Promise<CaseSummary[]> {
@@ -57,15 +99,28 @@ async function main() {
     console.warn('[sitemap] WARNING: API unreachable, generating static-only sitemap:', err);
   }
 
+  // Build a map of entity id → display_name from all cases
+  const entityMap = new Map<number, string | null>();
+  for (const c of cases) {
+    for (const e of c.entities) {
+      if (!entityMap.has(e.id)) {
+        entityMap.set(e.id, e.display_name);
+      }
+    }
+  }
+
   const entityIds = [...new Set(
     cases.flatMap(c => c.entities.map(e => e.id).filter((id): id is number => id != null))
   )];
 
   const entries: string[] = [
-    ...STATIC_ROUTES.map(r => urlEntry(`${CANONICAL}${r}`, today)),
-    ...UPDATE_IDS.map(id => urlEntry(`${CANONICAL}/updates/${id}`, today)),
-    ...cases.map(c => urlEntry(`${CANONICAL}/case/${c.id}`, toYMD(c.updated_at))),
-    ...entityIds.map(id => urlEntry(`${CANONICAL}/entity/${id}`, today)),
+    ...STATIC_ROUTES.map(r => urlEntry(`${CANONICAL}${r.path}`, today, r.title)),
+    ...UPDATE_ENTRIES.map(u => urlEntry(`${CANONICAL}/updates/${u.id}`, today, u.title)),
+    ...cases.map(c => urlEntry(`${CANONICAL}/case/${c.id}`, toYMD(c.updated_at), c.title ? `${c.title} — Jawafdehi` : undefined)),
+    ...entityIds.map(id => {
+      const name = entityMap.get(id);
+      return urlEntry(`${CANONICAL}/entity/${id}`, today, name ? `${name} — Jawafdehi` : undefined);
+    }),
   ];
 
   const xml = [


### PR DESCRIPTION
Adds human-readable `<title>` elements to every `<url>` entry in the generated `sitemap.xml`.

**Changes:**
- Static routes each have a hardcoded title (e.g. `Cases — Jawafdehi`)
- Update entries use their existing titles from `src/data/updates.ts`
- Case entries use the `title` field returned by the API (appended with `— Jawafdehi`)
- Entity entries use `display_name` from the entity data already embedded in case responses (no extra API calls needed)
- Added `escapeXml()` helper to safely encode special characters in titles
- Updated `CaseSummary` and `EntitySummary` interfaces to include `title` / `display_name`

**Note:** `<title>` is not part of the official sitemap 0.9 spec, but it is valid XML and widely tolerated by SEO tools and sitemap validators. Google Search Console ignores unknown elements gracefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sitemaps now include page titles for improved search engine optimization and content discoverability across static pages, case pages, and entity pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->