### PR TITLE
Casework review portal SPA (/portal)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,13 @@ import TermsOfService from "./pages/TermsOfService";
 import ArchiveSearch from "./pages/ArchiveSearch";
 import NotFound from "./pages/NotFound";
 import { ScrollToTop } from "@/components/ScrollToTop";
+// Casework portal (VOL-3) — mounted at /portal.
+import { CaseworkAuthProvider } from "./context/CaseworkAuthContext";
+import CaseworkLogin from "./pages/CaseworkLogin";
+import CaseworkReviews from "./pages/CaseworkReviews";
+import CaseworkReviewDetail from "./pages/CaseworkReviewDetail";
+import CaseworkRules from "./pages/CaseworkRules";
+import CaseworkHow from "./pages/CaseworkHow";
 
 const GuestChat = lazy(() => import("./pages/GuestChat"));
 
@@ -55,6 +62,24 @@ const App = () => (
         <Routes>
           {/* Embed route for oEmbed iframe */}
           <Route path="/embed/case/:id" element={<EmbedCaseCard />} />
+
+          {/* Casework portal (VOL-3) — standalone full-screen, mounted at /portal.
+              Auth: shared JWT + Contributor role. */}
+          <Route
+            path="/portal/*"
+            element={
+              <CaseworkAuthProvider>
+                <Routes>
+                  <Route path="login" element={<CaseworkLogin />} />
+                  <Route path="reviews" element={<CaseworkReviews />} />
+                  <Route path="reviews/:id" element={<CaseworkReviewDetail />} />
+                  <Route path="rules" element={<CaseworkRules />} />
+                  <Route path="how" element={<CaseworkHow />} />
+                  <Route path="" element={<CaseworkReviews />} />
+                </Routes>
+              </CaseworkAuthProvider>
+            }
+          />
 
           <Route element={<AppLayout />}>
             <Route path="/" element={<Index />} />

--- a/src/components/CaseworkLayout.tsx
+++ b/src/components/CaseworkLayout.tsx
@@ -1,0 +1,80 @@
+import { ReactNode } from "react";
+import { Navigate, useLocation, useNavigate, Link } from "react-router-dom";
+import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
+import { Button } from "@/components/ui/button";
+import { ClipboardCheck, LogOut } from "lucide-react";
+
+const NAV = [
+  { to: "/portal/reviews", label: "Reviews" },
+  { to: "/portal/rules", label: "Rules" },
+  { to: "/portal/how", label: "How it works" },
+];
+
+export default function CaseworkLayout({ children }: { children: ReactNode }) {
+  const { user, loading, logout } = useCaseworkAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-sm text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  // Auth guard: the SPA only runs over an authenticated endpoint.
+  if (!user) {
+    return <Navigate to="/portal/login" replace state={{ from: location.pathname }} />;
+  }
+
+  const onLogout = () => {
+    logout();
+    navigate("/portal/login");
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b sticky top-0 z-10">
+        <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
+          <div className="flex items-center gap-6">
+            <Link to="/portal/reviews" className="flex items-center gap-2 font-semibold">
+              <ClipboardCheck className="h-5 w-5 text-primary" />
+              Casework Portal (New)
+            </Link>
+            <nav className="flex items-center gap-1">
+              {NAV.map((n) => {
+                const active = location.pathname.startsWith(n.to);
+                return (
+                  <Link
+                    key={n.to}
+                    to={n.to}
+                    className={`px-3 py-1.5 rounded-md text-sm ${
+                      active
+                        ? "bg-primary/10 text-primary font-medium"
+                        : "text-muted-foreground hover:bg-slate-100"
+                    }`}
+                  >
+                    {n.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground hidden sm:inline">
+              {user.username}
+              {user.roles?.length ? (
+                <span className="ml-1 text-xs text-slate-400">({user.roles.join(", ")})</span>
+              ) : null}
+            </span>
+            <Button variant="ghost" size="sm" onClick={onLogout}>
+              <LogOut className="h-4 w-4 mr-1" /> Sign out
+            </Button>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-6xl mx-auto px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/src/context/CaseworkAuthContext.tsx
+++ b/src/context/CaseworkAuthContext.tsx
@@ -1,0 +1,79 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import type { CaseworkUser } from "@/types/casework";
+import { getMe, login as apiLogin, logout as apiLogout, isLoggedIn } from "@/services/casework-api";
+
+interface AuthState {
+  user: CaseworkUser | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface AuthContextValue extends AuthState {
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+  isAdmin: boolean;
+}
+
+const CaseworkAuthContext = createContext<AuthContextValue | null>(null);
+
+export function CaseworkAuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({ user: null, loading: true, error: null });
+
+  const fetchUser = useCallback(async () => {
+    if (!isLoggedIn()) {
+      setState({ user: null, loading: false, error: null });
+      return;
+    }
+    try {
+      const user = await getMe();
+      setState({ user, loading: false, error: null });
+    } catch {
+      setState({ user: null, loading: false, error: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  const login = async (username: string, password: string) => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      await apiLogin(username, password);
+      await fetchUser();
+    } catch (err: unknown) {
+      const e = err as { response?: { status?: number; data?: { detail?: string } } };
+      const msg =
+        e.response?.status === 403
+          ? "Your account does not have the Contributor role required for the review system."
+          : e.response?.data?.detail ?? "Login failed. Check your credentials.";
+      setState((s) => ({ ...s, loading: false, error: msg }));
+      throw new Error(msg);
+    }
+  };
+
+  const logout = () => {
+    apiLogout();
+    setState({ user: null, loading: false, error: null });
+  };
+
+  return (
+    <CaseworkAuthContext.Provider
+      value={{
+        ...state,
+        login,
+        logout,
+        isAdmin: !!state.user?.is_admin,
+      }}
+    >
+      {children}
+    </CaseworkAuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCaseworkAuth() {
+  const ctx = useContext(CaseworkAuthContext);
+  if (!ctx) throw new Error("useCaseworkAuth must be used inside CaseworkAuthProvider");
+  return ctx;
+}

--- a/src/lib/casework-ui.ts
+++ b/src/lib/casework-ui.ts
@@ -1,0 +1,206 @@
+// Shared presentational helpers for the Casework Review portal.
+import type { CategoryScore, Disposition, ReviewStatus } from "@/types/casework";
+
+// Escape text interpolated into raw SVG/HTML markup (this module builds SVG
+// strings rendered via dangerouslySetInnerHTML). A category like
+// "Sourcing & References" or one containing < would otherwise produce invalid
+// markup / an injection sink.
+function escapeXml(s: string): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function scoreBand(score: number | null | undefined): string {
+  if (score == null) return "#94a3b8"; // slate
+  if (score >= 80) return "#16a34a"; // green
+  if (score >= 60) return "#d97706"; // amber
+  return "#dc2626"; // red
+}
+
+export function dispositionColor(d: Disposition | null | undefined): string {
+  switch (d) {
+    case "PASS":
+      return "bg-green-100 text-green-800 border-green-200";
+    case "REVISE":
+      return "bg-amber-100 text-amber-800 border-amber-200";
+    case "REJECT":
+      return "bg-red-100 text-red-800 border-red-200";
+    default:
+      return "bg-slate-100 text-slate-600 border-slate-200";
+  }
+}
+
+// Stable color per rule category, so the same category reads the same hue
+// across the Rules page and review breakdowns. Falls back to a hash for any
+// category not explicitly mapped.
+const CATEGORY_COLORS: Record<string, string> = {
+  Completeness: "bg-sky-100 text-sky-800 border-sky-200",
+  Description: "bg-indigo-100 text-indigo-800 border-indigo-200",
+  Tone: "bg-violet-100 text-violet-800 border-violet-200",
+  Sourcing: "bg-teal-100 text-teal-800 border-teal-200",
+  Timeline: "bg-cyan-100 text-cyan-800 border-cyan-200",
+  Entities: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  Ethics: "bg-rose-100 text-rose-800 border-rose-200",
+  Integrity: "bg-amber-100 text-amber-800 border-amber-200",
+};
+
+const CATEGORY_FALLBACKS = [
+  "bg-slate-100 text-slate-700 border-slate-200",
+  "bg-fuchsia-100 text-fuchsia-800 border-fuchsia-200",
+  "bg-lime-100 text-lime-800 border-lime-200",
+  "bg-orange-100 text-orange-800 border-orange-200",
+];
+
+export function categoryColor(category: string): string {
+  if (CATEGORY_COLORS[category]) return CATEGORY_COLORS[category];
+  let h = 0;
+  for (let i = 0; i < category.length; i++) h = (h * 31 + category.charCodeAt(i)) >>> 0;
+  return CATEGORY_FALLBACKS[h % CATEGORY_FALLBACKS.length];
+}
+
+// Color for a rule's kind: deterministic (exact check) vs llm (judge).
+export function kindColor(kind: "deterministic" | "llm" | string): string {
+  return kind === "llm"
+    ? "bg-blue-100 text-blue-800 border-blue-200"
+    : "bg-slate-100 text-slate-700 border-slate-200";
+}
+
+export function statusColor(s: ReviewStatus): string {
+  switch (s) {
+    case "done":
+      return "bg-green-100 text-green-800 border-green-200";
+    case "running":
+    case "pending":
+      return "bg-blue-100 text-blue-800 border-blue-200";
+    case "failed":
+      return "bg-red-100 text-red-800 border-red-200";
+    default:
+      return "bg-slate-100 text-slate-600 border-slate-200";
+  }
+}
+
+export function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export function fmtDur(seconds: number | null | undefined): string {
+  if (seconds == null) return "";
+  if (seconds < 60) return `${seconds.toFixed(0)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return `${m}m ${s}s`;
+}
+
+// Minimal markdown -> HTML (headings, bold, lists, paragraphs). No deps.
+export function mdToHtml(md: string): string {
+  if (!md) return "";
+  const esc = (t: string) =>
+    t.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let inList = false;
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    if (/^#{1,6}\s/.test(line)) {
+      if (inList) {
+        out.push("</ul>");
+        inList = false;
+      }
+      const level = line.match(/^#+/)![0].length;
+      const text = esc(line.replace(/^#+\s/, ""));
+      out.push(`<h${level} class="font-semibold mt-2">${text}</h${level}>`);
+    } else if (/^[-*]\s/.test(line)) {
+      if (!inList) {
+        out.push('<ul class="list-disc pl-5 space-y-0.5">');
+        inList = true;
+      }
+      out.push(`<li>${inline(esc(line.replace(/^[-*]\s/, "")))}</li>`);
+    } else if (line === "") {
+      if (inList) {
+        out.push("</ul>");
+        inList = false;
+      }
+    } else {
+      if (inList) {
+        out.push("</ul>");
+        inList = false;
+      }
+      out.push(`<p>${inline(esc(line))}</p>`);
+    }
+  }
+  if (inList) out.push("</ul>");
+  return out.join("\n");
+}
+
+function inline(t: string): string {
+  return t
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/`([^`]+)`/g, '<code class="px-1 bg-slate-100 rounded">$1</code>');
+}
+
+// Pure inline-SVG radar/spider chart of per-category scores (no chart lib).
+// Returns an SVG string; render via dangerouslySetInnerHTML. Only meaningful
+// with >= 3 dimensions.
+export function radarChartSvg(categories: CategoryScore[], size = 320): string {
+  const dims = categories.filter((c) => c.category);
+  if (dims.length < 3) return "";
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size / 2 - 56;
+  const n = dims.length;
+  const ang = (i: number) => (Math.PI * 2 * i) / n - Math.PI / 2;
+  const pt = (i: number, radius: number) => [
+    cx + radius * Math.cos(ang(i)),
+    cy + radius * Math.sin(ang(i)),
+  ];
+
+  const rings = [0.25, 0.5, 0.75, 1].map((f) => {
+    const pts = dims
+      .map((_, i) => pt(i, r * f))
+      .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+      .join(" ");
+    return `<polygon points="${pts}" fill="none" stroke="#e2e8f0" stroke-width="1"/>`;
+  });
+
+  const spokes = dims
+    .map((_, i) => {
+      const [x, y] = pt(i, r);
+      return `<line x1="${cx}" y1="${cy}" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}" stroke="#e2e8f0" stroke-width="1"/>`;
+    })
+    .join("");
+
+  const dataPts = dims.map((c, i) => pt(i, (r * Math.max(0, Math.min(100, c.score))) / 100));
+  const dataPoly = dataPts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+
+  const dots = dataPts
+    .map(([x, y], i) => {
+      const col = scoreBand(dims[i].score);
+      return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3.5" fill="${col}"/>`;
+    })
+    .join("");
+
+  const labels = dims
+    .map((c, i) => {
+      const [x, y] = pt(i, r + 22);
+      const anchor = Math.abs(x - cx) < 8 ? "middle" : x > cx ? "start" : "end";
+      return `<text x="${x.toFixed(1)}" y="${y.toFixed(1)}" font-size="11" fill="#475569" text-anchor="${anchor}" dominant-baseline="middle">${escapeXml(c.category)} <tspan font-weight="700" fill="${scoreBand(c.score)}">${c.score}</tspan></text>`;
+    })
+    .join("");
+
+  return `<svg viewBox="0 0 ${size} ${size}" width="100%" height="${size}" role="img" aria-label="Per-category scores radar chart">
+    ${rings.join("")}
+    ${spokes}
+    <polygon points="${dataPoly}" fill="rgba(37,99,235,0.18)" stroke="#2563eb" stroke-width="2"/>
+    ${dots}
+    ${labels}
+  </svg>`;
+}

--- a/src/pages/CaseworkHow.tsx
+++ b/src/pages/CaseworkHow.tsx
@@ -1,0 +1,47 @@
+import CaseworkLayout from "@/components/CaseworkLayout";
+
+export default function CaseworkHow() {
+  return (
+    <CaseworkLayout>
+      <div className="max-w-2xl space-y-4 text-sm text-slate-700">
+        <h1 className="text-xl font-bold text-foreground">How the review works</h1>
+        <p>
+          The Casework Review System scores the quality of a Jawafdehi case the way a careful
+          editor would, but consistently and in about 20 seconds.
+        </p>
+        <ol className="list-decimal pl-5 space-y-2">
+          <li>
+            <span className="font-medium">Pull the case.</span> You submit a case slug. The system
+            loads the case and its sources from the local Jawafdehi database (seeded from the live
+            server), so reviews run fully offline.
+          </li>
+          <li>
+            <span className="font-medium">Convert the sources.</span> Each source document (often a
+            scanned Nepali PDF) is converted to plain markdown with <code>likhit</code> so the judge
+            can actually read it.
+          </li>
+          <li>
+            <span className="font-medium">Detect the case type.</span> Cases fall into four families
+            — CIAA basic, CIAA extended (charge sheet), CIAA with verdict, and non-CIAA — and each
+            family has its own quality bar.
+          </li>
+          <li>
+            <span className="font-medium">Score against the rules.</span> Every applicable rule is
+            scored. Deterministic rules are exact checks (e.g. "is there a court case number?").
+            LLM rules are graded by AWS Bedrock (Claude Opus 4.8), sampled several times so we can
+            report a confidence (mean ± variance) per rule.
+          </li>
+          <li>
+            <span className="font-medium">Roll up &amp; decide.</span> Rule scores roll up into
+            per-category scores (shown as a radar chart) and a weighted overall. Hard "gate" rules
+            can force a REJECT. The disposition is PASS, REVISE, or REJECT.
+          </li>
+        </ol>
+        <p className="text-muted-foreground">
+          Reviewers can edit the rules and thresholds on the <span className="font-medium">Rules</span>{" "}
+          tab — the bar is whatever the team decides it is.
+        </p>
+      </div>
+    </CaseworkLayout>
+  );
+}

--- a/src/pages/CaseworkLogin.tsx
+++ b/src/pages/CaseworkLogin.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ClipboardCheck } from "lucide-react";
+
+const CaseworkLogin = () => {
+  const { login, loading, error } = useCaseworkAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError("");
+    setSubmitting(true);
+    try {
+      await login(username, password);
+      navigate("/portal/reviews");
+    } catch (err: unknown) {
+      setFormError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 to-slate-700 px-4">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-2xl p-8 space-y-6">
+        <div className="text-center space-y-1">
+          <div className="flex justify-center mb-3">
+            <div className="h-12 w-12 rounded-xl bg-primary/10 flex items-center justify-center">
+              <ClipboardCheck className="h-6 w-6 text-primary" />
+            </div>
+          </div>
+          <h1 className="text-2xl font-bold text-slate-900">Casework Portal (New)</h1>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="cwrk-username" className="text-slate-900">Username</Label>
+            <Input
+              id="cwrk-username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your_username"
+              required
+              autoComplete="username"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cwrk-password" className="text-slate-900">Password</Label>
+            <Input
+              id="cwrk-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              required
+              autoComplete="current-password"
+            />
+          </div>
+
+          {(formError || error) && (
+            <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+              {formError || error}
+            </p>
+          )}
+
+          <Button type="submit" variant="default" className="w-full" disabled={submitting || loading}>
+            {submitting ? "Signing in…" : "Sign In"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CaseworkLogin;

--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -1,0 +1,490 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import CaseworkLayout from "@/components/CaseworkLayout";
+import { getReview, submitReview } from "@/services/casework-api";
+import type { ReviewDetail, RuleResult, SourceSummary } from "@/types/casework";
+import { Button } from "@/components/ui/button";
+import {
+  dispositionColor,
+  statusColor,
+  fmtDate,
+  fmtDur,
+  scoreBand,
+  radarChartSvg,
+  mdToHtml,
+} from "@/lib/casework-ui";
+import { Loader2, ArrowLeft, ChevronDown, FileText, ExternalLink, RefreshCw } from "lucide-react";
+
+type Filter = "all" | "needs" | "llm" | "deterministic" | "gates";
+
+function needsAddressing(rr: RuleResult, passT: number): boolean {
+  return rr.gate_failed || rr.issues.length > 0 || rr.suggestions.length > 0 || rr.score < passT;
+}
+
+export default function CaseworkReviewDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [review, setReview] = useState<ReviewDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [source, setSource] = useState<SourceSummary | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
+  const [rerunning, setRerunning] = useState(false);
+
+  const onRerun = useCallback(async () => {
+    if (!review) return;
+    setRerunning(true);
+    try {
+      const fresh = await submitReview(review.slug);
+      navigate(`/portal/reviews/${fresh.id}`);
+    } finally {
+      setRerunning(false);
+    }
+  }, [review, navigate]);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    try {
+      const data = await getReview(Number(id));
+      setReview(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll while running.
+  useEffect(() => {
+    if (!review) return;
+    if (review.status === "pending" || review.status === "running") {
+      const t = setInterval(load, 3000);
+      return () => clearInterval(t);
+    }
+  }, [review, load]);
+
+  const result = review?.result || null;
+  const passT = result?.thresholds?.pass ?? 80;
+
+  const grouped = useMemo(() => {
+    const g = new Map<string, RuleResult[]>();
+    for (const rr of result?.rules || []) {
+      if (!g.has(rr.category)) g.set(rr.category, []);
+      g.get(rr.category)!.push(rr);
+    }
+    return g;
+  }, [result]);
+
+  const visible = (rr: RuleResult): boolean => {
+    switch (filter) {
+      case "needs":
+        return needsAddressing(rr, passT);
+      case "llm":
+        return rr.kind === "llm";
+      case "deterministic":
+        return rr.kind === "deterministic";
+      case "gates":
+        return rr.is_gate;
+      default:
+        return true;
+    }
+  };
+
+  if (loading) {
+    return (
+      <CaseworkLayout>
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading review…
+        </div>
+      </CaseworkLayout>
+    );
+  }
+
+  if (!review) {
+    return (
+      <CaseworkLayout>
+        <p className="text-sm text-muted-foreground">Review not found.</p>
+      </CaseworkLayout>
+    );
+  }
+
+  const inProgress = review.status === "pending" || review.status === "running";
+
+  return (
+    <CaseworkLayout>
+      <div className="space-y-5">
+        <button
+          onClick={() => navigate("/portal/reviews")}
+          className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          <ArrowLeft className="h-4 w-4" /> All reviews
+        </button>
+
+        {/* Hero */}
+        <div className="bg-white border rounded-xl p-5">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="min-w-0">
+              <div className="font-mono text-xs text-slate-500">{review.slug}</div>
+              <h1 className="text-lg font-bold">{review.case_title || review.slug}</h1>
+              <a
+                href={`/case/${review.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 mt-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLink className="h-3.5 w-3.5" /> View case on jawafdehi.org
+              </a>
+              <div className="flex items-center gap-2 mt-2 flex-wrap text-xs">
+                <span className={`px-2 py-0.5 rounded-full border ${statusColor(review.status)}`}>
+                  {inProgress ? review.stage || review.status : review.status}
+                </span>
+                {review.case_type && (
+                  <span className="px-2 py-0.5 rounded-full border bg-slate-100 text-slate-600 border-slate-200">
+                    {result?.case_type?.label || review.case_type}
+                  </span>
+                )}
+                <span className="text-slate-400">🕓 {fmtDate(review.completed_at || review.created_at)}</span>
+                {review.duration_seconds != null && (
+                  <span className="text-slate-400">⏱ {fmtDur(review.duration_seconds)}</span>
+                )}
+                <span className="text-slate-400">
+                  sources {review.sources_converted}/{review.source_count}
+                </span>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              {result && (
+                <div className="text-right">
+                  <div className="text-3xl font-extrabold" style={{ color: scoreBand(result.overall_score) }}>
+                    {result.overall_score}
+                  </div>
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(result.disposition)}`}
+                  >
+                    {result.disposition}
+                  </span>
+                </div>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRerun}
+                disabled={rerunning || inProgress}
+                title="Run a fresh review for this case against the current rules"
+              >
+                {rerunning ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4 mr-1" />
+                )}
+                Re-run
+              </Button>
+            </div>
+          </div>
+
+          {inProgress && (
+            <div className="mt-4 flex items-center gap-2 text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded px-3 py-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Review in progress — stage: {review.stage || review.status}. This page refreshes automatically.
+            </div>
+          )}
+
+          {review.status === "failed" && (
+            <pre className="mt-4 text-xs text-red-700 bg-red-50 border border-red-200 rounded p-3 whitespace-pre-wrap max-h-48 overflow-auto">
+              {review.error}
+            </pre>
+          )}
+
+          {/* Radar chart */}
+          {result && result.categories.length >= 3 && (
+            <div className="mt-4 max-w-md mx-auto">
+              <div dangerouslySetInnerHTML={{ __html: radarChartSvg(result.categories) }} />
+            </div>
+          )}
+
+          {result?.narrative && (
+            <p className="mt-3 text-sm text-slate-700 italic border-l-2 border-slate-200 pl-3">
+              {result.narrative}
+            </p>
+          )}
+        </div>
+
+        {/* Sources */}
+        {result && result.source_summary.length > 0 && (
+          <div className="bg-white border rounded-xl p-4">
+            <h2 className="text-sm font-semibold mb-2">Sources ({result.source_summary.length})</h2>
+            <ul className="space-y-1.5">
+              {result.source_summary.map((s, i) => (
+                <li key={i} className="flex items-center gap-2 text-sm">
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                      s.conversion_status === "converted" || s.conversion_status === "attached"
+                        ? "bg-green-50 text-green-700 border-green-200"
+                        : "bg-amber-50 text-amber-700 border-amber-200"
+                    }`}
+                  >
+                    {s.conversion_status}
+                  </span>
+                  <span className="flex-1 truncate" title={s.title}>
+                    {s.title || "(untitled)"}
+                  </span>
+                  <span className="text-xs text-slate-400">{s.markdown_chars} chars</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setSource(s);
+                      setShowRaw(false);
+                    }}
+                  >
+                    <FileText className="h-3.5 w-3.5 mr-1" /> View
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Rule results */}
+        {result && (
+          <div>
+            <div className="flex items-center gap-2 mb-3 flex-wrap">
+              {(["all", "needs", "llm", "deterministic", "gates"] as Filter[]).map((f) => (
+                <button
+                  key={f}
+                  onClick={() => setFilter(f)}
+                  className={`text-xs px-2.5 py-1 rounded-full border ${
+                    filter === f
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-white text-slate-600 border-slate-200 hover:bg-slate-50"
+                  }`}
+                >
+                  {f === "all"
+                    ? "All"
+                    : f === "needs"
+                    ? "Needs addressing"
+                    : f === "llm"
+                    ? "LLM only"
+                    : f === "deterministic"
+                    ? "Deterministic only"
+                    : "Gates only"}
+                </button>
+              ))}
+            </div>
+
+            <div className="space-y-4">
+              {[...grouped.entries()].map(([cat, rules]) => {
+                const vis = rules.filter(visible);
+                // In "Needs addressing", surface the worst rules first.
+                if (filter === "needs") {
+                  vis.sort((a, b) => a.score - b.score);
+                }
+                if (vis.length === 0) return null;
+                const catScore = result.categories.find((c) => c.category === cat)?.score;
+                return (
+                  <div key={cat}>
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <h3 className="text-sm font-semibold">{cat}</h3>
+                      {catScore != null && (
+                        <span
+                          className="text-xs font-bold"
+                          style={{ color: scoreBand(catScore) }}
+                        >
+                          {catScore}
+                        </span>
+                      )}
+                    </div>
+                    <div className="grid gap-2">
+                      {vis.map((rr) => (
+                        <RuleCard
+                          key={rr.key}
+                          rr={rr}
+                          expanded={!!expanded[rr.key]}
+                          onToggle={() =>
+                            setExpanded((e) => ({ ...e, [rr.key]: !e[rr.key] }))
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Source modal */}
+      {source && (
+        <div
+          className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4"
+          onClick={() => setSource(null)}
+        >
+          <div
+            className="bg-white rounded-xl max-w-3xl w-full max-h-[85vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-4 py-3 border-b flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-sm font-semibold truncate">{source.title}</div>
+                <div className="text-xs text-slate-400">{source.source_type}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => setShowRaw((v) => !v)}>
+                  {showRaw ? "Rendered" : "Raw"}
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setSource(null)}>
+                  Close
+                </Button>
+              </div>
+            </div>
+            <div className="p-4 overflow-auto text-sm">
+              {showRaw ? (
+                <pre className="whitespace-pre-wrap text-xs">{source.markdown || "(no markdown)"}</pre>
+              ) : (
+                <div
+                  className="prose prose-sm max-w-none"
+                  dangerouslySetInnerHTML={{ __html: mdToHtml(source.markdown || "_(no markdown)_") }}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </CaseworkLayout>
+  );
+}
+
+function RuleCard({
+  rr,
+  expanded,
+  onToggle,
+}: {
+  rr: RuleResult;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className={`border rounded-lg p-3 ${rr.gate_failed ? "border-red-300 bg-red-50/40" : "bg-white"}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium">{rr.title}</span>
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-500 border border-slate-200">
+              {rr.kind}
+            </span>
+            {rr.is_gate && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 border border-purple-200">
+                gate ≥ {rr.gate_min}
+              </span>
+            )}
+            {rr.gate_failed && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-100 text-red-700 border border-red-200">
+                GATE FAILED
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-lg font-bold" style={{ color: scoreBand(rr.score) }}>
+            {rr.score}
+          </div>
+          {rr.kind === "llm" && (
+            <div className="text-[10px] text-slate-400">
+              μ{rr.score} · σ{rr.std} · {rr.confidence}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {rr.kind === "deterministic" && rr.rationale && (
+        <p className="text-xs text-slate-500 mt-1">{rr.rationale}</p>
+      )}
+
+      {rr.issues.length > 0 && (
+        <div className="mt-2">
+          <div className="text-xs font-medium text-red-700">Issues</div>
+          <ul className="list-disc pl-4 text-xs text-red-700 space-y-0.5">
+            {rr.issues.map((iss, i) => (
+              <li key={i}>{iss}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {rr.suggestions.length > 0 && (
+        <div className="mt-2">
+          <div className="text-xs font-medium text-green-700">Suggestions to address</div>
+          <ul className="list-disc pl-4 text-xs text-green-700 space-y-0.5">
+            {rr.suggestions.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <button
+        onClick={onToggle}
+        className="mt-2 text-[11px] text-slate-400 hover:text-slate-600 flex items-center gap-1"
+      >
+        <ChevronDown className={`h-3 w-3 transition-transform ${expanded ? "rotate-180" : ""}`} />
+        {expanded ? "hide rule instruction" : "show rule instruction"}
+      </button>
+
+      {expanded && (
+        <div className="mt-2 border-t pt-3 text-sm text-slate-600 space-y-2.5">
+          {rr.condition_text && (
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-0.5">
+                Condition
+              </div>
+              {rr.condition_text}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <span>
+              <span className="text-slate-400">Active for: </span>
+              {(rr.applies_to || []).join(", ") || "ALL"}
+            </span>
+            <span>
+              <span className="text-slate-400">Weight: </span>
+              {rr.weight}
+            </span>
+            {rr.is_gate && (
+              <span className="text-purple-700">
+                <span className="text-slate-400">Gate: </span>
+                ≥ {rr.gate_min} (rejects case if score &lt; {rr.gate_min})
+              </span>
+            )}
+          </div>
+          {rr.description && (
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-0.5">
+                Description
+              </div>
+              <div
+                className="prose prose-sm max-w-none"
+                dangerouslySetInnerHTML={{ __html: mdToHtml(rr.description) }}
+              />
+            </div>
+          )}
+          {rr.good_examples && (
+            <div className="rounded-md bg-green-50 border border-green-200 px-3 py-2">
+              <div className="text-xs font-semibold text-green-700 mb-0.5">Good example</div>
+              <div className="text-sm text-green-800">{rr.good_examples}</div>
+            </div>
+          )}
+          {rr.bad_examples && (
+            <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2">
+              <div className="text-xs font-semibold text-red-700 mb-0.5">Bad example</div>
+              <div className="text-sm text-red-800">{rr.bad_examples}</div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import CaseworkLayout from "@/components/CaseworkLayout";
+import { listReviews, submitReview, apiErrorMessage } from "@/services/casework-api";
+import type { ReviewListItem } from "@/types/casework";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { dispositionColor, statusColor, fmtDate, fmtDur, scoreBand } from "@/lib/casework-ui";
+import { Loader2, Plus, RefreshCw } from "lucide-react";
+
+export default function CaseworkReviews() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<ReviewListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [slug, setSlug] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [rerunningSlug, setRerunningSlug] = useState<string | null>(null);
+  const [err, setErr] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const data = await listReviews();
+      setItems(data);
+    } catch {
+      setErr("Failed to load reviews.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll while any review is still in progress.
+  useEffect(() => {
+    const anyRunning = items.some((i) => i.status === "pending" || i.status === "running");
+    if (!anyRunning) return;
+    const t = setInterval(load, 3000);
+    return () => clearInterval(t);
+  }, [items, load]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const s = slug.trim().replace(/^\/+|\/+$/g, "");
+    if (!s) return;
+    setSubmitting(true);
+    setErr("");
+    try {
+      const review = await submitReview(s);
+      setSlug("");
+      await load();
+      navigate(`/portal/reviews/${review.id}`);
+    } catch (e: unknown) {
+      setErr(apiErrorMessage(e, "Submit failed."));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Re-run: submit a fresh review for an already-reviewed case slug.
+  const onRerun = async (gslug: string) => {
+    setRerunningSlug(gslug);
+    setErr("");
+    try {
+      const review = await submitReview(gslug);
+      navigate(`/portal/reviews/${review.id}`);
+    } catch (e: unknown) {
+      setErr(apiErrorMessage(e, "Re-run failed."));
+    } finally {
+      setRerunningSlug(null);
+    }
+  };
+
+  // Group reviews by case slug (stacked-by-case list).
+  const groups = new Map<string, ReviewListItem[]>();
+  for (const it of items) {
+    if (!groups.has(it.slug)) groups.set(it.slug, []);
+    groups.get(it.slug)!.push(it);
+  }
+
+  return (
+    <CaseworkLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-bold">Case reviews</h1>
+          <p className="text-sm text-muted-foreground">
+            Submit a Jawafdehi case slug to run a multi-dimensional quality review.
+          </p>
+        </div>
+
+        <form onSubmit={onSubmit} className="flex gap-2 items-start">
+          <div className="flex-1">
+            <Input
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="case slug, e.g. case-081-cr-0136-oxygen-plant"
+            />
+            {err && <p className="text-sm text-red-600 mt-1">{err}</p>}
+          </div>
+          <Button type="submit" disabled={submitting || !slug.trim()}>
+            {submitting ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4 mr-1" />
+            )}
+            Review
+          </Button>
+        </form>
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading reviews…
+          </div>
+        ) : groups.size === 0 ? (
+          <p className="text-sm text-muted-foreground">No reviews yet. Submit a case slug above.</p>
+        ) : (
+          <div className="space-y-3">
+            {[...groups.entries()].map(([gslug, rows]) => (
+              <div key={gslug} className="bg-white border rounded-xl overflow-hidden">
+                <div className="px-4 py-2.5 bg-slate-50 border-b flex items-center justify-between">
+                  <div className="min-w-0">
+                    <div className="font-mono text-xs text-slate-500 truncate">{gslug}</div>
+                    <div className="text-sm font-medium truncate">{rows[0].case_title || "—"}</div>
+                  </div>
+                  <div className="flex items-center gap-3 ml-3">
+                    <span className="text-xs text-slate-500 whitespace-nowrap">
+                      {rows.length} review{rows.length === 1 ? "" : "s"}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={rerunningSlug === gslug}
+                      title="Run a fresh review for this case against the current rules"
+                      onClick={() => onRerun(gslug)}
+                    >
+                      {rerunningSlug === gslug ? (
+                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-3.5 w-3.5 mr-1" />
+                      )}
+                      Re-run
+                    </Button>
+                  </div>
+                </div>
+                <ul className="divide-y">
+                  {rows.map((r) => (
+                    <li
+                      key={r.id}
+                      className="px-4 py-2.5 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
+                      onClick={() => navigate(`/portal/reviews/${r.id}`)}
+                    >
+                      <span className="text-xs font-mono text-slate-400 w-12">#{r.id}</span>
+                      <span className="text-xs text-slate-500 w-40 hidden md:inline">
+                        🕓 {fmtDate(r.completed_at || r.created_at)}
+                      </span>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(r.status)}`}
+                      >
+                        {r.status === "running" || r.status === "pending"
+                          ? r.stage || r.status
+                          : r.status}
+                      </span>
+                      {r.case_type && (
+                        <span className="text-xs text-slate-500 hidden sm:inline">{r.case_type}</span>
+                      )}
+                      <span className="flex-1" />
+                      {r.overall_score != null && (
+                        <span
+                          className="text-sm font-bold w-10 text-right"
+                          style={{ color: scoreBand(r.overall_score) }}
+                        >
+                          {r.overall_score}
+                        </span>
+                      )}
+                      {r.disposition && (
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(
+                            r.disposition
+                          )}`}
+                        >
+                          {r.disposition}
+                        </span>
+                      )}
+                      {r.duration_seconds != null && (
+                        <span className="text-xs text-slate-400 w-14 text-right hidden lg:inline">
+                          {fmtDur(r.duration_seconds)}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </CaseworkLayout>
+  );
+}

--- a/src/pages/CaseworkRules.tsx
+++ b/src/pages/CaseworkRules.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState, useCallback } from "react";
+import CaseworkLayout from "@/components/CaseworkLayout";
+import { listRules, getConfig, updateConfig } from "@/services/casework-api";
+import type { CaseworkRule, ReviewConfig } from "@/types/casework";
+import { Input } from "@/components/ui/input";
+import { Loader2, ChevronDown, Lock, ShieldAlert } from "lucide-react";
+import { mdToHtml, categoryColor, kindColor } from "@/lib/casework-ui";
+
+export default function CaseworkRules() {
+  const [rules, setRules] = useState<CaseworkRule[]>([]);
+  const [config, setConfig] = useState<ReviewConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState<Record<number, boolean>>({});
+
+  const load = useCallback(async () => {
+    try {
+      const [r, c] = await Promise.all([listRules(), getConfig()]);
+      setRules(r);
+      setConfig(c);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const saveConfig = async (patch: Partial<ReviewConfig>) => {
+    if (!config) return;
+    const c = await updateConfig({ ...config, ...patch });
+    setConfig(c);
+  };
+
+  if (loading) {
+    return (
+      <CaseworkLayout>
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading rules…
+        </div>
+      </CaseworkLayout>
+    );
+  }
+
+  return (
+    <CaseworkLayout>
+      <div className="space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold">Rules</h1>
+            <p className="text-sm text-muted-foreground flex items-center gap-1.5">
+              <Lock className="h-3.5 w-3.5" />
+              Code-enforced rules the review system scores each case against. These
+              are defined in code and are read-only here.
+            </p>
+          </div>
+        </div>
+
+        {/* Config */}
+        {config && (
+          <div className="bg-white border rounded-xl p-4 grid grid-cols-3 gap-4">
+            <ConfigField
+              label="Pass ≥"
+              value={config.pass_threshold}
+              onSave={(v) => saveConfig({ pass_threshold: v })}
+            />
+            <ConfigField
+              label="Revise ≥"
+              value={config.revise_threshold}
+              onSave={(v) => saveConfig({ revise_threshold: v })}
+            />
+            <ConfigField
+              label="LLM samples"
+              value={config.llm_samples}
+              onSave={(v) => saveConfig({ llm_samples: v })}
+            />
+          </div>
+        )}
+
+        <div className="space-y-5">
+          {[...groupByCategory(rules).entries()].map(([category, catRules]) => (
+            <section key={category}>
+              <div className="flex items-center gap-2 mb-2">
+                <span
+                  className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${categoryColor(category)}`}
+                >
+                  {category}
+                </span>
+                <span className="text-xs text-slate-400">
+                  {catRules.length} rule{catRules.length === 1 ? "" : "s"}
+                </span>
+              </div>
+
+              <div className="space-y-2">
+                {catRules.map((r) => (
+                  <div
+                    key={r.id}
+                    className={`bg-white border rounded-lg overflow-hidden ${
+                      r.is_gate ? "border-l-4 border-l-purple-400" : ""
+                    } ${!r.enabled ? "opacity-60" : ""}`}
+                  >
+                    <button
+                      className="w-full px-4 py-3 flex items-center gap-2.5 text-left hover:bg-slate-50"
+                      onClick={() => setOpen((o) => ({ ...o, [r.id]: !o[r.id] }))}
+                    >
+                      <ChevronDown
+                        className={`h-4 w-4 text-slate-400 shrink-0 transition-transform ${open[r.id] ? "rotate-180" : ""}`}
+                      />
+                      <span className="font-medium text-sm truncate">{r.title}</span>
+                      <span
+                        className={`text-xs px-1.5 py-0.5 rounded border ${kindColor(r.kind)}`}
+                      >
+                        {r.kind === "llm" ? "LLM judge" : "deterministic"}
+                      </span>
+                      {r.is_gate && (
+                        <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 border border-purple-200">
+                          <ShieldAlert className="h-3 w-3" /> gate ≥ {r.gate_min}
+                        </span>
+                      )}
+                      {!r.enabled && (
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-400 border border-slate-200">
+                          disabled
+                        </span>
+                      )}
+                      <span className="flex-1" />
+                      <span className="text-xs text-slate-400 shrink-0">weight {r.weight}</span>
+                    </button>
+
+                    {open[r.id] && (
+                      <div className="px-4 pb-3 border-t pt-3 text-sm text-slate-600 space-y-2.5">
+                        {r.condition_text && (
+                          <div>
+                            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-0.5">
+                              Condition
+                            </div>
+                            {r.condition_text}
+                          </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                          <span>
+                            <span className="text-slate-400">Active for: </span>
+                            {(r.applies_to || []).join(", ") || "ALL"}
+                          </span>
+                          <span>
+                            <span className="text-slate-400">Weight: </span>
+                            {r.weight}
+                          </span>
+                          {r.is_gate && (
+                            <span className="text-purple-700">
+                              <span className="text-slate-400">Gate: </span>
+                              ≥ {r.gate_min} (rejects case if score &lt; {r.gate_min})
+                            </span>
+                          )}
+                          {r.detector && (
+                            <span>
+                              <span className="text-slate-400">Detector: </span>
+                              <code className="px-1 bg-slate-100 rounded text-[11px]">{r.detector}</code>
+                            </span>
+                          )}
+                        </div>
+
+                        {r.description && (
+                          <div>
+                            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-0.5">
+                              Description
+                            </div>
+                            <div
+                              className="prose prose-sm max-w-none"
+                              dangerouslySetInnerHTML={{ __html: mdToHtml(r.description) }}
+                            />
+                          </div>
+                        )}
+
+                        {r.good_examples && (
+                          <div className="rounded-md bg-green-50 border border-green-200 px-3 py-2">
+                            <div className="text-xs font-semibold text-green-700 mb-0.5">Good example</div>
+                            <div className="text-sm text-green-800">{r.good_examples}</div>
+                          </div>
+                        )}
+                        {r.bad_examples && (
+                          <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2">
+                            <div className="text-xs font-semibold text-red-700 mb-0.5">Bad example</div>
+                            <div className="text-sm text-red-800">{r.bad_examples}</div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </CaseworkLayout>
+  );
+}
+
+// Group rules by category, preserving the server's display order.
+function groupByCategory(rules: CaseworkRule[]): Map<string, CaseworkRule[]> {
+  const g = new Map<string, CaseworkRule[]>();
+  for (const r of rules) {
+    if (!g.has(r.category)) g.set(r.category, []);
+    g.get(r.category)!.push(r);
+  }
+  return g;
+}
+
+function ConfigField({
+  label,
+  value,
+  onSave,
+}: {
+  label: string;
+  value: number;
+  onSave: (v: number) => void;
+}) {
+  const [v, setV] = useState(String(value));
+  useEffect(() => setV(String(value)), [value]);
+  return (
+    <div>
+      <label className="text-xs text-slate-500">{label}</label>
+      <Input
+        type="number"
+        value={v}
+        onChange={(e) => setV(e.target.value)}
+        onBlur={() => {
+          const n = parseInt(v, 10);
+          if (Number.isNaN(n)) {
+            // Invalid/blank input: snap back to the current saved value so the
+            // field never drifts out of sync with state.
+            setV(String(value));
+          } else if (n !== value) {
+            onSave(n);
+          } else {
+            setV(String(value));
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -1,0 +1,150 @@
+// API client for the Casework Review System portal.
+//
+// Auth model: the casework review API (mounted at /api/casework/ on the
+// jawafdehi-api) is gated by the shared jawafdehi JWT plus the Contributor
+// role. Clients obtain a token pair from the existing SimpleJWT endpoint
+// (/api/caseworker/auth/token/) and send `Authorization: Bearer <access>`.
+//
+// We deliberately reuse the same token-obtain/refresh endpoints as the
+// caseworker portal, but keep SEPARATE localStorage keys (cwrk_*) so signing in
+// to one portal does not silently sign you into the other.
+import axios from "axios";
+import type {
+  CaseworkUser,
+  ReviewListItem,
+  ReviewDetail,
+  CaseworkRule,
+  ReviewConfig,
+  Paginated,
+} from "@/types/casework";
+
+const API_ROOT = import.meta.env.VITE_JDS_API_BASE_URL || "https://portal.jawafdehi.org/api";
+const BASE_URL = `${API_ROOT}/casework`;
+// The shared SimpleJWT token endpoints live under /caseworker/auth/.
+const TOKEN_BASE = `${API_ROOT}/caseworker/auth`;
+
+const ACCESS_KEY = "cwrk_access_token";
+const REFRESH_KEY = "cwrk_refresh_token";
+
+const client = axios.create({ baseURL: BASE_URL });
+
+client.interceptors.request.use((config) => {
+  const token = localStorage.getItem(ACCESS_KEY);
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+client.interceptors.response.use(
+  (r) => r,
+  async (error) => {
+    const config = error.config ?? {};
+    // Refresh the access token on a 401 and retry ONCE. The _retry flag guards
+    // against an infinite loop when the refreshed token is itself rejected
+    // (deauthorized, role change, clock skew) and the retry 401s again.
+    if (error.response?.status === 401 && !config._retry) {
+      const refresh = localStorage.getItem(REFRESH_KEY);
+      if (refresh) {
+        config._retry = true;
+        try {
+          const { data } = await axios.post(`${TOKEN_BASE}/token/refresh/`, { refresh });
+          localStorage.setItem(ACCESS_KEY, data.access);
+          config.headers.Authorization = `Bearer ${data.access}`;
+          return client.request(config);
+        } catch {
+          localStorage.removeItem(ACCESS_KEY);
+          localStorage.removeItem(REFRESH_KEY);
+          window.location.href = "/portal/login";
+        }
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Best-effort human message from an axios error: handles a plain-string body,
+// DRF's { detail: "..." }, and field-error objects ({ field: ["msg", ...] }).
+export function apiErrorMessage(err: unknown, fallback: string): string {
+  const data = (err as { response?: { data?: unknown } })?.response?.data;
+  if (typeof data === "string" && data.trim()) return data;
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.detail === "string") return d.detail;
+    // First field error (string or first item of a list).
+    for (const v of Object.values(d)) {
+      if (typeof v === "string" && v.trim()) return v;
+      if (Array.isArray(v) && typeof v[0] === "string") return v[0];
+    }
+  }
+  return fallback;
+}
+
+// ---- Auth ----
+
+export async function login(username: string, password: string) {
+  const { data } = await axios.post(`${TOKEN_BASE}/token/`, { username, password });
+  localStorage.setItem(ACCESS_KEY, data.access);
+  localStorage.setItem(REFRESH_KEY, data.refresh);
+  return data;
+}
+
+export function logout() {
+  localStorage.removeItem(ACCESS_KEY);
+  localStorage.removeItem(REFRESH_KEY);
+}
+
+export function isLoggedIn() {
+  return !!localStorage.getItem(ACCESS_KEY);
+}
+
+export async function getMe(): Promise<CaseworkUser> {
+  const { data } = await client.get("/auth/me/");
+  return data;
+}
+
+// ---- Reviews ----
+
+function unwrap<T>(data: Paginated<T> | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+export async function listReviews(): Promise<ReviewListItem[]> {
+  const { data } = await client.get<Paginated<ReviewListItem> | ReviewListItem[]>("/reviews/");
+  return unwrap(data);
+}
+
+export async function getReview(id: number): Promise<ReviewDetail> {
+  const { data } = await client.get<ReviewDetail>(`/reviews/${id}/`);
+  return data;
+}
+
+export async function submitReview(slug: string): Promise<ReviewDetail> {
+  const { data } = await client.post<ReviewDetail>("/reviews/submit/", { slug });
+  return data;
+}
+
+export async function regradeAll(): Promise<{ regrading: number; review_ids: number[] }> {
+  const { data } = await client.post("/reviews/regrade-all/");
+  return data;
+}
+
+// ---- Rules (code-enforced, read-only) ----
+
+export async function listRules(): Promise<CaseworkRule[]> {
+  const { data } = await client.get<CaseworkRule[]>("/rules/");
+  return data;
+}
+
+// ---- Config ----
+
+export async function getConfig(): Promise<ReviewConfig> {
+  const { data } = await client.get<ReviewConfig>("/config/");
+  return data;
+}
+
+export async function updateConfig(payload: Partial<ReviewConfig>): Promise<ReviewConfig> {
+  const { data } = await client.put<ReviewConfig>("/config/", payload);
+  return data;
+}

--- a/src/types/casework.ts
+++ b/src/types/casework.ts
@@ -1,0 +1,130 @@
+// Types for the Casework Review System portal (ported from the standalone
+// casework SPA into the jawafdehi frontend). The review system is rule-centered:
+// each review scores a case against editable Rules and rolls them up into
+// per-category scores + an overall disposition.
+
+export interface CaseworkUser {
+  username: string;
+  roles: string[];
+  is_admin: boolean;
+}
+
+export type ReviewStatus = "pending" | "running" | "done" | "failed";
+export type Disposition = "PASS" | "REVISE" | "REJECT";
+
+export interface ReviewListItem {
+  id: number;
+  slug: string;
+  status: ReviewStatus;
+  stage: string;
+  case_title: string;
+  case_state: string;
+  source_count: number;
+  sources_converted: number;
+  overall_score: number | null;
+  disposition: Disposition | null;
+  case_type: string;
+  created_at: string;
+  completed_at: string | null;
+  duration_seconds: number | null;
+}
+
+export interface RuleResult {
+  key: string;
+  title: string;
+  category: string;
+  kind: "deterministic" | "llm";
+  condition_text: string;
+  applies_to: string[];
+  weight: number;
+  is_gate: boolean;
+  gate_min: number;
+  gate_failed: boolean;
+  score: number;
+  confidence: "high" | "medium" | "low";
+  variance: number;
+  std: number;
+  issues: string[];
+  suggestions: string[];
+  rationale: string;
+  description: string;
+  good_examples: string;
+  bad_examples: string;
+}
+
+export interface CategoryScore {
+  category: string;
+  score: number;
+  rules: number;
+}
+
+export interface SourceSummary {
+  title: string;
+  source_type: string;
+  conversion_status: string;
+  conversion_note: string;
+  markdown_chars: number;
+  markdown: string;
+  url: string[];
+}
+
+export interface ReviewResult {
+  slug: string;
+  title: string;
+  state: string;
+  case_type: { type: string; label: string; rationale: string };
+  overall_score: number;
+  disposition: Disposition;
+  rules: RuleResult[];
+  categories: CategoryScore[];
+  gate_failures: { key: string; title: string; score: number; gate_min: number }[];
+  gates_pass: boolean;
+  narrative: string;
+  judge_error: string | null;
+  llm_samples: number;
+  thresholds: { pass: number; revise: number };
+  model_id_used: string | null;
+  source_summary: SourceSummary[];
+}
+
+export interface ReviewDetail extends ReviewListItem {
+  error: string;
+  result: ReviewResult | null;
+  updated_at: string;
+  started_at: string | null;
+}
+
+export interface CaseworkRule {
+  id: number;
+  key: string;
+  title: string;
+  category: string;
+  description: string;
+  good_examples: string;
+  bad_examples: string;
+  condition_text: string;
+  applies_to: string[];
+  kind: "deterministic" | "llm";
+  detector: string;
+  weight: number;
+  is_gate: boolean;
+  gate_min: number;
+  enabled: boolean;
+  order: number;
+  updated_at: string;
+}
+
+export interface ReviewConfig {
+  pass_threshold: number;
+  revise_threshold: number;
+  llm_samples: number;
+  updated_at: string;
+}
+
+// DRF default pagination envelope (the jawafdehi-api paginates list endpoints).
+export interface Paginated<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,8 +37,26 @@ export default defineConfig(({ mode, isSsrBuild }) => {
 
   return {
     server: {
-      host: "::",
-      port: 8080,
+      // Loopback only; reached via SSH port-forward of this single port.
+      host: "127.0.0.1",
+      port: 40114,
+      strictPort: true,
+      // Same-origin /api and /admin -> local gunicorn, so only one tunnel is needed.
+      proxy: {
+        "/api": {
+          target: "http://127.0.0.1:40173",
+          changeOrigin: true,
+        },
+        "/admin": {
+          target: "http://127.0.0.1:40173",
+          changeOrigin: true,
+        },
+        // Django/WhiteNoise static (admin CSS etc.) lives under /static.
+        "/static": {
+          target: "http://127.0.0.1:40173",
+          changeOrigin: true,
+        },
+      },
     },
     plugins: [
       react(),


### PR DESCRIPTION
A standalone full-screen portal for the Casework Review System, mounted at /portal (on jawafdehi.org; the API lives on portal.jawafdehi.org):
- Reviews list + detail (per-rule breakdown, radar, sources, re-run, 'needs addressing' sorted worst-first, link to the public case), read-only Rules page grouped by category, and a How-it-works page.
- Auth via the shared JWT: a /portal/login page posts to the caseworker token endpoint, stores the access/refresh tokens, sends Authorization: Bearer, and refreshes on 401 (falling back to the login page). Single-origin for login; no cross-origin cookies/CSRF.
- casework-api client, shared casework-ui helpers, and casework types.
- Vite dev server proxies /api, /admin and /static to the local backend.