### PR TITLE
Display source link types (original / permalink / markdown transcript)

### DIFF
--- a/src/components/DocumentSourceCard.tsx
+++ b/src/components/DocumentSourceCard.tsx
@@ -1,14 +1,15 @@
-import { ExternalLink } from "lucide-react";
+import { Archive, ExternalLink, FileText } from "lucide-react";
+import type { ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
-import type { DocumentSource, DocumentSourceType, SourceUrlEntry, SourceLinkRole } from "@/types/jds";
+import type {
+  DocumentSource,
+  DocumentSourceType,
+  SourceLink,
+  SourceLinkRole,
+} from "@/types/jds";
 import { DocumentSourceTypeKeys } from "@/types/jds";
 import { getSourceTypeBadgeClass } from "@/utils/source-type-badge";
-
-interface NormalizedUrl {
-  href: string;
-  role: SourceLinkRole | null;
-}
 
 interface DocumentSourceCardProps {
   source: DocumentSource | null;
@@ -17,45 +18,105 @@ interface DocumentSourceCardProps {
   evidenceDescription?: string;
 }
 
-const normalizeUrls = (url: SourceUrlEntry[] | string | null | undefined): NormalizedUrl[] => {
-  if (!url) return [];
+// URL scheme validation - only allow http/https
+const isAllowedScheme = (u: string) => /^https?:\/\//i.test(u.trim());
 
-  const isAllowedScheme = (u: string) => /^https?:\/\//i.test(u.trim());
+const KNOWN_ROLES: SourceLinkRole[] = ["RAW", "PERMALINK", "MARKDOWN"];
 
-  const arr = Array.isArray(url) ? url : [url];
-  return arr
-    .map((entry): NormalizedUrl | null => {
-      if (!entry) return null;
-      if (typeof entry === 'string') {
-        if (!isAllowedScheme(entry)) return null;
-        return { href: entry, role: null };
-      }
-      // dict format {link, role}
-      const href = entry.link?.trim();
-      if (!href || !isAllowedScheme(href)) return null;
-      return { href, role: entry.role ?? null };
-    })
-    .filter((u): u is NormalizedUrl => u !== null);
+// web.archive.org / archive.org snapshot URLs are permalinks by nature. Some
+// records mis-tag these as RAW (importer bug), so we override the stated role
+// from the URL itself to keep the UI correct regardless of bad data.
+const isArchiveUrl = (link: string) =>
+  /^https?:\/\/(web\.)?archive\.org\//i.test(link.trim());
+
+const normalizeRole = (
+  role: string | null | undefined,
+  link: string,
+): SourceLinkRole => {
+  if (isArchiveUrl(link)) return "PERMALINK";
+  return role && (KNOWN_ROLES as string[]).includes(role) ? (role as SourceLinkRole) : "RAW";
 };
 
-export function DocumentSourceCard({ 
-  source, 
-  sourceId, 
+/**
+ * Build a clean, role-tagged list of links from a source's `urls` field.
+ *
+ * `urls` is the canonical source of links: each entry is a `{link, role}` dict
+ * with an explicit role (RAW/MARKDOWN/PERMALINK). Invalid or non-http(s)
+ * entries are dropped.
+ */
+const resolveLinks = (source: DocumentSource | null): SourceLink[] => {
+  if (!source || !Array.isArray(source.urls)) return [];
+
+  return source.urls
+    .filter((u): u is SourceLink => Boolean(u?.link) && isAllowedScheme(u.link))
+    .map((u) => ({ link: u.link.trim(), role: normalizeRole(u.role, u.link) }));
+};
+
+// Visual treatment per role: icon + i18n label key for the prominent links.
+const PRIMARY_ROLE_META: Record<
+  "RAW" | "PERMALINK",
+  { icon: ComponentType<{ className?: string }>; labelKey: string }
+> = {
+  RAW: { icon: ExternalLink, labelKey: "documentSource.role.raw" },
+  PERMALINK: { icon: Archive, labelKey: "documentSource.role.permalink" },
+};
+
+/**
+ * Split links into the prominent primary links and the markdown transcript(s).
+ *
+ * The backend over-tags the markdown transcript's S3 URL: the same URL often
+ * appears BOTH as MARKDOWN and again as RAW/PERMALINK. Any non-markdown link
+ * pointing at a markdown URL is therefore the transcript itself, not a separate
+ * source — collapse it into the transcript (rendered once, as small text). The
+ * remaining primary links are then deduped by URL so a link tagged twice (e.g.
+ * RAW + PERMALINK on the same href) renders a single button.
+ */
+const partitionLinks = (links: SourceLink[]) => {
+  const markdownHrefs = new Set<string>();
+  const markdownLinks = links.filter((l) => {
+    if (l.role !== "MARKDOWN" || markdownHrefs.has(l.link)) return false;
+    markdownHrefs.add(l.link);
+    return true;
+  });
+
+  const primaryLinks: SourceLink[] = [];
+  const seen = new Set<string>();
+  for (const l of links) {
+    if (l.role === "MARKDOWN" || markdownHrefs.has(l.link)) continue;
+    if (seen.has(l.link)) continue;
+    seen.add(l.link);
+    primaryLinks.push(l);
+  }
+
+  return { primaryLinks, markdownLinks };
+};
+
+export function DocumentSourceCard({
+  source,
+  sourceId,
   itemNumber,
-  evidenceDescription
+  evidenceDescription,
 }: DocumentSourceCardProps) {
   const { t } = useTranslation();
-  const urls = normalizeUrls(source?.url);
-  const hasUrls = urls.length > 0;
-  
+  const links = resolveLinks(source);
+  const { primaryLinks, markdownLinks } = partitionLinks(links);
+
   // Get source type label with i18n support and fallback for legacy types
-  const sourceTypeLabel = source?.source_type 
-    ? (DocumentSourceTypeKeys[source.source_type as DocumentSourceType] 
-        ? t(DocumentSourceTypeKeys[source.source_type as DocumentSourceType])
-        : source.source_type)
+  const sourceTypeLabel = source?.source_type
+    ? DocumentSourceTypeKeys[source.source_type as DocumentSourceType]
+      ? t(DocumentSourceTypeKeys[source.source_type as DocumentSourceType])
+      : source.source_type
     : null;
   const sourceTypeClass = getSourceTypeBadgeClass(source?.source_type);
-  
+
+  // Only number a given role's links when there's more than one of that role,
+  // so a lone "View original" doesn't get an awkward "1" suffix.
+  const primaryRoleCounts = primaryLinks.reduce<Record<string, number>>((acc, l) => {
+    acc[l.role] = (acc[l.role] ?? 0) + 1;
+    return acc;
+  }, {});
+  const primaryRoleSeen: Record<string, number> = {};
+
   return (
     <article className="border-b border-border/70 py-3 last:border-b-0">
       <div className="flex min-w-0 items-start gap-3">
@@ -77,32 +138,29 @@ export function DocumentSourceCard({
               </div>
             </div>
 
-            {hasUrls && (
+            {primaryLinks.length > 0 && (
               <div className="flex flex-shrink-0 flex-wrap items-center gap-x-4 gap-y-1 md:justify-end">
-                {urls.map((item, index) => {
-                  const linkText = urls.length > 1
-                    ? t("documentSource.viewSourceN", { n: index + 1 })
-                    : t("documentSource.viewSource");
+                {primaryLinks.map((link, index) => {
+                  const meta = PRIMARY_ROLE_META[link.role as "RAW" | "PERMALINK"] ?? PRIMARY_ROLE_META.RAW;
+                  const Icon = meta.icon;
+                  const isNumbered = primaryRoleCounts[link.role] > 1;
+                  const n = (primaryRoleSeen[link.role] = (primaryRoleSeen[link.role] ?? 0) + 1);
+                  const baseLabel = t(meta.labelKey);
+                  const linkText = isNumbered ? `${baseLabel} ${n}` : baseLabel;
                   const ariaLabel = `${linkText} ${t("documentSource.opensInNewTab")}`;
 
                   return (
-                    <div key={`${index}-${item.href}`} className="inline-flex items-center gap-1.5">
-                      {item.role && (
-                        <Badge variant="secondary" className="rounded px-1.5 py-0 text-[10px] font-medium">
-                          {t(`documentSource.roles.${item.role}`, { defaultValue: item.role })}
-                        </Badge>
-                      )}
-                      <a
-                        href={item.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={ariaLabel}
-                        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline"
-                      >
-                        <ExternalLink className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
-                        {linkText}
-                      </a>
-                    </div>
+                    <a
+                      key={`${index}-${link.link}`}
+                      href={link.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={ariaLabel}
+                      className="inline-flex items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                      <Icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                      {linkText}
+                    </a>
                   );
                 })}
               </div>
@@ -119,6 +177,32 @@ export function DocumentSourceCard({
             <p className="mt-2 text-sm leading-6 text-muted-foreground break-words">
               {evidenceDescription}
             </p>
+          )}
+
+          {markdownLinks.length > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+              {markdownLinks.map((link, index) => {
+                const linkText =
+                  markdownLinks.length > 1
+                    ? t("documentSource.role.markdownN", { n: index + 1 })
+                    : t("documentSource.role.markdown");
+                const ariaLabel = `${linkText} ${t("documentSource.opensInNewTab")}`;
+
+                return (
+                  <a
+                    key={`md-${index}-${link.link}`}
+                    href={link.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={ariaLabel}
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                  >
+                    <FileText className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                    {linkText}
+                  </a>
+                );
+              })}
+            </div>
           )}
         </div>
       </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -503,10 +503,11 @@
     "viewSource": "View Source",
     "viewSourceN": "View Source {{n}}",
     "opensInNewTab": "(opens in a new tab)",
-    "roles": {
-      "RAW": "RAW",
-      "MARKDOWN": "Markdown",
-      "PERMALINK": "Permalink"
+    "role": {
+      "raw": "View original",
+      "permalink": "Permalink",
+      "markdown": "Show markdown transcript",
+      "markdownN": "Show markdown transcript {{n}}"
     }
   },
   "sourceType": {

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -503,10 +503,11 @@
     "viewSource": "स्रोत हेर्नुहोस्",
     "viewSourceN": "स्रोत {{n}} हेर्नुहोस्",
     "opensInNewTab": "(नयाँ ट्याबमा खुल्छ)",
-    "roles": {
-      "RAW": "RAW",
-      "MARKDOWN": "Markdown",
-      "PERMALINK": "स्थायी लिङ्क"
+    "role": {
+      "raw": "मूल हेर्नुहोस्",
+      "permalink": "स्थायी लिङ्क",
+      "markdown": "मार्कडाउन ट्रान्सक्रिप्ट हेर्नुहोस्",
+      "markdownN": "मार्कडाउन ट्रान्सक्रिप्ट {{n}} हेर्नुहोस्"
     }
   },
   "sourceType": {

--- a/src/services/guest-chat-adapter.ts
+++ b/src/services/guest-chat-adapter.ts
@@ -845,7 +845,9 @@ function findRelevantSources(
         source?.title,
         source?.description,
         evidenceDescription,
-        Array.isArray(source?.url) ? source?.url.join(" ") : "",
+        Array.isArray(source?.urls)
+          ? source.urls.map((u) => u?.link).filter(Boolean).join(" ")
+          : "",
       ]
         .filter(Boolean)
         .join(" ")

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -160,8 +160,11 @@ export interface CaseDetail extends Case {
 
 export type SourceLinkRole = 'RAW' | 'MARKDOWN' | 'PERMALINK';
 
-/** A single URL entry which may be a plain string or a {link, role} dict. */
-export type SourceUrlEntry = string | { link: string; role?: SourceLinkRole | null };
+/** A source link with an explicit role (the `urls` field shape). */
+export interface SourceLink {
+  link: string;
+  role: SourceLinkRole;
+}
 
 export interface DocumentSource {
   id: number;
@@ -169,7 +172,7 @@ export interface DocumentSource {
   title: string;
   description: string;
   source_type: DocumentSourceType | string | null; // DocumentSourceType for known values; plain string covers legacy/unknown backend values; null if not classified
-  url?: SourceUrlEntry[] | null; // Array of URLs/URL-dicts for this source (may be missing or null during migration)
+  urls?: SourceLink[] | null; // Link dicts with explicit role (RAW/MARKDOWN/PERMALINK); includes uploaded-file URL when present
   related_entities: JawafEntity[]; // Related entities
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
Render DocumentSource links by role instead of undifferentiated 'View Source 1/2/3'. Read links from the canonical `urls` field (`[{link, role}]`) and:

- RAW   -> 'View original' (external-link icon)
- PERMALINK -> 'Permalink' (archive icon)
- MARKDOWN  -> smaller, muted 'Show markdown transcript' below the body

The backend over-tags the markdown transcript's URL (same URL as both MARKDOWN and RAW/PERMALINK); collapse any non-markdown link that points at a markdown URL into the transcript, and dedupe primary links by URL. web.archive.org/archive.org URLs are forced to PERMALINK to survive records that mis-tag them as RAW.

BREAKING: drop the deprecated `url` field and `SourceUrlEntry` type; `DocumentSource` now exposes only `urls`. Update guest-chat-adapter accordingly.