### PR TITLE
Render timeline date_bs and end_date spans

### DIFF
--- a/src/components/CaseItem.tsx
+++ b/src/components/CaseItem.tsx
@@ -64,7 +64,7 @@ const CaseItem = ({ case: caseData }: CaseItemProps) => {
             <div className="space-y-2 pl-4 border-l-2 border-muted">
               {caseData.timeline.slice(0, 3).map((event, index) => (
                 <div key={index} className="pl-4">
-                  <div className="text-sm font-medium">{event.event}</div>
+                  <div className="text-sm font-medium">{event.title}</div>
                   <div className="text-xs text-muted-foreground">
                     {formatDate(event.date)}
                   </div>

--- a/src/components/CaseTimeline.tsx
+++ b/src/components/CaseTimeline.tsx
@@ -30,7 +30,9 @@ export function CaseTimeline({ timeline, title, className }: CaseTimelineProps) 
               aria-hidden="true"
             />
             <p className="text-xs font-semibold text-primary print:text-sm print:text-foreground">
-              {formatDateWithBS(item.date)}
+              {item.end_date
+                ? `${formatDateWithBS(item.date, "PP", item.date_bs)} – ${formatDateWithBS(item.end_date, "PP", item.end_date_bs)}`
+                : formatDateWithBS(item.date, "PP", item.date_bs)}
             </p>
             <p className="mt-1 text-sm font-medium leading-snug text-muted-foreground print:text-foreground">
               {item.title}

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -67,9 +67,12 @@ export interface EntityCaseRelationship {
 }
 
 export interface TimelineEntry {
-  date: string; // ISO date format
+  date: string; // AD ISO date format
   title: string;
   description: string;
+  date_bs?: string; // Bikram Sambat date (YYYY-MM-DD), as recorded in the source
+  end_date?: string; // AD ISO date; present when the event spans a period
+  end_date_bs?: string; // Bikram Sambat date (YYYY-MM-DD) for the span's end
 }
 
 export interface EvidenceEntry {

--- a/src/utils/bs-calendar.ts
+++ b/src/utils/bs-calendar.ts
@@ -84,3 +84,21 @@ export function adToBS(adYear: number, adMonth: number, adDay: number): BSDate {
     throw new RangeError('Date conversion failed');
   }
 }
+
+/**
+ * Format a curated Bikram Sambat date string ("YYYY-MM-DD") in the same
+ * Devanagari style as {@link adToBS} (e.g. "२०८२ पौष १७").
+ *
+ * Returns null if the string is not a well-formed BS date, so callers can fall
+ * back to converting the AD date instead.
+ */
+export function formatBSString(bsDateString: string | null | undefined): string | null {
+  if (!bsDateString) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(bsDateString);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const date = Number(match[3]);
+  if (month < 1 || month > 12 || date < 1 || date > 32) return null;
+  return `${toNepaliNumerals(year)} ${NEPALI_MONTHS[month - 1]} ${toNepaliNumerals(date)}`;
+}

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { formatDateWithBS } from "@/utils/date";
+import { formatBSString } from "@/utils/bs-calendar";
+
+describe("formatBSString", () => {
+  it("formats a curated BS date string in Devanagari", () => {
+    // 2081-10-27 BS -> "२०८१ माघ २७"
+    expect(formatBSString("2081-10-27")).toBe("२०८१ माघ २७");
+  });
+
+  it("returns null for malformed input", () => {
+    expect(formatBSString("2081/10/27")).toBeNull();
+    expect(formatBSString("")).toBeNull();
+    expect(formatBSString(undefined)).toBeNull();
+    expect(formatBSString("2081-13-01")).toBeNull();
+  });
+});
+
+describe("formatDateWithBS with bsOverride", () => {
+  it("uses the curated BS date verbatim when provided", () => {
+    const out = formatDateWithBS("2025-02-09", "PP", "2081-10-27");
+    expect(out).toContain("२०८१ माघ २७");
+  });
+
+  it("falls back to computed BS when override is absent", () => {
+    const out = formatDateWithBS("2025-02-09", "PP");
+    // Computed conversion of 2025-02-09 is also 2081 माघ 27.
+    expect(out).toContain("२०८१");
+  });
+
+  it("falls back to computed BS when override is malformed", () => {
+    const out = formatDateWithBS("2025-02-09", "PP", "garbage");
+    expect(out).toContain("२०८१");
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -6,7 +6,7 @@
 
 import { parseISO } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { adToBS } from './bs-calendar';
+import { adToBS, formatBSString } from './bs-calendar';
 
 const KATHMANDU_TZ = 'Asia/Kathmandu';
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
@@ -77,10 +77,22 @@ function convertToBS(dateString: string | null | undefined) {
 
 // ── Combined AD + BS formatting ──────────────────────────────────────────
 
-/** Format a date as "AD date | BS date". */
-export function formatDateWithBS(dateString: string | null | undefined, fmt = 'PP'): string {
+/**
+ * Format a date as "AD date | BS date".
+ *
+ * When `bsOverride` (a "YYYY-MM-DD" Bikram Sambat string) is supplied it is used
+ * verbatim instead of recomputing the BS date, so curated source dates are
+ * preserved exactly.
+ */
+export function formatDateWithBS(
+  dateString: string | null | undefined,
+  fmt = 'PP',
+  bsOverride?: string | null
+): string {
   if (!dateString) return 'N/A';
   const ad = formatDate(dateString, fmt);
+  const overrideFormatted = formatBSString(bsOverride);
+  if (overrideFormatted) return `${ad} | ${overrideFormatted}`;
   const bs = convertToBS(dateString);
   return bs ? `${ad} | ${bs.formatted}` : ad;
 }


### PR DESCRIPTION
## Summary

Frontend companion to the timeline schema work (CIAA factual timeline, #186). Timeline entries can now carry an optional curated Bikram Sambat date (\`date_bs\` / \`end_date_bs\`) and an \`end_date\` for events that span a period (e.g. the factual-incident / investigation window).

## Changes

- **\`TimelineEntry\`**: add optional \`date_bs\`, \`end_date\`, \`end_date_bs\`.
- **\`formatDateWithBS\`**: accept an optional \`bsOverride\` so curated source BS dates are shown verbatim instead of recomputing from the AD date (falls back to on-the-fly conversion when absent or malformed).
- **\`formatBSString\`** (new, \`bs-calendar.ts\`): format a curated \`YYYY-MM-DD\` BS string in the same Devanagari style as \`adToBS\` (e.g. \`२०८२ पौष १७\`); returns \`null\` on malformed input.
- **\`CaseTimeline\`**: render a \`start – end\` range when \`end_date\` is present, using curated BS for both ends when available.

## Bug fix (found in review)

- **\`CaseItem\`**: case cards rendered \`event.event\`, but \`TimelineEntry\` has no \`event\` field — the property is \`title\`. Every card showed a blank timeline title (date + description rendered, title was \`undefined\`). \`CaseTimeline\` (detail view) already used \`item.title\` correctly.

## Companion PR

Backend schema (validation for the new fields): Jawafdehi/JawafdehiAPI#189

## Test plan

- \`vitest run src/utils/date.test.ts\` — 5 passed (new): \`formatBSString\` formatting + malformed-input fallback, \`formatDateWithBS\` override/fallback paths.
- \`tsc --noEmit\` clean; \`eslint\` clean.