### PR TITLE
Support TAX_EVASION case type in case displays

### DIFF
--- a/src/components/CaseDetailBanner.tsx
+++ b/src/components/CaseDetailBanner.tsx
@@ -10,6 +10,7 @@ import { formatCaseDateRange } from "@/utils/date";
 import { getPrimaryName } from "@/utils/nes-helpers";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { formatBigo } from "@/utils/number";
+import { getCaseTypeLabelKey } from "@/utils/case-entities";
 
 interface CaseDetailBannerProps {
   caseData: CaseDetail;
@@ -39,7 +40,7 @@ export function CaseDetailBanner({
   };
   const statusKey = caseData.state ? stateMap[caseData.state] : "caseDetail.status.ongoing";
   const statusLabel = t(statusKey || "caseDetail.status.ongoing");
-  const caseTypeLabel = t("cases.type.corruption");
+  const caseTypeLabel = t(getCaseTypeLabelKey(caseData.case_type));
   const dateRange = formatCaseDateRange(caseData.case_start_date, caseData.case_end_date, t("cases.status.ongoing"));
   const notAvailableLabel = t("common.notAvailable");
 

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -14,6 +14,7 @@ import type {
 import { cn } from "@/lib/utils";
 import { getCaseById } from "@/services/jds-api";
 import { toggleArchiveSearchParam } from "@/utils/archive-search-params";
+import { getSubjectEntities } from "@/utils/case-entities";
 
 export function SearchResultCard({ result }: Readonly<{ result: ArchiveSearchResult }>) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -173,7 +174,9 @@ function resultMetadata(result: ArchiveSearchResult) {
 }
 
 function caseMetadata(result: CaseSearchResult) {
-  const primaryEntity = result.entities.find((entity) => entity.relationship_type === "accused");
+  // Subject entity: accused for CORRUPTION cases, else any named (non-location)
+  // entity so cases without an accused (e.g. TAX_EVASION) still name a subject.
+  const [primaryEntity] = getSubjectEntities(result.entities, e => e.relationship_type);
   const location = result.entities.find((entity) => entity.relationship_type === "location");
   return [entityName(primaryEntity), entityName(location)].filter(Boolean).join(" · ");
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -332,6 +332,7 @@
     "listView": "List view",
     "type": {
       "corruption": "Corruption",
+      "taxEvasion": "Tax Evasion",
       "misconduct": "Misconduct",
       "breachOfTrust": "Breach of Trust",
       "mediaTrial": "Media Trial"

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -332,6 +332,7 @@
     "listView": "सूची दृश्य",
     "type": {
       "corruption": "भ्रष्टाचार",
+      "taxEvasion": "कर छली",
       "misconduct": "दुर्व्यवहार",
       "breachOfTrust": "विश्वासको उल्लङ्घन",
       "mediaTrial": "मिडिया ट्रायल"

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -31,6 +31,7 @@ import type { Entity } from "@/types/nes";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { formatCaseDateRange } from "@/utils/date";
 import { stripMarkdown } from "@/utils/markdown";
+import { getSubjectEntities } from "@/utils/case-entities";
 import { ReportCaseDialog } from "@/components/ReportCaseDialog";
 import { DisqusComments } from "@/components/DisqusComments";
 import { JAWAFDEHI_WHATSAPP_NUMBER, JAWAFDEHI_EMAIL } from "@/config/constants";
@@ -170,11 +171,13 @@ const CaseDetail = () => {
     staleTime: 5 * 60 * 1000,
   });
 
-  const accusedEntities = caseData?.entities.filter(e => e.type === 'accused') ?? [];
-  const accusedCount = accusedEntities.length;
+  // Subject entities: accused for CORRUPTION cases, else any named (non-location)
+  // entity so cases without an accused (e.g. TAX_EVASION) still name a subject.
+  const bannerEntities = getSubjectEntities(caseData?.entities, e => e.type);
+  const accusedCount = bannerEntities.length;
   const BANNER_ACCUSED_LIMIT = 5;
   const collapsedAccused = accusedCount > BANNER_ACCUSED_LIMIT;
-  const visibleAccusedEntities = collapsedAccused ? accusedEntities.slice(0, BANNER_ACCUSED_LIMIT) : accusedEntities;
+  const visibleAccusedEntities = collapsedAccused ? bannerEntities.slice(0, BANNER_ACCUSED_LIMIT) : bannerEntities;
   const hiddenAccusedCount = accusedCount - visibleAccusedEntities.length;
 
   const sourceQueries = useQueries({

--- a/src/pages/Cases.tsx
+++ b/src/pages/Cases.tsx
@@ -14,6 +14,7 @@ import { getEntityById } from "@/services/api";
 import { useQuery, useQueries } from "@tanstack/react-query";
 
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
+import { getSubjectEntities } from "@/utils/case-entities";
 import type { Case } from "@/types/jds";
 
 /**
@@ -325,8 +326,10 @@ function CaseResults({
 }
 
 function getEntityNames(caseItem: Case, resolvedEntities: Record<string, unknown>, currentLang: string): string[] {
-  const accusedEntities = caseItem.entities?.filter(e => e.type === 'accused') || [];
-  return accusedEntities.map(e => {
+  // Subject entities: accused for CORRUPTION cases, else any named (non-location)
+  // entity so cases without an accused (e.g. TAX_EVASION) still name a subject.
+  const namedEntities = getSubjectEntities(caseItem.entities, e => e.type);
+  return namedEntities.map(e => {
     if (e.nes_id && resolvedEntities[e.nes_id]) {
       const entity = resolvedEntities[e.nes_id];
       return entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { Entity } from "@/types/nes";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
+import { getSubjectEntities } from "@/utils/case-entities";
 import { useTranslation } from "react-i18next";
 
 const Index = () => {
@@ -84,11 +85,13 @@ const Index = () => {
   const featuredCases = useMemo(() => {
     if (!casesData?.results) return [];
     return casesData.results.slice(0, 3).map((caseItem) => {
-      // Get accused entities and locations from unified entities array
-      const accusedEntities = caseItem.entities?.filter(e => e.type === 'accused') || [];
+      // Locations and the case's subject entities. Subjects are the accused for
+      // CORRUPTION cases, else any named (non-location) entity so cases without
+      // an accused (e.g. TAX_EVASION) still name a subject.
       const locationEntities = caseItem.entities?.filter(e => e.type === 'location') || [];
+      const namedEntities = getSubjectEntities(caseItem.entities, e => e.type);
 
-      const entityNames = accusedEntities.map(e => {
+      const entityNames = namedEntities.map(e => {
         if (e.nes_id && resolvedEntities[e.nes_id]) {
           const entity = resolvedEntities[e.nes_id];
           return entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id;
@@ -120,7 +123,7 @@ const Index = () => {
         allegations: caseItem.key_allegations, // Pass key allegations to CaseCard
         thumbnailUrl: caseItem.thumbnail_url ?? undefined,
         tags: caseItem.tags,
-        entityIds: accusedEntities.map(e => e.id),
+        entityIds: namedEntities.map(e => e.id),
         locationIds: locationEntities.map(l => l.id),
       };
     });

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -11,8 +11,9 @@
 // Enums
 // ============================================================================
 
-export type CaseType = 
-  | 'CORRUPTION';
+export type CaseType =
+  | 'CORRUPTION'
+  | 'TAX_EVASION';
 
 export type CaseState =
   | 'DRAFT'

--- a/src/utils/case-entities.ts
+++ b/src/utils/case-entities.ts
@@ -1,0 +1,46 @@
+// Helpers for selecting and labelling a case's subject entities.
+//
+// Not every case type names an "accused" party. CORRUPTION cases do; others
+// (e.g. TAX_EVASION) do not. So when we need to name a case's subject(s) we
+// prefer the accused entities, but fall back to any other *named* (non-location)
+// entity when there are none. Locations are never a subject.
+
+const LOCATION_ROLE = "location";
+const ACCUSED_ROLE = "accused";
+
+/**
+ * Return the entities that name a case's subject.
+ *
+ * Prefers accused entities; when there are none (e.g. a TAX_EVASION case) falls
+ * back to every other entity that has a defined, non-location role. Entities
+ * with a missing/empty role are never treated as a subject.
+ *
+ * @param entities  the case's entities (any shape)
+ * @param getRole   extracts the relationship role from one entity
+ */
+export function getSubjectEntities<T>(
+  entities: readonly T[] | null | undefined,
+  getRole: (entity: T) => string | null | undefined,
+): T[] {
+  const list = entities ?? [];
+  const accused = list.filter((e) => getRole(e) === ACCUSED_ROLE);
+  if (accused.length > 0) return accused;
+  return list.filter((e) => {
+    const role = getRole(e);
+    return Boolean(role) && role !== LOCATION_ROLE;
+  });
+}
+
+// i18n keys for each case type's display label, keyed by the backend CaseType
+// value. Single source of truth so every display site stays consistent.
+const CASE_TYPE_LABEL_KEYS: Record<string, string> = {
+  CORRUPTION: "cases.type.corruption",
+  TAX_EVASION: "cases.type.taxEvasion",
+};
+
+const DEFAULT_CASE_TYPE_LABEL_KEY = "cases.type.corruption";
+
+/** i18n key for a case type's display label (falls back to corruption). */
+export function getCaseTypeLabelKey(caseType: string | null | undefined): string {
+  return (caseType && CASE_TYPE_LABEL_KEYS[caseType]) || DEFAULT_CASE_TYPE_LABEL_KEY;
+}

--- a/tests/case-entities.test.ts
+++ b/tests/case-entities.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getSubjectEntities, getCaseTypeLabelKey } from '@/utils/case-entities';
+
+const role = (e: { type?: string | null }) => e.type;
+
+describe('getSubjectEntities', () => {
+  it('prefers accused entities when present', () => {
+    const entities = [
+      { id: 1, type: 'accused' },
+      { id: 2, type: 'related' },
+      { id: 3, type: 'location' },
+    ];
+    expect(getSubjectEntities(entities, role).map(e => e.id)).toEqual([1]);
+  });
+
+  it('returns all accused entities, not just the first', () => {
+    const entities = [
+      { id: 1, type: 'accused' },
+      { id: 2, type: 'accused' },
+    ];
+    expect(getSubjectEntities(entities, role).map(e => e.id)).toEqual([1, 2]);
+  });
+
+  it('falls back to non-location entities when there is no accused', () => {
+    const entities = [
+      { id: 1, type: 'related' },
+      { id: 2, type: 'witness' },
+      { id: 3, type: 'location' },
+    ];
+    expect(getSubjectEntities(entities, role).map(e => e.id)).toEqual([1, 2]);
+  });
+
+  it('never returns location-only entities as a subject', () => {
+    const entities = [{ id: 1, type: 'location' }];
+    expect(getSubjectEntities(entities, role)).toEqual([]);
+  });
+
+  it('ignores entities with a missing/empty role in the fallback', () => {
+    const entities = [
+      { id: 1, type: undefined },
+      { id: 2, type: '' },
+      { id: 3, type: 'related' },
+    ];
+    expect(getSubjectEntities(entities, role).map(e => e.id)).toEqual([3]);
+  });
+
+  it('handles null/undefined entity lists', () => {
+    expect(getSubjectEntities(null, role)).toEqual([]);
+    expect(getSubjectEntities(undefined, role)).toEqual([]);
+  });
+});
+
+describe('getCaseTypeLabelKey', () => {
+  it('maps known case types', () => {
+    expect(getCaseTypeLabelKey('CORRUPTION')).toBe('cases.type.corruption');
+    expect(getCaseTypeLabelKey('TAX_EVASION')).toBe('cases.type.taxEvasion');
+  });
+
+  it('falls back to corruption for unknown/null', () => {
+    expect(getCaseTypeLabelKey(null)).toBe('cases.type.corruption');
+    expect(getCaseTypeLabelKey('SOMETHING_ELSE')).toBe('cases.type.corruption');
+  });
+});


### PR DESCRIPTION
## What

Frontend support for the new **TAX_EVASION** case type. Display-only — case creation/editing is API/admin-driven, not a React form.

Pairs with backend PR Jawafdehi/JawafdehiAPI#191.

## How

- Adds `TAX_EVASION` to the `CaseType` union and a Nepali/English label (`cases.type.taxEvasion`).
- TAX_EVASION cases need not name an accused party, so the places that named a case's subject from its *accused* entities now fall back to any other named (non-location) entity. That selection — **accused first, else non-location, never location-only** — is centralized in a new `getSubjectEntities` helper used by the case detail banner/page, the cases list, the home page, and search result cards, replacing four near-duplicate inline implementations. The helper also ignores entities whose role is missing rather than mistaking them for a subject.
- The case-type display label goes through a shared `getCaseTypeLabelKey` helper instead of an inline map in the banner.

## Testing

- New unit tests for `getSubjectEntities` (accused-preference, non-location fallback, location-only → empty, missing-role ignored, null-safety) and `getCaseTypeLabelKey`.
- Full vitest suite passes (36 tests); `tsc` introduces no new errors; ESLint clean on all touched files.

🤖 Prepared with Claude Code