### PR TITLE
Adapt frontend to slim case LIST payload

### DIFF
--- a/src/components/guest/GuestCaseResultCard.tsx
+++ b/src/components/guest/GuestCaseResultCard.tsx
@@ -21,8 +21,13 @@ export function GuestCaseResultCard({
 }: GuestCaseResultCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // The list payload is slim, so `description` may be absent; fall back to
+  // `short_description` (and ultimately an empty string) to avoid crashing.
   const descriptionPreview = decodeHtmlEntities(
-    result.caseItem.description.replace(/<[^>]*>/g, " "),
+    (result.caseItem.short_description ?? result.caseItem.description ?? "").replace(
+      /<[^>]*>/g,
+      " ",
+    ),
   );
 
   return (

--- a/src/pages/Cases.tsx
+++ b/src/pages/Cases.tsx
@@ -305,7 +305,7 @@ function CaseResults({
             location={getLocationNames(caseItem, resolvedEntities, currentLang)}
             status={mapCaseStatusToBadge(getCaseStatus(caseItem))}
             tags={caseItem.tags || []}
-            description={caseItem.description.replace(/<[^>]*>/g, '').substring(0, 200)}
+            description={(caseItem.short_description ?? '').replace(/<[^>]*>/g, '').substring(0, 200)}
             allegations={caseItem.key_allegations}
             entityIds={(caseItem.entities?.filter(e => e.type === 'accused') || []).map(e => e.id)}
             locationIds={(caseItem.entities?.filter(e => e.type === 'location') || []).map(e => e.id)}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -119,7 +119,7 @@ const Index = () => {
         entityNames,
         location: locationNames,
         status: "ongoing" as const, // All published cases shown as ongoing
-        description: caseItem.description.replace(/<[^>]*>/g, '').substring(0, 200),
+        description: (caseItem.short_description ?? '').replace(/<[^>]*>/g, '').substring(0, 200),
         allegations: caseItem.key_allegations, // Pass key allegations to CaseCard
         thumbnailUrl: caseItem.thumbnail_url ?? undefined,
         tags: caseItem.tags,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -350,7 +350,7 @@ export async function getEntityAllegations(idOrSlug: string): Promise<Allegation
       status: 'ongoing', // Cases are published cases
       severity: jdsCase.case_type, // Map type to severity
       summary: jdsCase.key_allegations.join('; '),
-      evidence: jdsCase.evidence.map(e => e.description),
+      evidence: (jdsCase.evidence ?? []).map(e => e.description),
       date: jdsCase.created_at,
     }));
   } catch (error) {
@@ -375,8 +375,8 @@ export async function getEntityCases(idOrSlug: string): Promise<Case[]> {
       entity_id: idOrSlug,
       name: c.title,
       description: c.description,
-      documents: c.evidence.map(e => e.source_id.toString()),
-      timeline: c.timeline.map(t => ({
+      documents: (c.evidence ?? []).map(e => e.source_id.toString()),
+      timeline: (c.timeline ?? []).map(t => ({
         date: t.event_date,
         event: t.title,
         description: t.description

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -374,10 +374,12 @@ export async function getEntityCases(idOrSlug: string): Promise<Case[]> {
       id: c.id.toString(),
       entity_id: idOrSlug,
       name: c.title,
-      description: c.description,
+      // `c` is list-sourced, so the full `description` is absent; fall back to
+      // `short_description` (and ultimately '') for the required PAP field.
+      description: c.description ?? c.short_description ?? '',
       documents: (c.evidence ?? []).map(e => e.source_id.toString()),
       timeline: (c.timeline ?? []).map(t => ({
-        date: t.event_date,
+        date: t.date,
         event: t.title,
         description: t.description
       })),

--- a/src/services/guest-chat-adapter.ts
+++ b/src/services/guest-chat-adapter.ts
@@ -80,7 +80,7 @@ function getCaseSearchText(caseItem: Case): string {
       caseItem.key_allegations.join(" "),
       caseItem.tags.join(" "),
       caseItem.entities.map((entity) => `${entity.display_name || ""} ${entity.notes || ""}`).join(" "),
-      caseItem.timeline
+      (caseItem.timeline ?? [])
         .map((entry) => `${entry.title} ${entry.description}`)
         .join(" "),
     ]
@@ -90,7 +90,7 @@ function getCaseSearchText(caseItem: Case): string {
 }
 
 function getRelevantCiaaTimelineEntries(caseItem: Case) {
-  return caseItem.timeline.filter((entry) => {
+  return (caseItem.timeline ?? []).filter((entry) => {
     const text = normalize(`${entry.title} ${entry.description}`);
     return (
       text.includes("ciaa") ||
@@ -459,7 +459,7 @@ function scoreCaseForTopic(caseItem: Case, topicId: GuestTopicId): number {
 
     return (
       baseScore +
-      caseItem.timeline.filter((entry) =>
+      (caseItem.timeline ?? []).filter((entry) =>
         normalize(`${entry.title} ${entry.description}`).includes("ciaa") ||
         normalize(`${entry.title} ${entry.description}`).includes("अख्तियार")
       ).length * 2
@@ -469,7 +469,7 @@ function scoreCaseForTopic(caseItem: Case, topicId: GuestTopicId): number {
   if (topicId === "big_corruption_cases") {
     const bigoScore =
       caseItem.bigo && caseItem.bigo > 0 ? Math.min(12, Math.log10(caseItem.bigo + 1) * 3) : 0;
-    const evidenceScore = Math.min(5, caseItem.evidence.length);
+    const evidenceScore = Math.min(5, (caseItem.evidence ?? []).length);
     const allegationScore = Math.min(5, caseItem.key_allegations.length);
     const seriousTagScore = caseItem.tags.reduce((total, tag) => {
       const normalizedTag = normalize(tag);
@@ -533,7 +533,7 @@ function summarizeCiaaHandling(caseItem: Case, language: GuestLanguage): string 
   }
 
   const timelineText = normalize(
-    caseItem.timeline.map((entry) => `${entry.title} ${entry.description}`).join(" ")
+    (caseItem.timeline ?? []).map((entry) => `${entry.title} ${entry.description}`).join(" ")
   );
   const descriptionText = getCaseSearchText(caseItem);
 

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -145,19 +145,26 @@ export interface Case {
   banner_url?: string | null; // URL for wide banner image on case detail page
   entities: JawafEntity[]; // Unified entity relationships with type field
   tags: string[]; // Tags for categorization (e.g., 'land-encroachment', 'national-interest')
-  description: string; // Rich text description (HTML or Markdown)
   key_allegations: string[]; // List of key allegation statements
-  timeline: TimelineEntry[];
-  evidence: EvidenceEntry[];
   court_cases: string[]; // Court case IDs (e.g., "special:081-CR-0060")
-  notes: string; // Internal notes (HTML or Markdown)
-  missing_details?: string | null;
   bigo?: number | null;
   created_at: string; // ISO datetime
   updated_at: string; // ISO datetime
+  // The following heavy body fields are returned only by the case DETAIL
+  // endpoint. The slim LIST endpoint (CaseListSerializer) omits them, so they
+  // are optional on the base shape and re-asserted as required on CaseDetail.
+  description?: string; // Rich text description (HTML or Markdown)
+  timeline?: TimelineEntry[];
+  evidence?: EvidenceEntry[];
+  notes?: string; // Internal notes (HTML or Markdown)
+  missing_details?: string | null;
 }
 
 export interface CaseDetail extends Case {
+  description: string;
+  timeline: TimelineEntry[];
+  evidence: EvidenceEntry[];
+  notes: string;
   bigo: number | null; // Embezzled/irregular amount in NPR (null if not applicable)
   court_cases: string[] | null;
 }


### PR DESCRIPTION
## What

The backend case list endpoint (`GET /api/cases/`) now omits heavy detail-only fields (`description`, `timeline`, `evidence`, `notes`, `missing_details`) — see the companion API PR (Jawafdehi/JawafdehiAPI#201). This adapts the frontend so list consumers don't break on the now-absent fields.

## Changes

- **Types (`src/types/jds.ts`)** — make `description`, `timeline`, `evidence`, `notes` optional on the base `Case` (the list shape) and re-assert them as required on `CaseDetail` (the detail shape).
- **Cards (`Cases.tsx`, `Index.tsx`)** — render `short_description` instead of the full `description` for the card preview (`?? ''` handles blank/absent).
- **Null-safety for list-sourced field access** (`strictNullChecks` is off, so `tsc` won't catch these — they're runtime-crash risks):
  - **guest-chat knowledge index** (`guest-chat-adapter.ts`, `GuestCaseResultCard.tsx`) pages the list endpoint and indexed `description`/`timeline`/`evidence` client-side. Guarded with `?? []` / `?? ''` so it degrades gracefully (ranks on the lighter fields the slim list still carries) rather than crashing.
  - **`api.ts` helpers** `getEntityAllegations`/`getEntityCases` map over `.evidence`/`.timeline` of cases from `getCasesByEntity` (which hits the slim list); guarded with `?? []`.

## Verification
`tsc` clean (pre-existing `vite.config.ts` warnings unrelated), 41 unit tests pass.

> Note: degraded guest-chat ranking is intentional/accepted for this change. If it proves too weak, the clean follow-up is an opt-in `?detail=1` param on the list that the guest knowledge index alone passes.