### PR TITLE
Casework reviews: court-case-number/URL input + lazy-loaded list

### DIFF
--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -36,7 +36,7 @@ export default function CaseworkReviewDetail() {
     if (!review) return;
     setRerunning(true);
     try {
-      const fresh = await submitReview(review.slug);
+      const fresh = await submitReview({ slug: review.slug });
       navigate(`/portal/reviews/${fresh.id}`);
     } finally {
       setRerunning(false);

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -1,26 +1,60 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import CaseworkLayout from "@/components/CaseworkLayout";
-import { listReviews, submitReview, apiErrorMessage } from "@/services/casework-api";
+import {
+  listReviews,
+  submitReview,
+  buildSubmitPayload,
+  apiErrorMessage,
+} from "@/services/casework-api";
 import type { ReviewListItem } from "@/types/casework";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { dispositionColor, statusColor, fmtDate, fmtDur, scoreBand } from "@/lib/casework-ui";
 import { Loader2, Plus, RefreshCw } from "lucide-react";
 
+const PAGE_SIZE = 20;
+
+// Get the HTTP status off an axios error without pulling in axios types here.
+function errStatus(e: unknown): number | undefined {
+  return (e as { response?: { status?: number } })?.response?.status;
+}
+function conflictReviewId(e: unknown): number | undefined {
+  return (e as { response?: { data?: { review_id?: number } } })?.response?.data?.review_id;
+}
+
+// Merge freshly-fetched rows into the accumulated list: update existing rows in
+// place (by id) and add new ones, keeping newest-first (id desc mirrors the
+// backend's -created_at, -id ordering). Used so polling can refresh page 1
+// without discarding pages already loaded via "Load more".
+function mergeReviews(prev: ReviewListItem[], fresh: ReviewListItem[]): ReviewListItem[] {
+  const byId = new Map(prev.map((r) => [r.id, r]));
+  for (const r of fresh) byId.set(r.id, r);
+  return [...byId.values()].sort((a, b) => b.id - a.id);
+}
+
 export default function CaseworkReviews() {
   const navigate = useNavigate();
   const [items, setItems] = useState<ReviewListItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const [slug, setSlug] = useState("");
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [count, setCount] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [nextPage, setNextPage] = useState(2);
+  const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [rerunningSlug, setRerunningSlug] = useState<string | null>(null);
   const [err, setErr] = useState("");
+  const [conflictId, setConflictId] = useState<number | null>(null);
 
-  const load = useCallback(async () => {
+  // Load the first page (also used by polling to refresh in-progress rows).
+  const loadFirst = useCallback(async () => {
     try {
-      const data = await listReviews();
-      setItems(data);
+      const page = await listReviews({ page: 1, page_size: PAGE_SIZE });
+      setCount(page.count);
+      setHasNext(Boolean(page.next));
+      setNextPage(2);
+      setItems((prev) => (prev.length ? mergeReviews(prev, page.results) : page.results));
     } catch {
       setErr("Failed to load reviews.");
     } finally {
@@ -28,48 +62,71 @@ export default function CaseworkReviews() {
     }
   }, []);
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  const loadMore = useCallback(async () => {
+    setLoadingMore(true);
+    try {
+      const page = await listReviews({ page: nextPage, page_size: PAGE_SIZE });
+      setCount(page.count);
+      setHasNext(Boolean(page.next));
+      setNextPage((p) => p + 1);
+      setItems((prev) => mergeReviews(prev, page.results));
+    } catch {
+      setErr("Failed to load more reviews.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [nextPage]);
 
-  // Poll while any review is still in progress.
+  useEffect(() => {
+    loadFirst();
+  }, [loadFirst]);
+
+  // Poll the first page while any loaded review is still in progress; newly
+  // submitted reviews sort to the top, so page 1 covers status changes.
   useEffect(() => {
     const anyRunning = items.some((i) => i.status === "pending" || i.status === "running");
     if (!anyRunning) return;
-    const t = setInterval(load, 3000);
+    const t = setInterval(loadFirst, 3000);
     return () => clearInterval(t);
-  }, [items, load]);
+  }, [items, loadFirst]);
+
+  const runSubmit = async (
+    payload: Parameters<typeof submitReview>[0],
+    onDone: () => void,
+    fallback: string
+  ) => {
+    setErr("");
+    setConflictId(null);
+    try {
+      const review = await submitReview(payload);
+      navigate(`/portal/reviews/${review.id}`);
+    } catch (e: unknown) {
+      setErr(apiErrorMessage(e, fallback));
+      if (errStatus(e) === 409) setConflictId(conflictReviewId(e) ?? null);
+    } finally {
+      onDone();
+    }
+  };
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const s = slug.trim().replace(/^\/+|\/+$/g, "");
-    if (!s) return;
+    if (!input.trim()) return;
     setSubmitting(true);
-    setErr("");
-    try {
-      const review = await submitReview(s);
-      setSlug("");
-      await load();
-      navigate(`/portal/reviews/${review.id}`);
-    } catch (e: unknown) {
-      setErr(apiErrorMessage(e, "Submit failed."));
-    } finally {
-      setSubmitting(false);
-    }
+    await runSubmit(
+      buildSubmitPayload(input),
+      () => {
+        setSubmitting(false);
+        setInput("");
+        loadFirst();
+      },
+      "Submit failed."
+    );
   };
 
   // Re-run: submit a fresh review for an already-reviewed case slug.
   const onRerun = async (gslug: string) => {
     setRerunningSlug(gslug);
-    setErr("");
-    try {
-      const review = await submitReview(gslug);
-      navigate(`/portal/reviews/${review.id}`);
-    } catch (e: unknown) {
-      setErr(apiErrorMessage(e, "Re-run failed."));
-    } finally {
-      setRerunningSlug(null);
-    }
+    await runSubmit({ slug: gslug }, () => setRerunningSlug(null), "Re-run failed.");
   };
 
   // Group reviews by case slug (stacked-by-case list).
@@ -85,20 +142,37 @@ export default function CaseworkReviews() {
         <div>
           <h1 className="text-xl font-bold">Case reviews</h1>
           <p className="text-sm text-muted-foreground">
-            Submit a Jawafdehi case slug to run a multi-dimensional quality review.
+            Submit a case slug, court case number, or case URL to run a multi-dimensional
+            quality review.
           </p>
         </div>
 
         <form onSubmit={onSubmit} className="flex gap-2 items-start">
           <div className="flex-1">
             <Input
-              value={slug}
-              onChange={(e) => setSlug(e.target.value)}
-              placeholder="case slug, e.g. case-081-cr-0136-oxygen-plant"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="slug, court case no. (special:081-CR-0136), or case URL"
             />
-            {err && <p className="text-sm text-red-600 mt-1">{err}</p>}
+            {err && (
+              <p className="text-sm text-red-600 mt-1">
+                {err}
+                {conflictId != null && (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="underline font-medium"
+                      onClick={() => navigate(`/portal/reviews/${conflictId}`)}
+                    >
+                      View existing review
+                    </button>
+                  </>
+                )}
+              </p>
+            )}
           </div>
-          <Button type="submit" disabled={submitting || !slug.trim()}>
+          <Button type="submit" disabled={submitting || !input.trim()}>
             {submitting ? (
               <Loader2 className="h-4 w-4 mr-1 animate-spin" />
             ) : (
@@ -113,7 +187,9 @@ export default function CaseworkReviews() {
             <Loader2 className="h-4 w-4 animate-spin" /> Loading reviews…
           </div>
         ) : groups.size === 0 ? (
-          <p className="text-sm text-muted-foreground">No reviews yet. Submit a case slug above.</p>
+          <p className="text-sm text-muted-foreground">
+            No reviews yet. Submit a case above.
+          </p>
         ) : (
           <div className="space-y-3">
             {[...groups.entries()].map(([gslug, rows]) => (
@@ -192,6 +268,20 @@ export default function CaseworkReviews() {
                 </ul>
               </div>
             ))}
+
+            {hasNext && (
+              <div className="flex justify-center pt-1">
+                <Button variant="outline" size="sm" disabled={loadingMore} onClick={loadMore}>
+                  {loadingMore ? (
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                  ) : null}
+                  Load more
+                </Button>
+              </div>
+            )}
+            <p className="text-center text-xs text-slate-400">
+              Showing {items.length} of {count} review{count === 1 ? "" : "s"}
+            </p>
           </div>
         )}
       </div>

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -47,18 +47,22 @@ export default function CaseworkReviews() {
   const [err, setErr] = useState("");
   const [conflictId, setConflictId] = useState<number | null>(null);
 
-  // Load the first page (also used by polling to refresh in-progress rows).
-  const loadFirst = useCallback(async () => {
+  // Load the first page. When called by polling (isPoll), only merge the fresh
+  // page-1 rows — don't touch pagination/loading/error state, so a background
+  // refresh can't reset the user's "Load more" progress or clobber an error.
+  const loadFirst = useCallback(async (isPoll = false) => {
     try {
       const page = await listReviews({ page: 1, page_size: PAGE_SIZE });
-      setCount(page.count);
-      setHasNext(Boolean(page.next));
-      setNextPage(2);
+      if (!isPoll) {
+        setCount(page.count);
+        setHasNext(Boolean(page.next));
+        setNextPage(2);
+      }
       setItems((prev) => (prev.length ? mergeReviews(prev, page.results) : page.results));
     } catch {
-      setErr("Failed to load reviews.");
+      if (!isPoll) setErr("Failed to load reviews.");
     } finally {
-      setLoading(false);
+      if (!isPoll) setLoading(false);
     }
   }, []);
 
@@ -81,30 +85,35 @@ export default function CaseworkReviews() {
     loadFirst();
   }, [loadFirst]);
 
-  // Poll the first page while any loaded review is still in progress; newly
-  // submitted reviews sort to the top, so page 1 covers status changes.
+  // Poll the first page while a review on it is still in progress. The check is
+  // scoped to page 1 (the newest PAGE_SIZE rows, where freshly submitted reviews
+  // land) because polling only refreshes page 1 — scoping it avoids an endless
+  // poll when an in-progress review sits on an unrefreshed later page.
   useEffect(() => {
-    const anyRunning = items.some((i) => i.status === "pending" || i.status === "running");
+    const anyRunning = items
+      .slice(0, PAGE_SIZE)
+      .some((i) => i.status === "pending" || i.status === "running");
     if (!anyRunning) return;
-    const t = setInterval(loadFirst, 3000);
+    const t = setInterval(() => loadFirst(true), 3000);
     return () => clearInterval(t);
   }, [items, loadFirst]);
 
+  // Returns true on success (the component navigates away, so callers must not
+  // touch state afterward); on failure the error is set and false is returned.
   const runSubmit = async (
     payload: Parameters<typeof submitReview>[0],
-    onDone: () => void,
     fallback: string
-  ) => {
+  ): Promise<boolean> => {
     setErr("");
     setConflictId(null);
     try {
       const review = await submitReview(payload);
       navigate(`/portal/reviews/${review.id}`);
+      return true;
     } catch (e: unknown) {
       setErr(apiErrorMessage(e, fallback));
       if (errStatus(e) === 409) setConflictId(conflictReviewId(e) ?? null);
-    } finally {
-      onDone();
+      return false;
     }
   };
 
@@ -112,21 +121,15 @@ export default function CaseworkReviews() {
     e.preventDefault();
     if (!input.trim()) return;
     setSubmitting(true);
-    await runSubmit(
-      buildSubmitPayload(input),
-      () => {
-        setSubmitting(false);
-        setInput("");
-        loadFirst();
-      },
-      "Submit failed."
-    );
+    const ok = await runSubmit(buildSubmitPayload(input), "Submit failed.");
+    if (!ok) setSubmitting(false);
   };
 
   // Re-run: submit a fresh review for an already-reviewed case slug.
   const onRerun = async (gslug: string) => {
     setRerunningSlug(gslug);
-    await runSubmit({ slug: gslug }, () => setRerunningSlug(null), "Re-run failed.");
+    const ok = await runSubmit({ slug: gslug }, "Re-run failed.");
+    if (!ok) setRerunningSlug(null);
   };
 
   // Group reviews by case slug (stacked-by-case list).

--- a/src/services/casework-api.test.ts
+++ b/src/services/casework-api.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildSubmitPayload } from "./casework-api";
+
+describe("buildSubmitPayload", () => {
+  it("routes a court case ref to court_case_number", () => {
+    expect(buildSubmitPayload("special:081-CR-0079")).toEqual({
+      court_case_number: "special:081-CR-0079",
+    });
+  });
+
+  it("routes a bare slug to slug", () => {
+    expect(buildSubmitPayload("case-081-cr-0136-oxygen-plant")).toEqual({
+      slug: "case-081-cr-0136-oxygen-plant",
+    });
+  });
+
+  it("routes a full case URL to slug (backend extracts the slug)", () => {
+    expect(buildSubmitPayload("https://jawafdehi.org/case/alpha-case")).toEqual({
+      slug: "https://jawafdehi.org/case/alpha-case",
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(buildSubmitPayload("  special:081-CR-0079  ")).toEqual({
+      court_case_number: "special:081-CR-0079",
+    });
+    expect(buildSubmitPayload("  alpha-case  ")).toEqual({ slug: "alpha-case" });
+  });
+});

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -105,14 +105,36 @@ export async function getMe(): Promise<CaseworkUser> {
 
 // ---- Reviews ----
 
-function unwrap<T>(data: Paginated<T> | T[]): T[] {
-  if (Array.isArray(data)) return data;
-  return data.results ?? [];
+export interface SubmitReviewPayload {
+  slug?: string;
+  court_case_number?: string;
 }
 
-export async function listReviews(): Promise<ReviewListItem[]> {
-  const { data } = await client.get<Paginated<ReviewListItem> | ReviewListItem[]>("/reviews/");
-  return unwrap(data);
+// A court case ref is "<court>:<case_number>" (e.g. "special:081-CR-0079"):
+// lowercase-alnum court id, then a hyphen/alnum case number, no slashes/scheme.
+const COURT_REF_RE = /^[a-z0-9]+:[A-Za-z0-9-]+$/;
+
+// Classify free-text input from the submit box into the right field. A court
+// case ref goes to `court_case_number`; everything else (a bare slug or a full
+// case URL like https://jawafdehi.org/case/<slug>) goes to `slug`, which the
+// backend normalizes (it extracts the slug from a URL).
+export function buildSubmitPayload(raw: string): SubmitReviewPayload {
+  const value = raw.trim();
+  return COURT_REF_RE.test(value) ? { court_case_number: value } : { slug: value };
+}
+
+export async function listReviews(params?: {
+  page?: number;
+  page_size?: number;
+}): Promise<Paginated<ReviewListItem>> {
+  const { data } = await client.get<Paginated<ReviewListItem> | ReviewListItem[]>("/reviews/", {
+    params,
+  });
+  // Tolerate a non-paginated (plain array) response during rollout.
+  if (Array.isArray(data)) {
+    return { count: data.length, next: null, previous: null, results: data };
+  }
+  return data;
 }
 
 export async function getReview(id: number): Promise<ReviewDetail> {
@@ -120,8 +142,8 @@ export async function getReview(id: number): Promise<ReviewDetail> {
   return data;
 }
 
-export async function submitReview(slug: string): Promise<ReviewDetail> {
-  const { data } = await client.post<ReviewDetail>("/reviews/submit/", { slug });
+export async function submitReview(payload: SubmitReviewPayload): Promise<ReviewDetail> {
+  const { data } = await client.post<ReviewDetail>("/reviews/submit/", payload);
   return data;
 }
 

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -134,7 +134,14 @@ export async function listReviews(params?: {
   if (Array.isArray(data)) {
     return { count: data.length, next: null, previous: null, results: data };
   }
-  return data;
+  // Defensively default each field so a malformed envelope can't crash callers
+  // that iterate `results` (e.g. mergeReviews).
+  return {
+    count: data?.count ?? 0,
+    next: data?.next ?? null,
+    previous: data?.previous ?? null,
+    results: data?.results ?? [],
+  };
 }
 
 export async function getReview(id: number): Promise<ReviewDetail> {


### PR DESCRIPTION
Frontend follow-up to the backend review-submit changes (JawafdehiAPI #209, merged).

## Summary
- **Submit input now accepts slug / court case number / case URL.** `buildSubmitPayload` classifies free-text: a `court:case-number` ref (e.g. `special:081-CR-0079`) is sent as `court_case_number`; anything else (a bare slug or a full `https://jawafdehi.org/case/<slug>` URL) is sent as `slug`, which the backend normalizes. Placeholder/help text updated.
- **Verify errors surfaced.** A 404 (case not found) shows the backend's message; a 409 (a review for the case is already pending/running) shows the message plus a **View existing review** link to the returned `review_id`. On success we navigate to the new review (where the pulled `case_title` is shown).
- **Lazy-loaded review list.** `listReviews` now takes `{ page, page_size }` and returns the paginated envelope (`{count,next,previous,results}`); it tolerates a plain-array response during rollout. The page accumulates rows with a **Load more** button and a "Showing X of N" count. Polling (every 3s while anything is pending/running) refreshes page 1 and merges by id, so already-loaded pages aren't discarded.

## Test plan
- [x] `src/services/casework-api.test.ts` — `buildSubmitPayload` covers court ref, bare slug, full URL, and whitespace trimming (vitest: 4 passing).
- [x] `tsc -p tsconfig.app.json` clean for the changed files; updated the `CaseworkReviewDetail` re-run call to the new `submitReview({ slug })` signature.
- [x] `eslint` clean on changed files; client `vite build` succeeds.
- [ ] Manual: exercise submit-by-court-number, submit-by-URL, 404/409 paths, and Load more in the running portal (not done — no portal env wired up locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)