### PR TITLE
Move Weekly Series page to /saptahik

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ const App = () => (
             <Route path="/team" element={<OurTeam />} />
             <Route path="/volunteer" element={<Volunteer />} />
             <Route path="/products" element={<OurProducts />} />
-            <Route path="/weekly-series" element={<WeeklyMeetings />} />
+            <Route path="/saptahik" element={<WeeklyMeetings />} />
             <Route path="/privacy" element={<Privacy />} />
             <Route path="/terms" element={<TermsOfService />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -129,7 +129,7 @@ export const Footer = () => {
     { label: t("nav.about"), to: "/about" },
     { label: t("nav.team"), to: "/team" },
     { label: t("nav.products"), to: "/products" },
-    { label: t("nav.weeklySeries"), to: "/weekly-series" },
+    { label: t("nav.weeklySeries"), to: "/saptahik" },
     { label: t("nav.updates"), to: "/updates" },
     { label: t("footer.feedback"), to: "/feedback" },
   ];

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -90,7 +90,7 @@ export function Navbar() {
       { key: "about", label: t("nav.about"), to: "/about", exact: true },
       { key: "team", label: t("nav.team"), to: "/team" },
       { key: "products", label: t("nav.products"), to: "/products" },
-      { key: "weeklySeries", label: t("nav.weeklySeries"), to: "/weekly-series" },
+      { key: "weeklySeries", label: t("nav.weeklySeries"), to: "/saptahik" },
       { key: "updates", label: t("nav.updates"), to: "/updates" },
     ],
     [t],
@@ -99,7 +99,7 @@ export function Navbar() {
   const activeKey = useMemo(() => {
     const path = location.pathname;
 
-    if (["/about", "/team", "/products", "/weekly-series", "/updates"].includes(path) || path.startsWith("/updates/")) {
+    if (["/about", "/team", "/products", "/saptahik", "/updates"].includes(path) || path.startsWith("/updates/")) {
       return "about";
     }
     if (path === "/cases" || path === "/search" || path.startsWith("/case/")) {
@@ -267,7 +267,7 @@ export function Navbar() {
                   <Link to="/products">{t("nav.products")}</Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild className="rounded-xl text-sm font-normal">
-                  <Link to="/weekly-series">{t("nav.weeklySeries")}</Link>
+                  <Link to="/saptahik">{t("nav.weeklySeries")}</Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild className="rounded-xl text-sm font-normal">
                   <Link to="/updates">{t("nav.updates")}</Link>

--- a/src/data/site-routes.ts
+++ b/src/data/site-routes.ts
@@ -143,7 +143,7 @@ export const PRE_RENDERED_STATIC_ROUTES = [
     sitemapTitle: "Products — Jawafdehi",
   },
   {
-    path: "/weekly-series",
+    path: "/saptahik",
     titleKey: "nav.weeklySeries",
     descriptionKey: "searchCommand.descriptions.weeklySeries",
     keywords: ["weekly", "corruption", "series", "meeting", "zoom", "youtube", "live"],

--- a/src/pages/WeeklyMeetings.tsx
+++ b/src/pages/WeeklyMeetings.tsx
@@ -112,10 +112,10 @@ const WeeklyMeetings = () => {
           name="description"
           content="Join Jawafdehi's weekly corruption series: a live public meeting on Zoom analyzing Nepal's corruption cases, also streamed on YouTube."
         />
-        <link rel="canonical" href="https://jawafdehi.org/weekly-series" />
+        <link rel="canonical" href="https://jawafdehi.org/saptahik" />
         <meta property="og:site_name" content="Jawafdehi Nepal" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://jawafdehi.org/weekly-series" />
+        <meta property="og:url" content="https://jawafdehi.org/saptahik" />
         <meta property="og:title" content="Weekly Corruption Series — Jawafdehi" />
         <meta
           property="og:description"


### PR DESCRIPTION
## Summary
- Moves the Weekly Series page from **`/weekly-series`** to **`/saptahik`** (साप्ताहिक).
- Updates all 8 references: the route in `App.tsx`, nav links (About dropdown + footer), the navbar active-state path matcher, the static route registry in `site-routes.ts` (search/sitemap/SSR pre-render), and the page's `canonical`/`og:url`.
- Display labels and translation keys (`nav.weeklySeries`) are intentionally unchanged — only the URL path moved.

## Notes
- The old `/weekly-series` URL now 404s (renders NotFound). The page only shipped today (#141), so it's very unlikely to be linked/indexed yet. If you'd like, I can add a 301 redirect `/weekly-series → /saptahik` in `worker.ts` (it already has a redirect pattern) — say the word.

## Verification
- `tsc --noEmit` and `eslint` pass.
- `git grep` confirms no remaining `weekly-series` references.

## Test plan
- [ ] `/saptahik` loads the page; `/weekly-series` 404s.
- [ ] About dropdown (desktop + mobile) and footer links go to `/saptahik`; nav active-state highlights under About.
- [ ] Sitemap/site-search list `/saptahik`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)