### PR TITLE
Redirect /weekly to /saptahik (301)

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -195,6 +195,18 @@ export default {
     const isEmbedRoute = /^\/embed\/case\//.test(path);
     const secHeaders = isEmbedRoute ? securityHeadersAllowFrame() : securityHeaders();
 
+    // Short alias: /weekly → /saptahik (301)
+    if (path === '/weekly' || path === '/weekly/') {
+      return new Response(null, {
+        status: 301,
+        headers: {
+          'Location': '/saptahik',
+          'Cache-Control': 'public, max-age=3600',
+          ...secHeaders,
+        },
+      });
+    }
+
     // Handle legacy numeric case redirects (301)
     const caseMatch = path.match(/^\/case\/(\d+)\/?$/);
     if (caseMatch) {

--- a/worker.ts
+++ b/worker.ts
@@ -200,7 +200,7 @@ export default {
       return new Response(null, {
         status: 301,
         headers: {
-          'Location': '/saptahik',
+          'Location': '/saptahik' + url.search,
           'Cache-Control': 'public, max-age=3600',
           ...secHeaders,
         },


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from **`/weekly`** (and `/weekly/`) to **`/saptahik`** in `worker.ts`, giving the Weekly Series page a short, memorable alias.
- Implemented alongside the existing legacy-case redirect pattern, with the standard security headers and `Cache-Control: max-age=3600`.

## Verification
- `tsc --noEmit` and `eslint` pass.
- `wrangler deploy --dry-run` bundles the Worker successfully.

## Test plan
- [ ] `curl -I https://jawafdehi.org/weekly` → `301` with `Location: /saptahik`.
- [ ] `/weekly/` (trailing slash) also redirects.
- [ ] `/saptahik` still serves the page directly.

## Note
- This covers `/weekly` only, as requested. `/weekly-series` (the prior path) still 404s — happy to add that alias too if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)