### PR TITLE
CSP: allow auth.jawafdehi.org in connect-src (OIDC login)

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -22,7 +22,7 @@ interface FeedVideo {
 
 function securityHeaders(): Record<string, string> {
   return {
-    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://api.jawafdehi.org; worker-src blob:;",
+    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://api.jawafdehi.org https://auth.jawafdehi.org; worker-src blob:;",
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
     'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',


### PR DESCRIPTION
## Summary
The Cloudflare Worker's CSP `connect-src` didn't include `https://auth.jawafdehi.org`, so oidc-client-ts couldn't fetch the OIDC discovery/token/userinfo endpoints → **prod portal login blocked**. Adds `https://auth.jawafdehi.org` to `connect-src`.

(The redirect to the authorize endpoint is a top-level navigation, unaffected by CSP. The gtag/cloudflare-insights/sentry blocks are separate, non-essential analytics.)

## Test plan
- [ ] After deploy: jawafdehi.org/portal/login → "Login with Jawafdehi Auth" → Zitadel → back, no CSP error