### PR TITLE
Casework reviews: full per-case history + reviewer provenance

### DIFF
--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -153,6 +153,23 @@ export default function CaseworkReviewDetail() {
                 <span className="text-slate-400">
                   sources {review.sources_converted}/{review.source_count}
                 </span>
+                {review.reviewers && review.reviewers.length > 0 && (
+                  <span
+                    className="text-slate-400 font-mono"
+                    title={review.reviewers
+                      .map((rv) => `${rv.tier}: ${rv.provider}·${rv.model || "?"} (${rv.calls})`)
+                      .join(", ")}
+                  >
+                    🤖{" "}
+                    {Array.from(
+                      new Set(
+                        review.reviewers.map((rv) =>
+                          rv.model ? `${rv.provider}·${rv.model}` : rv.provider
+                        )
+                      )
+                    ).join(", ")}
+                  </span>
+                )}
               </div>
             </div>
             <div className="flex items-start gap-3">

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import CaseworkLayout from "@/components/CaseworkLayout";
 import {
-  listReviews,
+  listReviewsGrouped,
   submitReview,
   buildSubmitPayload,
   apiErrorMessage,
 } from "@/services/casework-api";
-import type { ReviewListItem } from "@/types/casework";
+import type { GroupedCase, ReviewListItem, ReviewerInfo } from "@/types/casework";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { dispositionColor, statusColor, fmtDate, fmtDur, scoreBand } from "@/lib/casework-ui";
@@ -23,19 +23,34 @@ function conflictReviewId(e: unknown): number | undefined {
   return (e as { response?: { data?: { review_id?: number } } })?.response?.data?.review_id;
 }
 
-// Merge freshly-fetched rows into the accumulated list: update existing rows in
-// place (by id) and add new ones, keeping newest-first (id desc mirrors the
-// backend's -created_at, -id ordering). Used so polling can refresh page 1
-// without discarding pages already loaded via "Load more".
-function mergeReviews(prev: ReviewListItem[], fresh: ReviewListItem[]): ReviewListItem[] {
-  const byId = new Map(prev.map((r) => [r.id, r]));
-  for (const r of fresh) byId.set(r.id, r);
-  return [...byId.values()].sort((a, b) => b.id - a.id);
+// Merge freshly-fetched case groups into the accumulated list: replace existing
+// cases in place (by slug) and add new ones, keeping most-recently-active first
+// (latest id desc mirrors the backend's ordering). Used so polling can refresh
+// page 1 without discarding cases already loaded via "Load more".
+function mergeGroups(prev: GroupedCase[], fresh: GroupedCase[]): GroupedCase[] {
+  const bySlug = new Map(prev.map((g) => [g.slug, g]));
+  for (const g of fresh) bySlug.set(g.slug, g);
+  return [...bySlug.values()].sort((a, b) => b.latest.id - a.latest.id);
+}
+
+// Distinct "provider·model" labels for the reviewer(s) that graded a run.
+function reviewerLabels(reviewers: ReviewerInfo[] | null): string[] {
+  if (!reviewers?.length) return [];
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const r of reviewers) {
+    const label = r.model ? `${r.provider}·${r.model}` : r.provider;
+    if (label && !seen.has(label)) {
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  return labels;
 }
 
 export default function CaseworkReviews() {
   const navigate = useNavigate();
-  const [items, setItems] = useState<ReviewListItem[]>([]);
+  const [groups, setGroups] = useState<GroupedCase[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [count, setCount] = useState(0);
@@ -47,18 +62,18 @@ export default function CaseworkReviews() {
   const [err, setErr] = useState("");
   const [conflictId, setConflictId] = useState<number | null>(null);
 
-  // Load the first page. When called by polling (isPoll), only merge the fresh
-  // page-1 rows — don't touch pagination/loading/error state, so a background
-  // refresh can't reset the user's "Load more" progress or clobber an error.
+  // Load the first page of cases. When called by polling (isPoll), only merge the
+  // fresh page-1 groups — don't touch pagination/loading/error state, so a
+  // background refresh can't reset the user's "Load more" progress.
   const loadFirst = useCallback(async (isPoll = false) => {
     try {
-      const page = await listReviews({ page: 1, page_size: PAGE_SIZE });
+      const page = await listReviewsGrouped({ page: 1, page_size: PAGE_SIZE });
       if (!isPoll) {
         setCount(page.count);
         setHasNext(Boolean(page.next));
         setNextPage(2);
       }
-      setItems((prev) => (prev.length ? mergeReviews(prev, page.results) : page.results));
+      setGroups((prev) => (prev.length ? mergeGroups(prev, page.results) : page.results));
     } catch {
       if (!isPoll) setErr("Failed to load reviews.");
     } finally {
@@ -69,11 +84,11 @@ export default function CaseworkReviews() {
   const loadMore = useCallback(async () => {
     setLoadingMore(true);
     try {
-      const page = await listReviews({ page: nextPage, page_size: PAGE_SIZE });
+      const page = await listReviewsGrouped({ page: nextPage, page_size: PAGE_SIZE });
       setCount(page.count);
       setHasNext(Boolean(page.next));
       setNextPage((p) => p + 1);
-      setItems((prev) => mergeReviews(prev, page.results));
+      setGroups((prev) => mergeGroups(prev, page.results));
     } catch {
       setErr("Failed to load more reviews.");
     } finally {
@@ -85,18 +100,17 @@ export default function CaseworkReviews() {
     loadFirst();
   }, [loadFirst]);
 
-  // Poll the first page while a review on it is still in progress. The check is
-  // scoped to page 1 (the newest PAGE_SIZE rows, where freshly submitted reviews
-  // land) because polling only refreshes page 1 — scoping it avoids an endless
-  // poll when an in-progress review sits on an unrefreshed later page.
+  // Poll the first page while a case on it has an in-progress latest run. Scoped
+  // to the newest PAGE_SIZE cases (where freshly submitted reviews land) since
+  // polling only refreshes page 1.
   useEffect(() => {
-    const anyRunning = items
+    const anyRunning = groups
       .slice(0, PAGE_SIZE)
-      .some((i) => i.status === "pending" || i.status === "running");
+      .some((g) => g.latest.status === "pending" || g.latest.status === "running");
     if (!anyRunning) return;
     const t = setInterval(() => loadFirst(true), 3000);
     return () => clearInterval(t);
-  }, [items, loadFirst]);
+  }, [groups, loadFirst]);
 
   // Returns true on success (the component navigates away, so callers must not
   // touch state afterward); on failure the error is set and false is returned.
@@ -132,12 +146,7 @@ export default function CaseworkReviews() {
     if (!ok) setRerunningSlug(null);
   };
 
-  // Group reviews by case slug (stacked-by-case list).
-  const groups = new Map<string, ReviewListItem[]>();
-  for (const it of items) {
-    if (!groups.has(it.slug)) groups.set(it.slug, []);
-    groups.get(it.slug)!.push(it);
-  }
+  const shownReviews = groups.reduce((n, g) => n + g.executions.length, 0);
 
   return (
     <CaseworkLayout>
@@ -189,31 +198,31 @@ export default function CaseworkReviews() {
           <div className="flex items-center gap-2 text-muted-foreground text-sm">
             <Loader2 className="h-4 w-4 animate-spin" /> Loading reviews…
           </div>
-        ) : groups.size === 0 ? (
+        ) : groups.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             No reviews yet. Submit a case above.
           </p>
         ) : (
           <div className="space-y-3">
-            {[...groups.entries()].map(([gslug, rows]) => (
-              <div key={gslug} className="bg-white border rounded-xl overflow-hidden">
+            {groups.map((g) => (
+              <div key={g.slug} className="bg-white border rounded-xl overflow-hidden">
                 <div className="px-4 py-2.5 bg-slate-50 border-b flex items-center justify-between">
                   <div className="min-w-0">
-                    <div className="font-mono text-xs text-slate-500 truncate">{gslug}</div>
-                    <div className="text-sm font-medium truncate">{rows[0].case_title || "—"}</div>
+                    <div className="font-mono text-xs text-slate-500 truncate">{g.slug}</div>
+                    <div className="text-sm font-medium truncate">{g.case_title || "—"}</div>
                   </div>
                   <div className="flex items-center gap-3 ml-3">
                     <span className="text-xs text-slate-500 whitespace-nowrap">
-                      {rows.length} review{rows.length === 1 ? "" : "s"}
+                      {g.executions.length} review{g.executions.length === 1 ? "" : "s"}
                     </span>
                     <Button
                       variant="outline"
                       size="sm"
-                      disabled={rerunningSlug === gslug}
+                      disabled={rerunningSlug === g.slug}
                       title="Run a fresh review for this case against the current rules"
-                      onClick={() => onRerun(gslug)}
+                      onClick={() => onRerun(g.slug)}
                     >
-                      {rerunningSlug === gslug ? (
+                      {rerunningSlug === g.slug ? (
                         <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
                       ) : (
                         <RefreshCw className="h-3.5 w-3.5 mr-1" />
@@ -223,50 +232,12 @@ export default function CaseworkReviews() {
                   </div>
                 </div>
                 <ul className="divide-y">
-                  {rows.map((r) => (
-                    <li
+                  {g.executions.map((r) => (
+                    <ReviewRow
                       key={r.id}
-                      className="px-4 py-2.5 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
+                      review={r}
                       onClick={() => navigate(`/portal/reviews/${r.id}`)}
-                    >
-                      <span className="text-xs font-mono text-slate-400 w-12">#{r.id}</span>
-                      <span className="text-xs text-slate-500 w-40 hidden md:inline">
-                        🕓 {fmtDate(r.completed_at || r.created_at)}
-                      </span>
-                      <span
-                        className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(r.status)}`}
-                      >
-                        {r.status === "running" || r.status === "pending"
-                          ? r.stage || r.status
-                          : r.status}
-                      </span>
-                      {r.case_type && (
-                        <span className="text-xs text-slate-500 hidden sm:inline">{r.case_type}</span>
-                      )}
-                      <span className="flex-1" />
-                      {r.overall_score != null && (
-                        <span
-                          className="text-sm font-bold w-10 text-right"
-                          style={{ color: scoreBand(r.overall_score) }}
-                        >
-                          {r.overall_score}
-                        </span>
-                      )}
-                      {r.disposition && (
-                        <span
-                          className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(
-                            r.disposition
-                          )}`}
-                        >
-                          {r.disposition}
-                        </span>
-                      )}
-                      {r.duration_seconds != null && (
-                        <span className="text-xs text-slate-400 w-14 text-right hidden lg:inline">
-                          {fmtDur(r.duration_seconds)}
-                        </span>
-                      )}
-                    </li>
+                    />
                   ))}
                 </ul>
               </div>
@@ -283,11 +254,59 @@ export default function CaseworkReviews() {
               </div>
             )}
             <p className="text-center text-xs text-slate-400">
-              Showing {items.length} of {count} review{count === 1 ? "" : "s"}
+              Showing {groups.length} of {count} case{count === 1 ? "" : "s"} ({shownReviews}{" "}
+              review{shownReviews === 1 ? "" : "s"})
             </p>
           </div>
         )}
       </div>
     </CaseworkLayout>
+  );
+}
+
+function ReviewRow({ review: r, onClick }: { review: ReviewListItem; onClick: () => void }) {
+  const reviewers = reviewerLabels(r.reviewers);
+  return (
+    <li
+      className="px-4 py-2.5 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
+      onClick={onClick}
+    >
+      <span className="text-xs font-mono text-slate-400 w-12">#{r.id}</span>
+      <span className="text-xs text-slate-500 w-40 hidden md:inline">
+        🕓 {fmtDate(r.completed_at || r.created_at)}
+      </span>
+      <span className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(r.status)}`}>
+        {r.status === "running" || r.status === "pending" ? r.stage || r.status : r.status}
+      </span>
+      {reviewers.length > 0 && (
+        <span
+          className="text-xs text-slate-400 font-mono hidden lg:inline truncate max-w-[14rem]"
+          title={`Graded by ${reviewers.join(", ")}`}
+        >
+          {reviewers.join(", ")}
+        </span>
+      )}
+      <span className="flex-1" />
+      {r.overall_score != null && (
+        <span
+          className="text-sm font-bold w-10 text-right"
+          style={{ color: scoreBand(r.overall_score) }}
+        >
+          {r.overall_score}
+        </span>
+      )}
+      {r.disposition && (
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(r.disposition)}`}
+        >
+          {r.disposition}
+        </span>
+      )}
+      {r.duration_seconds != null && (
+        <span className="text-xs text-slate-400 w-14 text-right hidden lg:inline">
+          {fmtDur(r.duration_seconds)}
+        </span>
+      )}
+    </li>
   );
 }

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -30,7 +30,7 @@ function conflictReviewId(e: unknown): number | undefined {
 function mergeGroups(prev: GroupedCase[], fresh: GroupedCase[]): GroupedCase[] {
   const bySlug = new Map(prev.map((g) => [g.slug, g]));
   for (const g of fresh) bySlug.set(g.slug, g);
-  return [...bySlug.values()].sort((a, b) => b.latest.id - a.latest.id);
+  return [...bySlug.values()].sort((a, b) => (b.latest?.id ?? 0) - (a.latest?.id ?? 0));
 }
 
 // Distinct "provider·model" labels for the reviewer(s) that graded a run.
@@ -106,7 +106,7 @@ export default function CaseworkReviews() {
   useEffect(() => {
     const anyRunning = groups
       .slice(0, PAGE_SIZE)
-      .some((g) => g.latest.status === "pending" || g.latest.status === "running");
+      .some((g) => g.latest?.status === "pending" || g.latest?.status === "running");
     if (!anyRunning) return;
     const t = setInterval(() => loadFirst(true), 3000);
     return () => clearInterval(t);
@@ -146,7 +146,7 @@ export default function CaseworkReviews() {
     if (!ok) setRerunningSlug(null);
   };
 
-  const shownReviews = groups.reduce((n, g) => n + g.executions.length, 0);
+  const shownReviews = groups.reduce((n, g) => n + (g.executions?.length ?? 0), 0);
 
   return (
     <CaseworkLayout>
@@ -213,7 +213,8 @@ export default function CaseworkReviews() {
                   </div>
                   <div className="flex items-center gap-3 ml-3">
                     <span className="text-xs text-slate-500 whitespace-nowrap">
-                      {g.executions.length} review{g.executions.length === 1 ? "" : "s"}
+                      {g.executions?.length ?? 0} review
+                      {(g.executions?.length ?? 0) === 1 ? "" : "s"}
                     </span>
                     <Button
                       variant="outline"
@@ -232,7 +233,7 @@ export default function CaseworkReviews() {
                   </div>
                 </div>
                 <ul className="divide-y">
-                  {g.executions.map((r) => (
+                  {(g.executions ?? []).map((r) => (
                     <ReviewRow
                       key={r.id}
                       review={r}

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -11,6 +11,7 @@ import type {
   CaseworkRule,
   ReviewConfig,
   Paginated,
+  GroupedCase,
 } from "@/types/casework";
 import { getAccessToken } from "./oidc";
 
@@ -87,6 +88,27 @@ export async function listReviews(params?: {
   }
   // Defensively default each field so a malformed envelope can't crash callers
   // that iterate `results` (e.g. mergeReviews).
+  return {
+    count: data?.count ?? 0,
+    next: data?.next ?? null,
+    previous: data?.previous ?? null,
+    results: data?.results ?? [],
+  };
+}
+
+// Reviews grouped by case, paginated BY CASE: each entry carries ALL of a
+// case's executions (so older runs that would fall on a later page of the flat
+// list still show under their case). Used by the review list page.
+export async function listReviewsGrouped(params?: {
+  page?: number;
+  page_size?: number;
+}): Promise<Paginated<GroupedCase>> {
+  const { data } = await client.get<Paginated<GroupedCase> | GroupedCase[]>("/reviews/grouped/", {
+    params,
+  });
+  if (Array.isArray(data)) {
+    return { count: data.length, next: null, previous: null, results: data };
+  }
   return {
     count: data?.count ?? 0,
     next: data?.next ?? null,

--- a/src/types/casework.ts
+++ b/src/types/casework.ts
@@ -12,6 +12,16 @@ export interface CaseworkUser {
 export type ReviewStatus = "pending" | "running" | "done" | "failed";
 export type Disposition = "PASS" | "REVISE" | "REJECT";
 
+// Which reviewer (LLM harness) graded a run, per tier. Gate rules use the
+// premium tier, routine rules/narrative/source analysis the cheap tier, so a
+// single review usually lists more than one entry.
+export interface ReviewerInfo {
+  tier: string;
+  provider: string;
+  model: string;
+  calls: number;
+}
+
 export interface ReviewListItem {
   id: number;
   slug: string;
@@ -24,9 +34,19 @@ export interface ReviewListItem {
   overall_score: number | null;
   disposition: Disposition | null;
   case_type: string;
+  reviewers: ReviewerInfo[] | null;
   created_at: string;
   completed_at: string | null;
   duration_seconds: number | null;
+}
+
+// One case with ALL of its review executions (newest first), from the grouped
+// review list. The internal case_id is the grouping key and is not exposed.
+export interface GroupedCase {
+  slug: string;
+  case_title: string;
+  latest: ReviewListItem;
+  executions: ReviewListItem[];
 }
 
 export interface RuleResult {
@@ -90,6 +110,7 @@ export interface ReviewResult {
 export interface ReviewDetail extends ReviewListItem {
   error: string;
   result: ReviewResult | null;
+  reviewers: ReviewerInfo[] | null;
   updated_at: string;
   started_at: string | null;
 }


### PR DESCRIPTION
## Summary

Frontend half of the reviewer overhaul (pairs with JawafdehiAPI#229).

- **Full per-case history (#3):** the review list now calls the new `GET /reviews/grouped/` endpoint, which paginates **by case** and returns ALL of a case's executions. Previously the page client-side grouped a flat paginated list, so older runs of a case (e.g. "ncell" review #1 vs #91) could land on an unloaded page and disappear from the group. Now every execution of a case is shown together, and "Load more"/polling page by case.
- **Reviewer provenance (#2):** each execution row and the review detail header now show which reviewer(s) graded the run (`provider·model`, from the new `reviewers` field — gate rules vs routine rules can use different harnesses).

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 45 passed
- [ ] CI green
- [ ] Manual: `/portal/reviews` shows cases each expandable to full history incl. runs beyond page 1; reviewer model·adapter shown per run (requires API#229 deployed)

> Depends on JawafdehiAPI#229 (the `/reviews/grouped/` endpoint and `reviewers` field). Safe to merge after the API ships; the grouped client tolerates a missing/relabeled envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)