### PR TITLE
reviews: show source conversion failures with their cause

### DIFF
--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -372,7 +372,7 @@ export default function CaseworkReviewDetail() {
               </div>
             </div>
             <div className="p-4 overflow-auto text-sm">
-              {!source.markdown && source.conversion_note ? (
+              {!(source.conversion_status === "converted" || source.conversion_status === "attached") && source.conversion_note ? (
                 // No converted text — show WHY (e.g. "Conversion failed: ...").
                 <p className="text-amber-700 break-words">⚠ {source.conversion_note}</p>
               ) : showRaw ? (

--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -234,33 +234,46 @@ export default function CaseworkReviewDetail() {
           <div className="bg-white border rounded-xl p-4">
             <h2 className="text-sm font-semibold mb-2">Sources ({result.source_summary.length})</h2>
             <ul className="space-y-1.5">
-              {result.source_summary.map((s, i) => (
-                <li key={i} className="flex items-center gap-2 text-sm">
-                  <span
-                    className={`text-[10px] px-1.5 py-0.5 rounded border ${
-                      s.conversion_status === "converted" || s.conversion_status === "attached"
-                        ? "bg-green-50 text-green-700 border-green-200"
-                        : "bg-amber-50 text-amber-700 border-amber-200"
-                    }`}
-                  >
-                    {s.conversion_status}
-                  </span>
-                  <span className="flex-1 truncate" title={s.title}>
-                    {s.title || "(untitled)"}
-                  </span>
-                  <span className="text-xs text-slate-400">{s.markdown_chars} chars</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setSource(s);
-                      setShowRaw(false);
-                    }}
-                  >
-                    <FileText className="h-3.5 w-3.5 mr-1" /> View
-                  </Button>
-                </li>
-              ))}
+              {result.source_summary.map((s, i) => {
+                const ok =
+                  s.conversion_status === "converted" || s.conversion_status === "attached";
+                return (
+                  <li key={i} className="text-sm">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                          ok
+                            ? "bg-green-50 text-green-700 border-green-200"
+                            : "bg-amber-50 text-amber-700 border-amber-200"
+                        }`}
+                      >
+                        {s.conversion_status}
+                      </span>
+                      <span className="flex-1 truncate" title={s.title}>
+                        {s.title || "(untitled)"}
+                      </span>
+                      <span className="text-xs text-slate-400">{s.markdown_chars} chars</span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setSource(s);
+                          setShowRaw(false);
+                        }}
+                      >
+                        <FileText className="h-3.5 w-3.5 mr-1" /> View
+                      </Button>
+                    </div>
+                    {/* Surface the conversion failure cause instead of hiding it
+                        behind an empty "0 chars" / empty View. */}
+                    {!ok && s.conversion_note && (
+                      <p className="mt-0.5 ml-1 text-xs text-amber-700 break-words">
+                        ⚠ {s.conversion_note}
+                      </p>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}
@@ -359,7 +372,10 @@ export default function CaseworkReviewDetail() {
               </div>
             </div>
             <div className="p-4 overflow-auto text-sm">
-              {showRaw ? (
+              {!source.markdown && source.conversion_note ? (
+                // No converted text — show WHY (e.g. "Conversion failed: ...").
+                <p className="text-amber-700 break-words">⚠ {source.conversion_note}</p>
+              ) : showRaw ? (
                 <pre className="whitespace-pre-wrap text-xs">{source.markdown || "(no markdown)"}</pre>
               ) : (
                 <div


### PR DESCRIPTION
## Summary

A source that fails to convert previously showed only `error · 0 chars` with an empty **View** modal — the *reason* (which the backend already records in `conversion_note`) was hidden. Now it's surfaced:

- **Sources list:** failed/skipped sources show the `conversion_note` inline (e.g. ⚠ *Conversion failed: No module named markitdown*).
- **Viewer modal:** when a source has no converted text, the modal shows the conversion note instead of an empty "(no markdown)".

Context: this is what made prod review 78 look broken (all sources "0 chars", View showed nothing) — the underlying conversion deps were missing in the poller image (fixed separately in JawafdehiAPI). This change makes such failures self-explanatory going forward.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [ ] CI green
- [ ] Manual: a review with a failed source shows the error cause inline + in the modal; a converted source still renders its markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)