### PR TITLE
reviews: surface the non-scoring notes channel per rule

### DIFF
--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -448,7 +448,7 @@ function RuleCard({
         </div>
       )}
 
-      {rr.notes?.length > 0 && (
+      {rr.notes && rr.notes.length > 0 && (
         <div className="mt-2">
           <div className="text-xs font-medium text-slate-500">Notes (informational, not scored)</div>
           <ul className="list-disc pl-4 text-xs text-slate-500 space-y-0.5">

--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -448,6 +448,17 @@ function RuleCard({
         </div>
       )}
 
+      {rr.notes?.length > 0 && (
+        <div className="mt-2">
+          <div className="text-xs font-medium text-slate-500">Notes (informational, not scored)</div>
+          <ul className="list-disc pl-4 text-xs text-slate-500 space-y-0.5">
+            {rr.notes.map((n, i) => (
+              <li key={i}>{n}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {rr.suggestions.length > 0 && (
         <div className="mt-2">
           <div className="text-xs font-medium text-green-700">Suggestions to address</div>

--- a/src/types/casework.ts
+++ b/src/types/casework.ts
@@ -65,6 +65,8 @@ export interface RuleResult {
   variance: number;
   std: number;
   issues: string[];
+  // Optional: reviews created before the notes channel won't carry this field.
+  notes?: string[];
   suggestions: string[];
   rationale: string;
   description: string;
@@ -100,6 +102,9 @@ export interface ReviewResult {
   gate_failures: { key: string; title: string; score: number; gate_min: number }[];
   gates_pass: boolean;
   narrative: string;
+  // Informational, non-scoring notes (trivial / cosmetic findings) rolled up
+  // across rules. Surfaced separately from issues so they don't read as gaps.
+  info?: { rule: string; note: string }[];
   judge_error: string | null;
   llm_samples: number;
   thresholds: { pass: number; revise: number };


### PR DESCRIPTION
## Summary

Frontend follow-up to JawafdehiAPI #236, which added a **non-scoring `notes` channel** to the casework review system (trivial/cosmetic findings — paisa rounding, single-outlet typo figures, formatting/length — are separated from material `issues` so they no longer drag the grade down).

Until now those notes were computed in the backend but **invisible in the reviewer UI**, which only renders per-rule `issues` and `suggestions`. This PR surfaces them.

- `RuleResult` gains an optional `notes?: string[]` (optional because reviews created before the channel won't carry it); `ReviewResult` gains the rolled-up `info?` list for type completeness.
- `CaseworkReviewDetail` renders a **"Notes (informational, not scored)"** block per rule, between Issues (red) and Suggestions (green), styled neutral slate to signal it does not affect the score.
- Notes deliberately do **not** trigger the rule's "needs attention" state — they're informational only.

## Test plan
- [x] `bun run lint` clean (whole repo)
- [x] `bun run test` — 45/45 pass
- [x] Changed files typecheck clean (eslint); the JSX mirrors the existing Issues/Suggestions blocks
- [ ] Visual check in the review detail once a review with `notes` is generated (needs an API review run on the new backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)