### PR TITLE
Update privacy policy & ToS for US/GDPR compliance + consent-gated analytics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,6 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^5.4.19",
-        "vite-plugin-radar": "^0.10.1",
         "vitest": "^4.0.9",
       },
     },
@@ -1654,8 +1653,6 @@
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "vite-plugin-radar": ["vite-plugin-radar@0.10.1", "", { "peerDependencies": { "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-a1PEDWgbuh7Wms8d/KHY5v7YM2w/mw2ShnlZSiIeAqr+sRQJf6POZE5Vg4eTXhoaWhKH89rl1llznHGNX9CMMQ=="],
 
     "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
-    "vite-plugin-radar": "^0.10.1",
     "vitest": "^4.0.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,9 +276,6 @@ importers:
       vite:
         specifier: ^5.4.19
         version: 5.4.21(@types/node@22.19.20)
-      vite-plugin-radar:
-        specifier: ^0.10.1
-        version: 0.10.1(vite@5.4.21(@types/node@22.19.20))
       vitest:
         specifier: ^4.0.9
         version: 4.1.8(@types/node@22.19.20)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@5.4.21(@types/node@22.19.20))
@@ -3853,11 +3850,6 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
-
-  vite-plugin-radar@0.10.1:
-    resolution: {integrity: sha512-a1PEDWgbuh7Wms8d/KHY5v7YM2w/mw2ShnlZSiIeAqr+sRQJf6POZE5Vg4eTXhoaWhKH89rl1llznHGNX9CMMQ==}
-    peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -7774,10 +7766,6 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
-
-  vite-plugin-radar@0.10.1(vite@5.4.21(@types/node@22.19.20)):
-    dependencies:
-      vite: 5.4.21(@types/node@22.19.20)
 
   vite@5.4.21(@types/node@22.19.20):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ClientOnly } from "@/components/ClientOnly";
+import { CookieConsentBanner } from "@/components/CookieConsentBanner";
 import { SentryErrorFallback } from "@/components/SentryErrorFallback";
 import { Routes, Route } from "react-router-dom";
 import { AppLayout } from "@/components/AppLayout";
@@ -69,6 +70,7 @@ const App = () => (
       <ClientOnly>
         <Toaster />
         <Sonner />
+        <CookieConsentBanner />
       </ClientOnly>
       <Suspense fallback={<RouteLoadingFallback />}>
         <ScrollToTop />

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { getConsent, setConsent } from "@/lib/consent";
+import { loadGoogleAnalytics } from "@/lib/ga";
+
+/**
+ * Opt-in cookie consent banner. Analytics (Google Analytics) load only after
+ * the visitor accepts. If a prior decision exists, the banner stays hidden and
+ * analytics load only when consent was previously granted.
+ */
+export function CookieConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const decision = getConsent();
+    if (decision === null) {
+      setVisible(true);
+    } else if (decision === "granted") {
+      loadGoogleAnalytics();
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  const accept = () => {
+    setConsent("granted");
+    loadGoogleAnalytics();
+    setVisible(false);
+  };
+
+  const decline = () => {
+    setConsent("denied");
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      className="fixed inset-x-0 bottom-0 z-50 border-t bg-background/95 backdrop-blur-sm p-4 shadow-lg no-print"
+    >
+      <div className="container mx-auto flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground max-w-3xl">
+          We use cookies that are necessary for the site to work, and—only with
+          your consent—Google Analytics to understand how the platform is used.
+          You can decline analytics without affecting your use of the site. See
+          our{" "}
+          <Link to="/privacy" className="text-primary underline hover:no-underline">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+        <div className="flex shrink-0 gap-2">
+          <Button variant="outline" size="sm" onClick={decline}>
+            Decline
+          </Button>
+          <Button size="sm" onClick={accept}>
+            Accept analytics
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -138,7 +138,8 @@ export const Footer = () => {
     { label: t("footer.contributorPortal"), to: "https://portal.jawafdehi.org", external: true },
     { label: t("footer.githubRepo"), to: "https://github.com/Jawafdehi/Jawafdehi", external: true },
     { label: t("footer.siteStatus"), to: "https://status.jawafdehi.org/status/public", external: true },
-
+    { label: t("footer.privacy"), to: "/privacy" },
+    { label: t("footer.terms"), to: "/terms" },
   ];
 
   const socialLinks: FooterSocialLink[] = [

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,30 @@
+/**
+ * Cookie/analytics consent state.
+ *
+ * Stores the visitor's opt-in decision for non-essential cookies (Google
+ * Analytics). Essential cookies (language preference, caseworker session) and
+ * error monitoring are not gated by this. See the Privacy Policy.
+ */
+
+const STORAGE_KEY = "jawafdehi_analytics_consent";
+
+export type ConsentValue = "granted" | "denied";
+
+export function getConsent(): ConsentValue | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === "granted" || v === "denied" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setConsent(value: ConsentValue): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // ignore (private mode / storage disabled)
+  }
+}

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -1,0 +1,28 @@
+/**
+ * Google Analytics 4 loader — only invoked after the visitor opts in via the
+ * cookie consent banner. IP anonymization is enabled. Until this runs,
+ * gtag.js is never fetched and no GA cookies are set.
+ */
+import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
+
+let loaded = false;
+
+export function loadGoogleAnalytics(): void {
+  if (typeof window === "undefined" || loaded || window.gtag) return;
+  loaded = true;
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${JAWAFDEHI_GA_MEASUREMENT_ID}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  // gtag must push the literal `arguments` object, so a rest array won't work.
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer!.push(arguments);
+  } as Window["gtag"];
+
+  window.gtag("js", new Date());
+  window.gtag("config", JAWAFDEHI_GA_MEASUREMENT_ID, { anonymize_ip: true });
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -10,12 +10,16 @@ export function initSentry(): void {
   Sentry.init({
     dsn,
     environment: import.meta.env.MODE,
+    // Do not attach IP address, cookies, or other PII to events.
+    sendDefaultPii: false,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
+      // Mask text and block media in any captured replay.
+      Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
     ],
-    tracesSampleRate: 1.0,
-    replaysSessionSampleRate: 0.1,
+    tracesSampleRate: 0.1,
+    // Error-only replay: never record random sessions, only when an error fires.
+    replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
   });
 }

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -4,19 +4,19 @@ const Privacy = () => {
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <Helmet>
-        <title>Privacy Policy | Jawafdehi Nepal</title>
-        <meta name="description" content="Jawafdehi's privacy policy — how we handle data, cookies, and user information on Nepal's open corruption accountability platform." />
+        <title>Jawafdehi Initiative Privacy Policy</title>
+        <meta name="description" content="Jawafdehi's privacy policy — how we handle data, cookies, analytics, and user information on Nepal's open corruption accountability platform." />
         <link rel="canonical" href="https://jawafdehi.org/privacy" />
         <meta property="og:site_name" content="Jawafdehi Nepal" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://jawafdehi.org/privacy" />
-        <meta property="og:title" content="Privacy Policy | Jawafdehi Nepal" />
-        <meta property="og:description" content="Jawafdehi's privacy policy — how we handle data, cookies, and user information on Nepal's open corruption accountability platform." />
+        <meta property="og:title" content="Jawafdehi Initiative Privacy Policy" />
+        <meta property="og:description" content="Jawafdehi's privacy policy — how we handle data, cookies, analytics, and user information on Nepal's open corruption accountability platform." />
         <meta property="og:image" content="https://jawafdehi.org/og-favicon.png" />
         <meta property="og:locale" content="en_US" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Privacy Policy | Jawafdehi Nepal" />
-        <meta name="twitter:description" content="Jawafdehi's privacy policy — how we handle data, cookies, and user information on Nepal's open corruption accountability platform." />
+        <meta name="twitter:title" content="Jawafdehi Initiative Privacy Policy" />
+        <meta name="twitter:description" content="Jawafdehi's privacy policy — how we handle data, cookies, analytics, and user information on Nepal's open corruption accountability platform." />
         <meta name="twitter:image" content="https://jawafdehi.org/og-favicon.png" />
       </Helmet>
 
@@ -25,10 +25,10 @@ const Privacy = () => {
           <div className="container mx-auto px-4">
             <div className="max-w-3xl">
               <h1 className="text-4xl md:text-5xl font-bold text-primary-foreground mb-4">
-                Privacy Policy
+                Jawafdehi Initiative Privacy Policy
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: May 2026
+                Last updated: June 2026
               </p>
             </div>
           </div>
@@ -37,16 +37,26 @@ const Privacy = () => {
         <section className="py-12 md:py-16">
           <div className="container mx-auto px-4">
             <div className="max-w-3xl mx-auto prose prose-neutral dark:prose-invert">
+              {/*
+                NOTE FOR COUNSEL REVIEW (remove before publish):
+                - Confirm registered Michigan mailing address for CCPA/GDPR contact.
+                - Confirm whether an EU/UK Article 27 representative is required.
+                - Confirm CCPA applicability thresholds for a nonprofit.
+              */}
+
               <h2 id="overview">1. Overview</h2>
               <p>
-                Jawafdehi ("we", "our", or "us") operates the jawafdehi.org website. This Privacy Policy explains how we collect, use, and protect information when you use our platform. We believe in minimal data collection and maximum transparency — consistent with our mission as Nepal's open corruption accountability platform.
+                This Privacy Policy explains how Jawafdehi Initiative Inc., a Michigan public benefit nonprofit corporation ("Jawafdehi", "we", "our", or "us"), collects, uses, shares, and protects information when you use the jawafdehi.org website and related services (the "Platform"). We believe in minimal data collection and maximum transparency — consistent with our mission as Nepal's open corruption accountability platform.
+              </p>
+              <p>
+                We are the data controller for personal information processed through the Platform. If you have questions or wish to exercise your privacy rights, contact us at <a href="mailto:privacy@jawafdehi.org" className="text-primary hover:underline">privacy@jawafdehi.org</a>.
               </p>
 
               <h2 id="information-we-collect">2. Information We Collect</h2>
 
               <h3 id="information-you-provide">2.1 Information You Provide</h3>
               <p>
-                When you submit feedback, report an allegation, or volunteer through our platform, you may provide:
+                When you submit feedback, report an allegation, or volunteer through our Platform, you may provide:
               </p>
               <ul>
                 <li>Your name (optional)</li>
@@ -54,12 +64,12 @@ const Privacy = () => {
                 <li>Any information you choose to include in your submission</li>
               </ul>
               <p>
-                All submissions are voluntary. You may submit feedback or reports anonymously.
+                All submissions are voluntary. You may submit feedback or allegation reports anonymously.
               </p>
 
               <h3 id="automatically-collected-information">2.2 Automatically Collected Information</h3>
               <p>
-                When you visit jawafdehi.org, our hosting infrastructure automatically collects standard server logs that may include:
+                When you visit jawafdehi.org, our infrastructure automatically collects standard server logs that may include:
               </p>
               <ul>
                 <li>IP address (temporarily logged for security and debugging)</li>
@@ -67,80 +77,139 @@ const Privacy = () => {
                 <li>Pages visited and time spent</li>
                 <li>Referring URL</li>
               </ul>
+
+              <h3 id="analytics-data">2.3 Analytics Data</h3>
               <p>
-                We use Cloudflare for DNS, CDN, and security. Cloudflare may process visitor data according to their privacy policy. We do not use any third-party analytics trackers, advertising networks, or tracking cookies.
+                With your consent, we use Google Analytics 4 to understand how visitors use the Platform (for example, which pages are viewed). Google Analytics sets cookies and processes usage data. Google Analytics 4 does not log or store full IP addresses, and we do not use Google Analytics for advertising or cross-context behavioral tracking. Analytics do not load and no analytics cookies are set unless you opt in through our cookie banner. You can decline analytics at any time without affecting your use of the Platform (see Section 4).
+              </p>
+
+              <h3 id="error-monitoring">2.4 Error Monitoring</h3>
+              <p>
+                We use Sentry to detect and diagnose technical errors so we can keep the Platform working. Sentry captures error and diagnostic data when something goes wrong. We have configured Sentry to minimize personal data: we do not send IP addresses or other personal identifiers by default, text is masked, and media is blocked in any captured diagnostics. We rely on this strictly for reliability and security (our legitimate interest) and do not use it to profile or track you.
               </p>
 
               <h2 id="cookies">3. Cookies</h2>
               <p>
-                Jawafdehi.org uses minimal cookies:
+                Jawafdehi.org uses the following cookies and similar technologies:
               </p>
               <ul>
-                <li><strong>Language preference</strong>: We store your chosen language (English or Nepali) in a cookie so you don't have to select it on every visit.</li>
-                <li><strong>Session cookies</strong>: If you access the caseworker portal, we use session cookies for authentication.</li>
+                <li><strong>Essential cookies</strong>: A language preference cookie (English or Nepali) and, if you access the caseworker portal, a session cookie for authentication. These are necessary for the site to function and are not used for tracking.</li>
+                <li><strong>Analytics cookies (optional)</strong>: Set by Google Analytics only after you opt in. These help us understand site usage. They are never set if you decline.</li>
               </ul>
               <p>
-                We do not use tracking cookies, advertising cookies, or third-party analytics cookies.
+                We do not use advertising cookies or third-party advertising networks.
               </p>
 
-              <h2 id="how-we-use-information">4. How We Use Information</h2>
-              <p>We use collected information only for:</p>
+              <h2 id="consent">4. Your Consent Choices</h2>
+              <p>
+                When you first visit the Platform, we ask whether you consent to analytics cookies. You may accept or decline, and declining does not limit your access to the Platform. You can change your decision later by clearing your browser storage for jawafdehi.org, which will prompt the consent banner again. Essential cookies do not require consent because the site cannot function without them.
+              </p>
+
+              <h2 id="how-we-use-information">5. How We Use Information and Legal Bases</h2>
+              <p>We use collected information to:</p>
               <ul>
-                <li>Processing feedback, allegations, and volunteer submissions</li>
-                <li>Operating and improving the website</li>
-                <li>Security monitoring and abuse prevention</li>
-                <li>Responding to inquiries</li>
+                <li>Process feedback, allegation reports, and volunteer submissions, and respond to inquiries</li>
+                <li>Operate, maintain, and improve the Platform</li>
+                <li>Monitor security and prevent abuse</li>
+                <li>Publish and maintain the public corruption case archive</li>
+                <li>Understand site usage (analytics), where you have consented</li>
               </ul>
+              <p>
+                For visitors in the European Economic Area, United Kingdom, and other regions with similar laws, our legal bases for processing are: your <strong>consent</strong> (analytics cookies); our <strong>legitimate interests</strong> (operating and securing the Platform, error monitoring, preventing abuse, and responding to submissions you send us); and the performance of tasks carried out in the <strong>public interest</strong> (documenting and archiving public-domain corruption records).
+              </p>
               <p>
                 We never sell, rent, or share personal information with third parties for commercial purposes.
               </p>
 
-              <h2 id="data-storage-and-security">5. Data Storage and Security</h2>
+              <h2 id="ai-processing">6. Automated and AI Processing</h2>
               <p>
-                Jawafdehi operates on Cloudflare infrastructure. Submission data and server logs are stored securely. We take reasonable technical and organizational measures to protect data against unauthorized access, alteration, or destruction.
+                To document and summarize corruption cases drawn from public records, we use third-party large language model services, including Anthropic's Claude. Published case data on the Platform is in the public domain and may be processed in this way.
               </p>
               <p>
-                Server logs are retained for a limited period for operational purposes and are not used for user profiling.
+                We may also use AI services to help process and triage <strong>allegation reports</strong> that you submit. We do <strong>not</strong> send the content of general <strong>feedback submissions</strong> to AI services. Where we use Anthropic's Claude, submitted content is processed under Anthropic's commercial terms and is <strong>not used to train their models</strong>. Decisions that materially affect individuals are reviewed by humans; we do not rely solely on automated processing for such decisions.
               </p>
 
-              <h2 id="third-party-services">6. Third-Party Services</h2>
+              <h2 id="source-protection">7. Source and Whistleblower Protection</h2>
               <p>
-                We use the following third-party services that may process visitor data:
+                We recognize that people who report corruption may face risk. You may submit allegation reports anonymously, and we do not require you to provide your name or email. We minimize the personal data we collect, limit access to submissions to authorized personnel, and do not publish the identity of a source without their informed consent. Server logs that may contain IP addresses are retained only briefly for security purposes (see Section 9). If you are concerned about your safety, we encourage you to avoid including identifying details in your submission and to use privacy-protective tools (such as the Tor Browser) when accessing the Platform.
+              </p>
+
+              <h2 id="data-storage-and-security">8. Data Storage, Security, and International Transfers</h2>
+              <p>
+                The Platform runs on self-hosted infrastructure operated across multiple cloud providers (see Section 10), located primarily in the United States, with error-monitoring data processed in the European Union. We take reasonable technical and organizational measures to protect data against unauthorized access, alteration, or destruction.
+              </p>
+              <p>
+                Because we and our service providers operate internationally, your information may be transferred to and processed in countries other than your own, including the United States. Where required, such transfers are carried out under appropriate safeguards, such as the European Commission's Standard Contractual Clauses.
+              </p>
+
+              <h2 id="third-party-services">9. Service Providers and Sub-Processors</h2>
+              <p>
+                We rely on the following service providers, which may process limited data on our behalf:
               </p>
               <ul>
-                <li><strong>Cloudflare</strong>: DNS, CDN, DDoS protection, and hosting infrastructure.</li>
-                <li><strong>UptimeRobot</strong>: External uptime monitoring (linked from our status page).</li>
+                <li><strong>Cloudflare</strong>: DNS, CDN, DDoS protection, and object storage.</li>
+                <li><strong>Oracle Cloud Infrastructure</strong> and <strong>Monal Cloud</strong>: compute hosting for the Platform.</li>
+                <li><strong>Amazon Web Services (AWS)</strong>: transactional and newsletter email delivery.</li>
+                <li><strong>Google Cloud</strong>: supporting infrastructure services.</li>
+                <li><strong>Google Analytics</strong>: usage analytics (only with your consent).</li>
+                <li><strong>Sentry</strong>: error and performance monitoring (EU region).</li>
+                <li><strong>Anthropic</strong>: AI processing of public case data and, where applicable, allegation reports (not used to train models).</li>
+                <li><strong>UptimeRobot</strong>: external uptime monitoring.</li>
               </ul>
               <p>
                 Links to external websites (e.g., GitHub, social media, Let's Build Nepal) are governed by their respective privacy policies.
               </p>
 
-              <h2 id="childrens-privacy">7. Children's Privacy</h2>
-              <p>
-                Our platform is not directed at children under 13. We do not knowingly collect personal information from children. If you believe a child has provided us with personal data, please contact us and we will delete it.
-              </p>
+              <h2 id="data-retention">10. Data Retention</h2>
+              <p>We retain information only as long as needed for the purposes described above:</p>
+              <ul>
+                <li><strong>Edge and access logs</strong>: up to 30 days.</li>
+                <li><strong>Application and security logs</strong>: up to 90 days.</li>
+                <li><strong>Error-monitoring (Sentry) events</strong>: up to 90 days.</li>
+                <li><strong>Analytics data</strong>: up to 14 months.</li>
+                <li><strong>Feedback submissions</strong>: up to 24 months, then deleted unless tied to a published case.</li>
+                <li><strong>Allegation reports</strong>: retained for the life of any resulting public record; otherwise purged when closed without action.</li>
+                <li><strong>Volunteer applications</strong>: until no longer needed or upon your request to withdraw.</li>
+                <li><strong>Published case data</strong>: retained indefinitely as part of the permanent public-interest archive.</li>
+                <li><strong>Backups</strong>: deletions propagate as backups cycle out, within approximately 90 days.</li>
+              </ul>
 
-              <h2 id="your-rights">8. Your Rights</h2>
+              <h2 id="your-rights">11. Your Privacy Rights</h2>
               <p>
-                You may request:
+                Depending on where you live, you may have some or all of the following rights regarding your personal information:
               </p>
               <ul>
-                <li>Access to any personal data we hold about you</li>
-                <li>Correction or deletion of your personal data</li>
-                <li>Information about how your data is processed</li>
+                <li><strong>Access / know</strong>: the categories and specific pieces of personal information we hold about you and how we use it.</li>
+                <li><strong>Deletion</strong>: request that we delete your personal information.</li>
+                <li><strong>Correction</strong>: request that we correct inaccurate personal information.</li>
+                <li><strong>Portability</strong>: receive a copy of certain information in a portable format.</li>
+                <li><strong>Restriction / objection</strong>: restrict or object to certain processing.</li>
+                <li><strong>Withdraw consent</strong>: withdraw analytics consent at any time.</li>
+                <li><strong>Non-discrimination</strong>: we will not discriminate against you for exercising your rights.</li>
               </ul>
               <p>
-                To exercise these rights, contact us through the Feedback page.
+                <strong>California residents (CCPA/CPRA)</strong>: As a nonprofit organization, we are generally not subject to the CCPA/CPRA, but we voluntarily extend these protections to California residents. We do not sell your personal information and do not share it for cross-context behavioral advertising. You may exercise the rights above, and you may use an authorized agent to do so.
+              </p>
+              <p>
+                <strong>EEA / UK residents (GDPR)</strong>: In addition to the rights above, you have the right to lodge a complaint with your local data protection supervisory authority.
+              </p>
+              <p>
+                To exercise any of these rights, email <a href="mailto:privacy@jawafdehi.org" className="text-primary hover:underline">privacy@jawafdehi.org</a> or use our <a href="/feedback" className="text-primary hover:underline">Feedback page</a>. We will verify your request and respond within the timeframes required by applicable law.
               </p>
 
-              <h2 id="policy-changes">9. Changes to This Policy</h2>
+              <h2 id="childrens-privacy">12. Children's Privacy</h2>
+              <p>
+                The Platform is not directed at children under 16, and we do not knowingly collect personal information from them. If you believe a child has provided us with personal data, please contact us at <a href="mailto:privacy@jawafdehi.org" className="text-primary hover:underline">privacy@jawafdehi.org</a> and we will delete it.
+              </p>
+
+              <h2 id="policy-changes">13. Changes to This Policy</h2>
               <p>
                 We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated "Last updated" date. We encourage you to review this policy periodically.
               </p>
 
-              <h2 id="contact">10. Contact</h2>
+              <h2 id="contact">14. Contact</h2>
               <p>
-                For questions about this Privacy Policy, please use our <a href="/feedback" className="text-primary hover:underline">Feedback page</a>.
+                For questions about this Privacy Policy or to exercise your rights, contact us at <a href="mailto:privacy@jawafdehi.org" className="text-primary hover:underline">privacy@jawafdehi.org</a> or through our <a href="/feedback" className="text-primary hover:underline">Feedback page</a>.
               </p>
             </div>
           </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -28,7 +28,7 @@ const Privacy = () => {
                 Jawafdehi Initiative Privacy Policy
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: June 2026
+                Last updated: June 22, 2026
               </p>
             </div>
           </div>

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -4,18 +4,18 @@ const TermsOfService = () => {
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <Helmet>
-        <title>Terms of Service | Jawafdehi Nepal</title>
+        <title>Jawafdehi Initiative Terms of Service</title>
         <meta name="description" content="Jawafdehi's terms of service — guidelines for using Nepal's open corruption accountability platform and public case archive." />
         <link rel="canonical" href="https://jawafdehi.org/terms" />
         <meta property="og:site_name" content="Jawafdehi Nepal" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://jawafdehi.org/terms" />
-        <meta property="og:title" content="Terms of Service | Jawafdehi Nepal" />
+        <meta property="og:title" content="Jawafdehi Initiative Terms of Service" />
         <meta property="og:description" content="Jawafdehi's terms of service — guidelines for using Nepal's open corruption accountability platform and public case archive." />
         <meta property="og:image" content="https://jawafdehi.org/og-favicon.png" />
         <meta property="og:locale" content="en_US" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Terms of Service | Jawafdehi Nepal" />
+        <meta name="twitter:title" content="Jawafdehi Initiative Terms of Service" />
         <meta name="twitter:description" content="Jawafdehi's terms of service — guidelines for using Nepal's open corruption accountability platform and public case archive." />
         <meta name="twitter:image" content="https://jawafdehi.org/og-favicon.png" />
       </Helmet>
@@ -25,10 +25,10 @@ const TermsOfService = () => {
           <div className="container mx-auto px-4">
             <div className="max-w-3xl">
               <h1 className="text-4xl md:text-5xl font-bold text-primary-foreground mb-4">
-                Terms of Service
+                Jawafdehi Initiative Terms of Service
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: May 2026
+                Last updated: June 2026
               </p>
             </div>
           </div>
@@ -44,10 +44,10 @@ const TermsOfService = () => {
 
               <h2 id="about-jawafdehi">2. About Jawafdehi</h2>
               <p>
-                Jawafdehi is Nepal's open corruption accountability platform. We document, simplify, and permanently archive CIAA (Commission for the Investigation of Abuse of Authority) corruption cases. All published case data is in the public domain and is provided for public interest, transparency, and accountability purposes.
+                The Platform is operated by Jawafdehi Initiative Inc., a Michigan public benefit nonprofit corporation. Jawafdehi is Nepal's open corruption accountability platform. We document, simplify, and permanently archive CIAA (Commission for the Investigation of Abuse of Authority) corruption cases. All published case data is in the public domain and is provided for public interest, transparency, and accountability purposes.
               </p>
               <p>
-                Jawafdehi is a volunteer-run, open-source project. We are not a government entity, law firm, or legal authority. We do not provide legal advice.
+                Jawafdehi is an open-source project run with the help of volunteers. We are not a government entity, law firm, or legal authority. We do not provide legal advice.
               </p>
 
               <h2 id="platform-use">3. Use of the Platform</h2>
@@ -126,7 +126,7 @@ const TermsOfService = () => {
 
               <h2 id="governing-law">12. Governing Law</h2>
               <p>
-                These Terms are governed by the laws of Nepal. Any disputes arising from these Terms shall be subject to the jurisdiction of Nepali courts.
+                These Terms are governed by the laws of the State of Michigan, United States, without regard to its conflict-of-laws principles. Any disputes arising from these Terms shall be subject to the jurisdiction of the state and federal courts located in Michigan.
               </p>
 
               <h2 id="contact">13. Contact</h2>

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -28,7 +28,7 @@ const TermsOfService = () => {
                 Jawafdehi Initiative Terms of Service
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: June 2026
+                Last updated: June 22, 2026
               </p>
             </div>
           </div>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -13,6 +13,7 @@ declare global {
       targetOrEvent: string | Date,
       params?: Record<string, unknown>
     ) => void;
+    dataLayer?: unknown[];
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,6 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import fs from "node:fs";
 import { componentTagger } from "lovable-tagger";
-import { VitePluginRadar } from "vite-plugin-radar";
-import { JAWAFDEHI_GA_MEASUREMENT_ID } from "./src/config/analytics-config";
 
 function serveGeneratedSearchIndex() {
   return {
@@ -67,12 +65,9 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       react(),
       mode === "development" && serveGeneratedSearchIndex(),
       mode === "development" && componentTagger(),
-      // Only enable analytics in production with a configured GA ID
-      mode === "production" && JAWAFDEHI_GA_MEASUREMENT_ID && VitePluginRadar({
-        analytics: {
-          id: JAWAFDEHI_GA_MEASUREMENT_ID,
-        },
-      }),
+      // Google Analytics is loaded at runtime only after the visitor opts in
+      // via the cookie consent banner (see src/lib/ga.ts). Do not inject a GA
+      // tag here — doing so would load analytics before consent.
     ].filter(Boolean),
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- Rewrites the Privacy Policy and Terms of Service to name **Jawafdehi Initiative Inc.** (Michigan public benefit nonprofit) as data controller and correct material inaccuracies (the old policy claimed "no analytics" while GA was wired). Adds an accurate sub-processor list, AI-processing disclosure, source/whistleblower protection, a retention schedule, and CCPA/CPRA + GDPR rights. Governing law moves Nepal → Michigan, USA.
- Makes Google Analytics **opt-in**: a new cookie consent banner gates `gtag.js`, which now loads only after the visitor accepts. Removes `vite-plugin-radar`, which was injecting GA unconditionally in production and would have bypassed consent.
- Scopes Sentry to essential error monitoring (error-only replay, no session recording, `sendDefaultPii: false`, masked text / blocked media).
- Sets legal page titles to **"Jawafdehi Initiative Privacy Policy"** / **"... Terms of Service"** to satisfy the TikTok app-review requirement, and surfaces Privacy/Terms in the footer Resources column.

## Verification
- `tsc --noEmit` and eslint pass.
- Drove the dev server with headless Chromium (Playwright):
  - Before consent: **0** GA scripts loaded.
  - Accept → banner closes, consent persists across reload, GA script injected, `window.gtag` defined.
  - Decline → consent stored, **0** GA scripts, banner closes.
  - Page titles/H1 render as "Jawafdehi Initiative Privacy Policy" / "... Terms of Service".

## Follow-ups (out of scope, intentionally not in this PR)
- A `{/* NOTE FOR COUNSEL */}` comment in `Privacy.tsx` flags items needing legal sign-off: registered Michigan mailing address, whether an EU/UK Art. 27 representative is required, and CCPA nonprofit thresholds. Remove before publish.
- `privacy@jawafdehi.org` must be set up to route.
- **Pre-existing**: the committed `pnpm-lock.yaml` on `main` is already out of sync with `package.json` (missing `isomorphic-dompurify`, `oidc-client-ts`, `react-oidc-context`, `rehype-raw`); a frozen/CI install would fail. Needs a separate lockfile-sync commit.

## Test plan
- [ ] Confirm "Jawafdehi Initiative" exactly matches the registered TikTok app name; resubmit app review.
- [ ] Legal/counsel review of the flagged placeholders.
- [ ] Verify `privacy@jawafdehi.org` routes.
- [ ] Smoke-test consent banner in a production build (not just dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)