### PR TITLE
Redirect /case/<court-ref> to the canonical slug

### DIFF
--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -26,7 +26,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Banknote, Calendar, FileText, AlertTriangle, ArrowLeft, ExternalLink, AlertCircle, Info, Mail, MapPin, MessageCircle, Scale, StickyNote, User, Share2 } from "lucide-react";
-import { getCaseById, getCourtCase, getDocumentSourceById } from "@/services/jds-api";
+import { getCaseById, getCaseByCourtRef, getCourtCase, getDocumentSourceById } from "@/services/jds-api";
 import { getEntityById } from "@/services/api";
 import type { CourtCase, DocumentSource, JawafEntity } from "@/types/jds";
 import type { Entity } from "@/types/nes";
@@ -42,6 +42,7 @@ import { trackEvent } from "@/utils/analytics";
 import { cn } from "@/lib/utils";
 import { formatBigo } from "@/utils/number";
 import { resolveLegacyCaseSlug } from "@/utils/legacyCaseMap";
+import { isCourtCaseRef } from "@/utils/courtCaseRef";
 import { useIsMobile } from "@/hooks/use-mobile";
 import "@/styles/print.css";
 
@@ -166,9 +167,13 @@ const CaseDetail = () => {
   // (local dev, preview deploys, direct hits that bypass the worker).
   const legacyTargetSlug = resolveLegacyCaseSlug(id);
 
+  // /case/<court-ref> URLs (e.g. /case/081-CR-0116): resolved via the by-court-ref
+  // API, then replaced with the canonical slug below once the case loads.
+  const isCourtRef = isCourtCaseRef(id);
+
   const { data: caseData, isLoading, isError } = useQuery({
     queryKey: ['case', id],
-    queryFn: () => getCaseById(id!),
+    queryFn: () => (isCourtRef ? getCaseByCourtRef(id!) : getCaseById(id!)),
     enabled: id != null && legacyTargetSlug == null,
     staleTime: 5 * 60 * 1000,
   });
@@ -265,6 +270,12 @@ const CaseDetail = () => {
   // happen after all hooks have run so we don't violate rules-of-hooks.
   if (legacyTargetSlug) {
     return <Navigate to={`/case/${legacyTargetSlug}`} replace />;
+  }
+
+  // /case/<court-ref> URLs: once the case resolves, replace with its canonical
+  // slug. Cases without a slug stay on the court-ref URL.
+  if (isCourtRef && caseData?.slug && caseData.slug !== id) {
+    return <Navigate to={`/case/${caseData.slug}`} replace />;
   }
 
   if (isLoading) {

--- a/src/services/jds-api.ts
+++ b/src/services/jds-api.ts
@@ -10,6 +10,7 @@
  */
 
 import axios, { AxiosError, AxiosInstance } from 'axios';
+import { courtRefCandidates } from '@/utils/courtCaseRef';
 import type {
   Case,
   CaseDetail,
@@ -171,6 +172,26 @@ export async function getCaseById(id: string | number): Promise<CaseDetail> {
   } catch (error) {
     handleApiError(error, `/cases/${id}/`);
   }
+}
+
+/**
+ * Resolve a bare court case number (e.g. "081-CR-0116") to its case by probing
+ * the known court identifiers (special:, supreme:). Returns the first match;
+ * rethrows the last error if none resolve.
+ */
+export async function getCaseByCourtRef(ref: string): Promise<CaseDetail> {
+  const identifiers = courtRefCandidates(ref);
+  let lastError: unknown;
+  for (const identifier of identifiers) {
+    try {
+      return await getCaseById(identifier);
+    } catch (error) {
+      lastError = error;
+      if (error instanceof JDSApiError && error.statusCode === 404) continue;
+      throw error;
+    }
+  }
+  throw lastError;
 }
 
 /**

--- a/src/utils/courtCaseRef.test.ts
+++ b/src/utils/courtCaseRef.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isCourtCaseRef, courtRefCandidates } from './courtCaseRef';
+
+describe('isCourtCaseRef', () => {
+  it('matches bare court case numbers', () => {
+    expect(isCourtCaseRef('081-CR-0116')).toBe(true);
+    expect(isCourtCaseRef('81-cr-116')).toBe(true);
+  });
+
+  it('rejects slugs, numeric ids, and malformed values', () => {
+    expect(isCourtCaseRef('case-081-cr-0090-389ad1')).toBe(false);
+    expect(isCourtCaseRef('438')).toBe(false);
+    expect(isCourtCaseRef('special:081-CR-0116')).toBe(false);
+    expect(isCourtCaseRef('93-068-0194')).toBe(false); // numeric middle segment
+    expect(isCourtCaseRef(undefined)).toBe(false);
+  });
+});
+
+describe('courtRefCandidates', () => {
+  it('probes special before supreme', () => {
+    expect(courtRefCandidates('081-CR-0116')).toEqual([
+      'special:081-CR-0116',
+      'supreme:081-CR-0116',
+    ]);
+  });
+});

--- a/src/utils/courtCaseRef.ts
+++ b/src/utils/courtCaseRef.ts
@@ -1,0 +1,28 @@
+/**
+ * Friendly court-case-reference case URLs.
+ *
+ * A bare court case number in the path (e.g. /case/081-CR-0116) is redirected to
+ * the canonical slug URL. The court identifier (special/supreme) is not part of
+ * the URL, so we probe the known identifiers in order. Mirrors the legacy-numeric
+ * redirect pattern in legacyCaseMap.ts (worker.ts edge 301 + CaseDetail
+ * client-side fallback).
+ */
+
+// Bare court case number: digits-letters-digits (e.g. 081-CR-0116, 81-cr-116).
+// Zero-padding / casing is normalised server-side by the cases API.
+const COURT_REF_PATTERN = /^\d+-[A-Za-z]+-\d+$/;
+
+// Court identifiers the cases API understands, probed in this order.
+const COURT_IDENTIFIERS = ['special', 'supreme'] as const;
+
+export function isCourtCaseRef(id: string | undefined): boolean {
+  return id != null && COURT_REF_PATTERN.test(id);
+}
+
+/**
+ * API lookup identifiers for a bare court ref, e.g.
+ * ['special:081-CR-0116', 'supreme:081-CR-0116'].
+ */
+export function courtRefCandidates(ref: string): string[] {
+  return COURT_IDENTIFIERS.map((court) => `${court}:${ref}`);
+}

--- a/worker.ts
+++ b/worker.ts
@@ -1,4 +1,5 @@
 import { LEGACY_CASE_MAP } from './src/utils/legacyCaseMap';
+import { courtRefCandidates } from './src/utils/courtCaseRef';
 import { JAWAFDEHI_WEEKLY_SERIES } from './src/config/constants';
 
 interface Env {
@@ -127,6 +128,29 @@ function extractCaseSlugFromUrl(caseUrl: string): string | null {
   }
 }
 
+// Resolve a bare court case number (e.g. "081-CR-0116") to its canonical slug
+// by probing the known court identifiers against the cases API. Returns null if
+// no case resolves (or the resolved case has no slug), so the caller falls
+// through to normal handling.
+async function resolveCourtRefSlug(ref: string): Promise<string | null> {
+  for (const identifier of courtRefCandidates(ref)) {
+    try {
+      const apiUrl = `${JDS_API_BASE}/cases/${encodeURIComponent(identifier)}/`;
+      const apiResponse = await fetch(apiUrl, { headers: { Accept: 'application/json' } });
+      if (!apiResponse.ok) {
+        continue;
+      }
+      const caseData = (await apiResponse.json()) as { slug?: string | null };
+      if (caseData.slug) {
+        return caseData.slug;
+      }
+    } catch {
+      // Network/parse failure: fall through to the next identifier.
+    }
+  }
+  return null;
+}
+
 async function handleOembed(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const targetUrl = url.searchParams.get('url');
@@ -212,6 +236,22 @@ export default {
     if (caseMatch) {
       const legacyId = caseMatch[1];
       const targetSlug = LEGACY_CASE_MAP[legacyId];
+      if (targetSlug) {
+        return new Response(null, {
+          status: 301,
+          headers: {
+            'Location': `/case/${targetSlug}`,
+            'Cache-Control': 'public, max-age=3600',
+            ...secHeaders,
+          },
+        });
+      }
+    }
+
+    // Court-case-ref case URLs: /case/081-CR-0116 → canonical slug (301)
+    const courtRefMatch = path.match(/^\/case\/(\d+-[A-Za-z]+-\d+)\/?$/);
+    if (courtRefMatch) {
+      const targetSlug = await resolveCourtRefSlug(courtRefMatch[1]);
       if (targetSlug) {
         return new Response(null, {
           status: 301,


### PR DESCRIPTION
## Summary
- Visiting a case by its bare court case number (e.g. `jawafdehi.org/case/081-CR-0116`) now redirects to that case's canonical slug URL.
- Resolution probes the `special:` then `supreme:` court identifiers against the existing by-court-ref cases API (which returns the full case incl. its slug).
- Mirrors the existing legacy-numeric redirect pattern: `worker.ts` issues an **edge 301** in production; `CaseDetail` does a **client-side replace** for dev/preview/direct hits that bypass the worker.

## Changes
- `src/utils/courtCaseRef.ts` (new) — `isCourtCaseRef()` (matches bare `NNN-LL-NNNN`) + `courtRefCandidates()` (builds the `special:`/`supreme:` probe list). Unit-tested.
- `src/services/jds-api.ts` — `getCaseByCourtRef()` probes the candidates, falling through on 404.
- `worker.ts` — `resolveCourtRefSlug()` + a `/case/<court-ref>` → canonical-slug **301**.
- `src/pages/CaseDetail.tsx` — court-ref-aware query + `<Navigate replace>` to the canonical slug once the case resolves.

No backend change: the slug and by-court-ref API paths already share the same `can_view_case` permission gating.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx eslint` clean on changed files
- [x] `vitest run` — full suite 48/48 (incl. new `courtCaseRef.test.ts`)
- [x] Live (headless Chrome vs `bun run dev`):
  - `/case/081-CR-0116` → `/case/case-99ca8d124afa-dbd7c3` (special, direct)
  - `/case/075-WF-0005` → `/case/case-ncell-capital-gains-tax-dispute-part2` (supreme, via fallback after a 404)
- [ ] Reviewer: confirm the production **edge 301** from `worker.ts` after deploy (local dev exercises only the client-side fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)