### PR TITLE
legal: disclose TikTok / social media account integration

### DIFF
--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -28,7 +28,7 @@ const Privacy = () => {
                 Jawafdehi Initiative Privacy Policy
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: June 22, 2026
+                Last updated: June 23, 2026
               </p>
             </div>
           </div>
@@ -86,6 +86,11 @@ const Privacy = () => {
               <h3 id="error-monitoring">2.4 Error Monitoring</h3>
               <p>
                 We use Sentry to detect and diagnose technical errors so we can keep the Platform working. Sentry captures error and diagnostic data when something goes wrong. We have configured Sentry to minimize personal data: we do not send IP addresses or other personal identifiers by default, text is masked, and media is blocked in any captured diagnostics. We rely on this strictly for reliability and security (our legitimate interest) and do not use it to profile or track you.
+              </p>
+
+              <h3 id="social-media-integration">2.5 Social Media Account Integration</h3>
+              <p>
+                To publish Jawafdehi Initiative's own content, we connect our organization's own social media accounts (including TikTok) to a self-hosted social media scheduling tool. Through a platform's official API, and only for accounts we ourselves own and connect, we may access basic profile information (such as account ID, display name, and avatar), account statistics (such as follower, like, and video counts), and the list of our own published videos, and we may upload videos we create as drafts for further editing and publishing on the platform. We do not access, collect, or store information belonging to any other users of those platforms. Information obtained through these integrations is used solely to manage our own accounts and is also subject to the terms and privacy policies of the relevant platform, including those of TikTok.
               </p>
 
               <h2 id="cookies">3. Cookies</h2>

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -28,7 +28,7 @@ const TermsOfService = () => {
                 Jawafdehi Initiative Terms of Service
               </h1>
               <p className="text-xl text-primary-foreground/80 leading-relaxed">
-                Last updated: June 22, 2026
+                Last updated: June 23, 2026
               </p>
             </div>
           </div>
@@ -72,6 +72,11 @@ const TermsOfService = () => {
                 <li>Impersonate any person or entity, or misrepresent your affiliation</li>
                 <li>Use the Platform for any unlawful purpose</li>
               </ul>
+
+              <h3 id="connected-social-accounts">3.3 Connected Social Media Accounts</h3>
+              <p>
+                We use third-party tools to manage and publish content to social media accounts that we operate (including TikTok). Our use of those accounts and the platforms' developer interfaces is additionally subject to the terms of service and policies of each platform, including those of TikTok. Information accessed through these integrations is described in our <a href="/privacy" className="text-primary hover:underline">Privacy Policy</a>.
+              </p>
 
               <h2 id="public-domain-data">4. Public Domain Data</h2>
               <p>


### PR DESCRIPTION
## Summary
Adds the disclosure TikTok's app review requires: that Jawafdehi connects its **own** social accounts (incl. TikTok) to a self-hosted scheduler, and what data that integration touches.

- **Privacy Policy** — new §2.5 *Social Media Account Integration*: lists exactly what we access via the platform API (basic profile, account stats, our own video list, draft uploads), states we access only our own accounts and no other users' data, and that use is subject to TikTok's terms.
- **Terms of Service** — new §3.3 *Connected Social Media Accounts*: our use of those accounts/developer APIs is additionally subject to each platform's terms.
- Bumped "Last updated" to June 23, 2026 on both.

## Why
TikTok rejected our developer app partly because reviewers expect the privacy policy to disclose what TikTok data the app accesses. This closes that gap (scopes requested: `user.info.basic`, `user.info.stats`, `video.list`, `video.upload`; we are **not** requesting `video.publish`).

## Notes
- Text-only references to TikTok's policies (no deep links) to avoid linking to URLs that may change.
- Pure static JSX copy; mirrors existing section markup. No logic changes.

## Test plan
- [ ] `https://jawafdehi.org/privacy` shows §2.5 and the new date
- [ ] `https://jawafdehi.org/terms` shows §3.3 and the new date
- [ ] Counsel ok with the wording (the existing COUNSEL REVIEW note in Privacy is unrelated/pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Privacy Policy with new section on social media account integration practices.
  * Updated Terms of Service with new section on connected social media accounts and information handling.
  * Updated policy document revision dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->