### PR TITLE
feat(updates): render Wagtail headless article preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ModerationDashboard from "./pages/ModerationDashboard";
 import Feedback from "./pages/Feedback";
 import Updates from "./pages/Updates";
 import UpdateDetail from "./pages/UpdateDetail";
+import UpdatePreview from "./pages/UpdatePreview";
 import EmbedCaseCard from "./pages/EmbedCaseCard";
 import Privacy from "./pages/Privacy";
 import TermsOfService from "./pages/TermsOfService";
@@ -113,6 +114,8 @@ const App = () => (
             <Route path="/moderation" element={<ModerationDashboard />} />
             <Route path="/feedback" element={<Feedback />} />
             <Route path="/updates" element={<Updates />} />
+            {/* Wagtail headless preview target — must precede the :slug route. */}
+            <Route path="/updates/preview" element={<UpdatePreview />} />
             <Route path="/updates/:slug" element={<UpdateDetail />} />
             <Route path="/information" element={<Information />} />
             <Route path="/about" element={<About />} />

--- a/src/components/ArticleView.test.tsx
+++ b/src/components/ArticleView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { ArticleView } from "@/components/ArticleView";
+import type { Article } from "@/types/cms";
+
+// Passthrough translations so assertions don't depend on i18n resources.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const article: Article = {
+  id: 7,
+  meta: {
+    type: "content.ArticlePage",
+    slug: "draft-article",
+    first_published_at: null,
+  },
+  title: "Draft headline",
+  category: "UPDATE",
+  date: "2026-06-24",
+  excerpt: "Draft excerpt",
+  thumbnail: null,
+  body: [
+    { type: "heading", value: "A section", id: "b1" },
+    { type: "paragraph", value: "<p>Body paragraph</p>", id: "b2" },
+  ],
+  related_cases: [
+    { id: 3, case_id: "080-CR-0165", title: "Related case title", slug: "a-case" },
+  ],
+};
+
+describe("ArticleView", () => {
+  it("renders the title, formatted date, body blocks and related cases", () => {
+    render(
+      <MemoryRouter>
+        <ArticleView article={article} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Draft headline" }),
+    ).toBeTruthy();
+    expect(screen.getByText("June 24, 2026")).toBeTruthy();
+    // StreamField content (heading + rich-text paragraph) renders.
+    expect(screen.getByText("A section")).toBeTruthy();
+    expect(screen.getByText("Body paragraph")).toBeTruthy();
+    // Related case links to the public case page.
+    const caseLink = screen.getByText("Related case title").closest("a");
+    expect(caseLink?.getAttribute("href")).toBe("/case/a-case");
+  });
+
+  it("omits the related-cases section when there are none", () => {
+    render(
+      <MemoryRouter>
+        <ArticleView article={{ ...article, related_cases: [] }} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("Related cases")).toBeNull();
+  });
+});

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -1,0 +1,76 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, Calendar, ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { StreamField } from "@/components/StreamField";
+import { formatPublicationDate } from "@/utils/date";
+import type { Article } from "@/types/cms";
+
+/**
+ * Presentational article view shared by the public Updates detail page and the
+ * Wagtail headless preview. Keeping a single component guarantees editors
+ * preview the article exactly as it renders live (desktop, tablet, mobile).
+ */
+export const ArticleView = ({ article }: { article: Article }) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="min-h-screen flex flex-col bg-background">
+            <main id="main-content" className="flex-1 py-8 md:py-12">
+                <div className="container mx-auto px-4 animate-fade-in">
+                    <div className="mb-8">
+                        <Button
+                            variant="ghost"
+                            asChild
+                            className="pl-0 hover:bg-transparent hover:text-primary"
+                        >
+                            <Link to="/updates" className="flex items-center gap-2">
+                                <ArrowLeft className="h-4 w-4 relative -top-px" />
+                                <span className="mt-1">{t("updates.backToUpdates")}</span>
+                            </Link>
+                        </Button>
+                    </div>
+
+                    <div className="mx-auto max-w-4xl">
+                        <article className="prose prose-slate dark:prose-invert lg:prose-xl max-w-none">
+                            <div className="mb-8 not-prose">
+                                <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">{article.title}</h1>
+                                <div className="flex items-center text-muted-foreground">
+                                    <Calendar className="mr-2 h-4 w-4" />
+                                    <span className="mt-1">{formatPublicationDate(article.date)}</span>
+                                </div>
+                            </div>
+
+                            <div className="markdown-content">
+                                <StreamField blocks={article.body} />
+                            </div>
+                        </article>
+
+                        {article.related_cases && article.related_cases.length > 0 && (
+                            <section className="mx-auto mt-12 max-w-4xl">
+                                <h2 className="text-lg font-bold text-foreground">
+                                    {t("updates.relatedCases", "Related cases")}
+                                </h2>
+                                <div className="mt-4 grid gap-3">
+                                    {article.related_cases.map((relatedCase) => (
+                                        <Link
+                                            key={relatedCase.id}
+                                            to={`/case/${relatedCase.slug}`}
+                                            className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-card p-4 transition-colors hover:border-primary/20 hover:bg-primary/[0.03]"
+                                        >
+                                            <span className="font-semibold text-foreground">{relatedCase.title}</span>
+                                            <ArrowRight className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                                        </Link>
+                                    ))}
+                                </div>
+                            </section>
+                        )}
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+};
+
+export default ArticleView;

--- a/src/pages/UpdateDetail.tsx
+++ b/src/pages/UpdateDetail.tsx
@@ -1,29 +1,12 @@
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
 import { getArticleBySlug } from "@/services/cms-api";
-import { StreamField } from "@/components/StreamField";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calendar, ArrowRight } from "lucide-react";
+import { ArticleView } from "@/components/ArticleView";
 import NotFound from "./NotFound";
-import { useTranslation } from "react-i18next";
-
-const formatDate = (value: string) => {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        timeZone: "UTC",
-    });
-};
 
 const UpdateDetail = () => {
     const { slug } = useParams();
-    const { t } = useTranslation();
 
     const { data: article, isLoading, isError } = useQuery({
         queryKey: ["cms-article", slug],
@@ -46,7 +29,7 @@ const UpdateDetail = () => {
     const description = (article.excerpt || "").slice(0, 160);
 
     return (
-        <div className="min-h-screen flex flex-col bg-background">
+        <>
             <Helmet>
                 <title>{article.title} | Jawafdehi</title>
                 <meta name="description" content={description} />
@@ -58,62 +41,8 @@ const UpdateDetail = () => {
                 {article.thumbnail?.url && <meta name="twitter:image" content={article.thumbnail.url} />}
             </Helmet>
 
-            <main id="main-content" className="flex-1 py-8 md:py-12">
-                <div className="container mx-auto px-4 animate-fade-in">
-                    <div className="mb-8">
-                        <Button
-                            variant="ghost"
-                            asChild
-                            className="pl-0 hover:bg-transparent hover:text-primary"
-                        >
-                            <Link
-                                to="/updates"
-                                className="flex items-center gap-2"
-                            >
-                                <ArrowLeft className="h-4 w-4 relative -top-px" />
-                                <span className="mt-1">{t("updates.backToUpdates")}</span>
-                            </Link>
-                        </Button>
-                    </div>
-
-                    <div className="mx-auto max-w-4xl">
-                        <article className="prose prose-slate dark:prose-invert lg:prose-xl max-w-none">
-                            <div className="mb-8 not-prose">
-                                <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">{article.title}</h1>
-                                <div className="flex items-center text-muted-foreground">
-                                    <Calendar className="mr-2 h-4 w-4" />
-                                    <span className="mt-1">{formatDate(article.date)}</span>
-                                </div>
-                            </div>
-
-                            <div className="markdown-content">
-                                <StreamField blocks={article.body} />
-                            </div>
-                        </article>
-
-                        {article.related_cases && article.related_cases.length > 0 && (
-                            <section className="mx-auto mt-12 max-w-4xl">
-                                <h2 className="text-lg font-bold text-foreground">
-                                    {t("updates.relatedCases", "Related cases")}
-                                </h2>
-                                <div className="mt-4 grid gap-3">
-                                    {article.related_cases.map((relatedCase) => (
-                                        <Link
-                                            key={relatedCase.id}
-                                            to={`/case/${relatedCase.slug}`}
-                                            className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-card p-4 transition-colors hover:border-primary/20 hover:bg-primary/[0.03]"
-                                        >
-                                            <span className="font-semibold text-foreground">{relatedCase.title}</span>
-                                            <ArrowRight className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
-                                        </Link>
-                                    ))}
-                                </div>
-                            </section>
-                        )}
-                    </div>
-                </div>
-            </main>
-        </div>
+            <ArticleView article={article} />
+        </>
     );
 };
 

--- a/src/pages/UpdatePreview.test.tsx
+++ b/src/pages/UpdatePreview.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type { Article } from "@/types/cms";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const getArticlePreview = vi.fn();
+vi.mock("@/services/cms-api", () => ({
+  getArticlePreview: (...args: unknown[]) => getArticlePreview(...args),
+}));
+
+import UpdatePreview from "@/pages/UpdatePreview";
+
+const draft: Article = {
+  id: 7,
+  meta: { type: "content.ArticlePage", slug: "x", first_published_at: null },
+  title: "Draft headline",
+  category: "UPDATE",
+  date: "2026-06-24",
+  excerpt: "",
+  thumbnail: null,
+  body: [],
+  related_cases: [],
+};
+
+const renderAt = (search: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/updates/preview${search}`]}>
+          <UpdatePreview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+};
+
+beforeEach(() => {
+  getArticlePreview.mockReset();
+});
+
+describe("UpdatePreview", () => {
+  it("fetches the draft by content_type + token and renders it", async () => {
+    getArticlePreview.mockResolvedValue(draft);
+
+    renderAt("?content_type=content.articlepage&token=abc123");
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: "Draft headline" })).toBeTruthy(),
+    );
+    expect(getArticlePreview).toHaveBeenCalledWith("content.articlepage", "abc123");
+  });
+
+  it("does not fetch and renders NotFound when params are missing", () => {
+    renderAt("");
+
+    expect(getArticlePreview).not.toHaveBeenCalled();
+    expect(screen.queryByText("Draft headline")).toBeNull();
+    expect(screen.getByText("notFound.title")).toBeTruthy();
+  });
+});

--- a/src/pages/UpdatePreview.tsx
+++ b/src/pages/UpdatePreview.tsx
@@ -1,0 +1,60 @@
+import { useSearchParams } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { useQuery } from "@tanstack/react-query";
+
+import { getArticlePreview } from "@/services/cms-api";
+import { ArticleView } from "@/components/ArticleView";
+import NotFound from "./NotFound";
+
+/**
+ * Wagtail headless preview target. The article edit screen's preview iframe is
+ * redirected here (by `wagtail_headless_preview`) with `content_type` + `token`
+ * query params; we fetch the unsaved draft and render it with the same
+ * `ArticleView` the public page uses, so editors preview the real styled
+ * article on every device size. Client-rendered only — never pre-rendered.
+ */
+const UpdatePreview = () => {
+    const [params] = useSearchParams();
+    const contentType = params.get("content_type") ?? "";
+    const token = params.get("token") ?? "";
+    const hasParams = Boolean(contentType && token);
+
+    const { data: article, isLoading, isError } = useQuery({
+        queryKey: ["cms-article-preview", contentType, token],
+        queryFn: () => getArticlePreview(contentType, token),
+        enabled: hasParams,
+        // Always refetch the latest draft when Wagtail reloads the iframe.
+        staleTime: 0,
+        gcTime: 0,
+        refetchOnMount: "always",
+        retry: false,
+    });
+
+    if (!hasParams) {
+        return <NotFound />;
+    }
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-background">
+                <p className="text-muted-foreground">Loading preview…</p>
+            </div>
+        );
+    }
+
+    if (isError || !article) {
+        return <NotFound />;
+    }
+
+    return (
+        <>
+            {/* Drafts must never be indexed if the preview URL ever leaks. */}
+            <Helmet>
+                <meta name="robots" content="noindex, nofollow" />
+            </Helmet>
+            <ArticleView article={article} />
+        </>
+    );
+};
+
+export default UpdatePreview;

--- a/src/pages/Updates.tsx
+++ b/src/pages/Updates.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getArticles } from "@/services/cms-api";
 import type { ArticleListItem } from "@/types/cms";
 import { cn } from "@/lib/utils";
+import { formatPublicationDate } from "@/utils/date";
 import {
     CalendarIcon,
     ChevronRight,
@@ -13,19 +14,6 @@ import {
     List,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-
-const formatDate = (value: string) => {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        timeZone: "UTC",
-    });
-};
 
 type ViewMode = "cards" | "list";
 
@@ -65,7 +53,7 @@ const UpdateCard = ({ article, viewMode }: UpdateCardProps) => {
                 <div>
                     <div className="mb-3 flex items-center gap-2 text-sm leading-5 text-muted-foreground">
                         <CalendarIcon className="h-4 w-4" aria-hidden="true" />
-                        <span>{formatDate(article.date)}</span>
+                        <span>{formatPublicationDate(article.date)}</span>
                     </div>
                     <h2 className="line-clamp-2 text-lg font-semibold leading-8 tracking-normal text-foreground transition-colors group-hover:text-primary">
                         {article.title}

--- a/src/services/cms-api.ts
+++ b/src/services/cms-api.ts
@@ -52,3 +52,23 @@ export async function getArticleBySlug(slug: string): Promise<Article | null> {
   });
   return res.data.items[0] ?? null;
 }
+
+/**
+ * Fetch the current *unsaved* draft for the Wagtail headless preview iframe.
+ *
+ * The edit-screen preview redirects here with `content_type` + `token` (set by
+ * `wagtail_headless_preview` on the backend). The draft is resolved from the
+ * token, so the pk in the detail path is a placeholder (`0`); the response is a
+ * single serialized page with the same fields as a published article, so the
+ * preview renders identically.
+ */
+export async function getArticlePreview(
+  contentType: string,
+  token: string,
+): Promise<Article | null> {
+  const res = await cmsClient.get<Article>("/page_preview/0/", {
+    params: { content_type: contentType, token, fields: "*" },
+    headers: { Accept: "application/json" },
+  });
+  return res.data ?? null;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -65,7 +65,10 @@ export function formatDateTime(dateString: string | null | undefined): string {
  * a date-only value shows the calendar day the editor entered regardless of the
  * viewer's timezone. Shared by the Updates list and the article detail/preview.
  */
-export function formatPublicationDate(value: string): string {
+export function formatPublicationDate(value: string | null | undefined): string {
+  if (!value) {
+    return '';
+  }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
     return value;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -59,6 +59,25 @@ export function formatDateTime(dateString: string | null | undefined): string {
   return formatDate(dateString, 'PPp');
 }
 
+/**
+ * Format a CMS publication date (a date-only "YYYY-MM-DD" value) as
+ * "Month D, YYYY". Rendered in UTC — not Kathmandu like the helpers above — so
+ * a date-only value shows the calendar day the editor entered regardless of the
+ * viewer's timezone. Shared by the Updates list and the article detail/preview.
+ */
+export function formatPublicationDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 // ── BS conversion ────────────────────────────────────────────────────────
 
 /** Convert an ISO date string → BS date (year, month, date, formatted). */

--- a/worker.ts
+++ b/worker.ts
@@ -23,7 +23,7 @@ interface FeedVideo {
 
 function securityHeaders(): Record<string, string> {
   return {
-    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://api.jawafdehi.org https://auth.jawafdehi.org; worker-src blob:;",
+    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://auth.jawafdehi.org; worker-src blob:;",
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
     'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
@@ -33,6 +33,22 @@ function securityHeaders(): Record<string, string> {
 function securityHeadersAllowFrame(): Record<string, string> {
   const headers = securityHeaders();
   delete headers['X-Frame-Options'];
+  return headers;
+}
+
+const CMS_ADMIN_ORIGIN = 'https://portal.jawafdehi.org';
+
+// Headers for the Wagtail headless preview route. Unlike the embed widget
+// (framable anywhere), the preview shows an unsaved draft, so we scope framing
+// to the CMS admin via CSP frame-ancestors (which supersedes X-Frame-Options,
+// removed here so it doesn't block the admin), and add X-Robots-Tag so the
+// draft is never indexed even when the SPA shell is served before JS runs.
+function previewSecurityHeaders(): Record<string, string> {
+  const headers = securityHeaders();
+  delete headers['X-Frame-Options'];
+  headers['Content-Security-Policy'] +=
+    ` frame-ancestors ${CMS_ADMIN_ORIGIN};`;
+  headers['X-Robots-Tag'] = 'noindex, nofollow';
   return headers;
 }
 
@@ -216,8 +232,17 @@ export default {
       return handleLatestVideos(request);
     }
 
+    // The case-embed widget and the Wagtail headless preview both render inside
+    // an <iframe>, so neither can send X-Frame-Options: DENY. The embed widget
+    // is framable anywhere; the preview (an unsaved draft) is scoped to the CMS
+    // admin and marked noindex — see previewSecurityHeaders.
     const isEmbedRoute = /^\/embed\/case\//.test(path);
-    const secHeaders = isEmbedRoute ? securityHeadersAllowFrame() : securityHeaders();
+    const isPreviewRoute = /^\/updates\/preview\/?$/.test(path);
+    const secHeaders = isPreviewRoute
+      ? previewSecurityHeaders()
+      : isEmbedRoute
+        ? securityHeadersAllowFrame()
+        : securityHeaders();
 
     // Short alias: /weekly → /saptahik (301)
     if (path === '/weekly' || path === '/weekly/') {


### PR DESCRIPTION
## Why
Backend companion **Jawafdehi/JawafdehiAPI#250** redirects the CMS article-preview iframe to the SPA. This adds the page that renders it.

## What
- New `/updates/preview` route: reads `content_type` + `token`, fetches the unsaved draft from `page_preview`, renders it with a shared `ArticleView`.
- Extract `ArticleView` from `UpdateDetail` (published page unchanged); consolidate the publication-date formatter into `utils/date`.
- Worker serves `/updates/preview` with CSP `frame-ancestors https://portal.jawafdehi.org` (scopes framing to the CMS admin) and `X-Robots-Tag: noindex`; drop the dead `api.jawafdehi.org` host from `connect-src`.

## Testing
52 vitest tests pass (incl. new `ArticleView` + `UpdatePreview`); eslint clean; `vite build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
