### PR TITLE
Frontend: unified /api paths + full admin CRUD (R4 + R5b)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,9 @@ import NgmCourtCaseForm from "./pages/admin/ngm/NgmCourtCaseForm";
 import NgmMaterials from "./pages/admin/ngm/NgmMaterials";
 import NgmMaterialForm from "./pages/admin/ngm/NgmMaterialForm";
 import AdminCases from "./pages/admin/jawafdehi/AdminCases";
+import AdminCaseForm from "./pages/admin/jawafdehi/AdminCaseForm";
 import AdminSources from "./pages/admin/jawafdehi/AdminSources";
+import AdminSourceForm from "./pages/admin/jawafdehi/AdminSourceForm";
 import Moderation from "./pages/admin/casework/Moderation";
 import CaseworkLogin from "./pages/CaseworkLogin";
 import CaseworkCallback from "./pages/CaseworkCallback";
@@ -136,8 +138,19 @@ const App = () => (
                         <Route path="ngm/materials/new" element={<NgmMaterialForm />} />
                         <Route path="ngm/materials/edit/*" element={<NgmMaterialForm />} />
                         <Route path="ngm/materials" element={<NgmMaterials />} />
-                        {/* Jawafdehi */}
+                        {/* Jawafdehi — create/edit before the list so the
+                            literal "new" segment wins over the :slug/:id param. */}
+                        <Route path="jawafdehi/cases/new" element={<AdminCaseForm />} />
+                        <Route
+                          path="jawafdehi/cases/:slug/edit"
+                          element={<AdminCaseForm />}
+                        />
                         <Route path="jawafdehi/cases" element={<AdminCases />} />
+                        <Route path="jawafdehi/sources/new" element={<AdminSourceForm />} />
+                        <Route
+                          path="jawafdehi/sources/:id/edit"
+                          element={<AdminSourceForm />}
+                        />
                         <Route path="jawafdehi/sources" element={<AdminSources />} />
                         {/* Casework (folded in from /portal) */}
                         <Route path="reviews" element={<CaseworkReviews />} />

--- a/src/components/admin/DeleteButton.test.tsx
+++ b/src/components/admin/DeleteButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// The toast hook is a side-effect; stub it so we can assert it fired.
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...a: unknown[]) => toast(...a) }));
+
+import DeleteButton from "./DeleteButton";
+
+// The last button labelled "Delete" is the confirm action inside the dialog
+// (the first is the trigger that's still in the DOM).
+function confirmButton(): HTMLElement {
+  const btns = screen.getAllByRole("button", { name: /delete/i });
+  return btns[btns.length - 1];
+}
+
+beforeEach(() => {
+  toast.mockClear();
+});
+
+describe("DeleteButton", () => {
+  it("only calls onDelete after the confirm dialog is confirmed", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    const onDeleted = vi.fn();
+    render(
+      <DeleteButton
+        resourceLabel="entity"
+        onDelete={onDelete}
+        onDeleted={onDeleted}
+      />,
+    );
+
+    // Trigger click opens the dialog but does NOT delete yet.
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(await screen.findByText(/delete entity\?/i)).toBeTruthy();
+
+    // Confirm inside the dialog -> the delete runs, toast fires, onDeleted runs.
+    fireEvent.click(confirmButton());
+    await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledTimes(1));
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "entity deleted" }),
+    );
+  });
+
+  it("does not delete when the dialog is cancelled", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    render(<DeleteButton resourceLabel="source" onDelete={onDelete} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /cancel/i }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/admin/DeleteButton.tsx
+++ b/src/components/admin/DeleteButton.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { adminErrorMessage } from "@/services/admin-api";
+import { toast } from "@/hooks/use-toast";
+import { Loader2, Trash2 } from "lucide-react";
+
+interface DeleteButtonProps {
+  // The async delete call (already bound to its resource key).
+  onDelete: () => Promise<void>;
+  // Human label of the thing being deleted (shown in the confirm dialog).
+  resourceLabel: string;
+  // Called after a successful delete (e.g. navigate away or refetch a list).
+  onDeleted?: () => void;
+  // Trigger button appearance.
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
+  buttonLabel?: string;
+  // Most backend deletes are SOFT (204) — say so in the copy unless told hard.
+  hard?: boolean;
+}
+
+// A confirm-then-delete button. Wraps the delete call in an AlertDialog so a
+// stray click can't destroy data; on success it toasts + calls onDeleted.
+// Shared by every admin resource (entities, court cases, materials, cases,
+// sources) so the delete flow is uniform.
+export default function DeleteButton({
+  onDelete,
+  resourceLabel,
+  onDeleted,
+  variant = "outline",
+  size = "sm",
+  buttonLabel = "Delete",
+  hard = false,
+}: DeleteButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleConfirm = async () => {
+    setDeleting(true);
+    try {
+      await onDelete();
+      toast({ title: `${resourceLabel} deleted` });
+      setOpen(false);
+      onDeleted?.();
+    } catch (err) {
+      toast({
+        title: "Delete failed",
+        description: adminErrorMessage(err, `Could not delete ${resourceLabel}.`),
+        variant: "destructive",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant={variant} size={size} className="text-red-600">
+          <Trash2 className="mr-1 h-4 w-4" />
+          {buttonLabel}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {resourceLabel}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {hard
+              ? "This permanently removes the record and cannot be undone."
+              : "This soft-deletes the record (it can be restored by an admin). It will disappear from the public site and the admin lists."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          {/* Not AlertDialogAction: it auto-closes before the async call
+              resolves, hiding the pending/error state. A plain button lets us
+              keep the dialog open until the delete settles. */}
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={deleting}
+          >
+            {deleting ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="mr-1 h-4 w-4" />
+            )}
+            Delete
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -14,8 +14,10 @@ import type { JawafEntity } from './types/jds';
 const JDS_API_BASE_URL = process.env.VITE_JDS_API_BASE_URL || 'https://portal.jawafdehi.org/api';
 // NGM read plane. SSR runs in Node, so a relative base won't resolve — fall back to
 // the production host when no absolute override is set. Post-consolidation NGM
-// lives on the same monolith as JDS under /api/ngm (not a separate ngm host).
-const NGM_API_BASE_URL = process.env.VITE_NGM_API_BASE_URL || 'https://portal.jawafdehi.org/api/ngm';
+// lives on the same monolith as JDS under the SINGLE unified /api root (the former
+// /api/ngm prefix was hard-cut): materials at /api/materials, court cases at
+// /api/courtcases.
+const NGM_API_BASE_URL = process.env.VITE_NGM_API_BASE_URL || 'https://portal.jawafdehi.org/api';
 
 export interface RenderResult {
   html: string;
@@ -102,6 +104,7 @@ async function prefetch(url: string, queryClient: QueryClient): Promise<void> {
       queryKey: ['ngm-material', tail],
       queryFn: async () => {
         const res = await axios.get(`${NGM_API_BASE_URL}/materials/${tail}`);
+        // (materials path unchanged under the unified /api root)
         return res.data;
       },
     });
@@ -115,7 +118,7 @@ async function prefetch(url: string, queryClient: QueryClient): Promise<void> {
   if (courtcaseMatch) {
     const court = decodeURIComponent(courtcaseMatch[1]);
     const caseNumber = decodeURIComponent(courtcaseMatch[2]);
-    const base = `${NGM_API_BASE_URL}/cases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`;
+    const base = `${NGM_API_BASE_URL}/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`;
     await queryClient.prefetchQuery({
       queryKey: ['ngm-courtcase', court, caseNumber],
       queryFn: async () => {

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -1,0 +1,64 @@
+// Client-side vocab + helpers for the Jawafdehi corruption-case and document-
+// source admin forms. The enum values mirror src/types/jds.ts (CaseType /
+// CaseState / DocumentSourceType) and the backend serializers; the backend
+// remains the authority and re-validates.
+import type {
+  CaseType,
+  CaseState,
+  DocumentSourceType,
+} from "@/types/jds";
+
+// Corruption-case type + workflow-state choices (see types/jds.ts).
+export const CASE_TYPES: readonly CaseType[] = [
+  "CORRUPTION",
+  "BRIBERY",
+  "FORGERY",
+  "EMBEZZLEMENT",
+  "ABUSE_OF_OFFICE",
+  "MONEY_LAUNDERING",
+  "ILLEGAL_PROPERTY",
+  "EXAM_RIGGING",
+  "TAX_EVASION",
+];
+
+export const CASE_STATES: readonly CaseState[] = [
+  "DRAFT",
+  "IN_REVIEW",
+  "PUBLISHED",
+  "CLOSED",
+];
+
+// Document-source type choices (see types/jds.ts DocumentSourceType).
+export const SOURCE_TYPES: readonly DocumentSourceType[] = [
+  "LEGAL_COURT_ORDER",
+  "LEGAL_PROCEDURAL",
+  "OFFICIAL_GOVERNMENT",
+  "FINANCIAL_FORENSIC",
+  "INTERNAL_CORPORATE",
+  "MEDIA_NEWS",
+  "INVESTIGATIVE_REPORT",
+  "PUBLIC_COMPLAINT",
+  "LEGISLATIVE_DOC",
+  "SOCIAL_MEDIA",
+  "OTHER_VISUAL",
+];
+
+// Source-link roles. Uploaded files are RAW; the rest cover the URL kinds a
+// source can carry (mirrors SourceLinkRole in types/jds.ts).
+export const SOURCE_LINK_ROLES = [
+  "RAW",
+  "MARKDOWN",
+  "PERMALINK",
+  "SOURCE_PAGE",
+  "ALTERNATE",
+] as const;
+
+// URL-friendly slug: lowercase alnum, hyphen-separated (mirrors the case-slug
+// rule; reused from the NES slugify shape).
+export function slugify(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/lib/ngm-forms.ts
+++ b/src/lib/ngm-forms.ts
@@ -22,7 +22,7 @@ export function isValidMaterialIri(value: string): boolean {
 }
 
 // Split a material @id IRI into its {source, ident} path components — the keys
-// the PUT /api/ngm/materials/<source>/<ident> route expects. `source` may be
+// the PUT /api/materials/<source>/<ident> route expects. `source` may be
 // multi-segment (e.g. "court"); `ident` is the final segment. Returns null for
 // a non-material IRI.
 export function parseMaterialIri(

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  createCase,
+  getCase,
+  patchCase,
+  deleteCase,
+  adminErrorMessage,
+} from "@/services/admin-api";
+import { diffToPatchOps } from "@/lib/nes-jsonld";
+import { CASE_TYPES, CASE_STATES, slugify } from "@/lib/jawafdehi-forms";
+import DeleteButton from "@/components/admin/DeleteButton";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+import { ArrowLeft, Loader2, Save } from "lucide-react";
+
+// Keys the dedicated inputs own — the extra-properties JSON must not set these
+// (it would silently shadow a field). Also the immutable/server keys.
+const MANAGED_KEYS = new Set([
+  "id",
+  "case_id",
+  "slug",
+  "title",
+  "case_type",
+  "state",
+  "short_description",
+  "created_at",
+  "updated_at",
+]);
+
+const str = (v: unknown): string => (v == null ? "" : String(v));
+
+// Create + edit a Jawafdehi corruption case (DISTINCT from an NGM court case).
+// Create POSTs the full object; edit sends an RFC-6902 patch (diff of the
+// loaded doc vs the edited one), mirroring the NES entity editor.
+export default function AdminCaseForm() {
+  const params = useParams();
+  const navigate = useNavigate();
+  const slug = params.slug ?? "";
+  const editing = slug !== "";
+
+  const [loaded, setLoaded] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(editing);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [slugField, setSlugField] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [caseType, setCaseType] = useState<string>(CASE_TYPES[0]);
+  const [state, setState] = useState<string>(CASE_STATES[0]);
+  const [shortDescription, setShortDescription] = useState("");
+  const [extraJson, setExtraJson] = useState("");
+
+  const hydrate = useCallback((c: Record<string, unknown>) => {
+    setTitle(str(c.title));
+    setSlugField(str(c.slug));
+    if (typeof c.case_type === "string") setCaseType(c.case_type);
+    if (typeof c.state === "string") setState(c.state);
+    setShortDescription(str(c.short_description));
+    const extra: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(c)) {
+      if (MANAGED_KEYS.has(k)) continue;
+      extra[k] = v;
+    }
+    setExtraJson(Object.keys(extra).length ? JSON.stringify(extra, null, 2) : "");
+  }, []);
+
+  useEffect(() => {
+    if (!editing) return;
+    let alive = true;
+    setLoading(true);
+    getCase<Record<string, unknown>>(slug)
+      .then((c) => {
+        if (!alive) return;
+        setLoaded(c);
+        hydrate(c);
+      })
+      .catch((err) => alive && setError(adminErrorMessage(err, "Failed to load case")))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [editing, slug, hydrate]);
+
+  const onTitle = (v: string) => {
+    setTitle(v);
+    if (!editing && !slugTouched) setSlugField(slugify(v));
+  };
+
+  // Parse the extra-properties JSON box (the free-form long tail of the case).
+  const { parsedExtra, extraError } = useMemo(() => {
+    if (!extraJson.trim()) return { parsedExtra: {}, extraError: null as string | null };
+    try {
+      const parsed = JSON.parse(extraJson);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { parsedExtra: {}, extraError: "Extra properties must be a JSON object." };
+      }
+      const clash = Object.keys(parsed).find((k) => MANAGED_KEYS.has(k));
+      if (clash) {
+        return {
+          parsedExtra: {},
+          extraError: `"${clash}" is set by the fields above — remove it from extra properties.`,
+        };
+      }
+      return { parsedExtra: parsed as Record<string, unknown>, extraError: null };
+    } catch {
+      return { parsedExtra: {}, extraError: "Extra properties must be valid JSON." };
+    }
+  }, [extraJson]);
+
+  // The "after" object the form describes (used for both create and the edit diff).
+  const after = useMemo((): Record<string, unknown> => {
+    const obj: Record<string, unknown> = {
+      title: title.trim(),
+      case_type: caseType,
+      state,
+    };
+    if (slugField.trim()) obj.slug = slugField.trim();
+    if (shortDescription.trim()) obj.short_description = shortDescription.trim();
+    Object.assign(obj, parsedExtra);
+    return obj;
+  }, [title, caseType, state, slugField, shortDescription, parsedExtra]);
+
+  // In edit mode, the patch is the diff of the managed+extra keys vs the loaded
+  // doc. We diff only the keys the form manages so untouched server fields (id,
+  // timestamps, …) are never emitted as ops.
+  const patchOps = useMemo(() => {
+    if (!editing || !loaded || extraError) return [];
+    const before: Record<string, unknown> = {};
+    const keys = new Set([...Object.keys(after), "short_description", "slug"]);
+    for (const k of keys) if (k in loaded) before[k] = loaded[k];
+    return diffToPatchOps(before, after);
+  }, [editing, loaded, after, extraError]);
+
+  const canSave =
+    !saving &&
+    !extraError &&
+    title.trim() !== "" &&
+    (editing ? patchOps.length > 0 : true);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (editing) {
+        const updated = await patchCase<Record<string, unknown>>(slug, patchOps);
+        setLoaded(updated);
+        hydrate(updated);
+        toast({ title: "Case updated" });
+      } else {
+        const created = await createCase<Record<string, unknown>>(after);
+        toast({ title: "Case created" });
+        const newSlug = str(created.slug) || slugField.trim();
+        navigate(newSlug ? `/admin/jawafdehi/cases/${newSlug}/edit` : "/admin/jawafdehi/cases");
+      }
+    } catch (err) {
+      setError(adminErrorMessage(err, "Failed to save case"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mb-2 -ml-2"
+          onClick={() => navigate("/admin/jawafdehi/cases")}
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" /> Cases
+        </Button>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {editing ? "Edit Case" : "New Case"}
+        </h1>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      <form onSubmit={onSubmit} className="space-y-5">
+        <div className="space-y-1">
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            value={title}
+            onChange={(e) => onTitle(e.target.value)}
+            placeholder="Oxygen plant procurement scandal"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="slug">Slug</Label>
+          <Input
+            id="slug"
+            value={slugField}
+            onChange={(e) => {
+              setSlugTouched(true);
+              setSlugField(e.target.value);
+            }}
+            disabled={editing}
+            placeholder="oxygen-plant-procurement"
+            className="font-mono text-xs"
+          />
+          {editing && (
+            <p className="text-xs text-muted-foreground">
+              The slug is the case key and can&apos;t be changed here.
+            </p>
+          )}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label>Case type</Label>
+            <Select value={caseType} onValueChange={setCaseType}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CASE_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>State</Label>
+            <Select value={state} onValueChange={setState}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CASE_STATES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="short_description">Short description</Label>
+          <Textarea
+            id="short_description"
+            value={shortDescription}
+            onChange={(e) => setShortDescription(e.target.value)}
+            rows={2}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="extra">
+            Extra properties (JSON, optional) — description, tags,
+            key_allegations, dates…
+          </Label>
+          <Textarea
+            id="extra"
+            value={extraJson}
+            onChange={(e) => setExtraJson(e.target.value)}
+            rows={10}
+            className="font-mono text-xs"
+            placeholder={'{\n  "tags": ["procurement"],\n  "key_allegations": ["…"]\n}'}
+          />
+          {extraError && <p className="text-xs text-red-600">{extraError}</p>}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" disabled={!canSave}>
+            {saving ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-1 h-4 w-4" />
+            )}
+            {editing ? "Save changes" : "Create case"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate("/admin/jawafdehi/cases")}
+          >
+            Cancel
+          </Button>
+          {editing && (
+            <div className="ml-auto">
+              <DeleteButton
+                resourceLabel="case"
+                onDelete={() => deleteCase(slug)}
+                onDeleted={() => navigate("/admin/jawafdehi/cases")}
+              />
+            </div>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/admin/jawafdehi/AdminCases.tsx
+++ b/src/pages/admin/jawafdehi/AdminCases.tsx
@@ -1,6 +1,9 @@
+import { Link, useNavigate } from "react-router-dom";
 import ResourceTable, { type Column } from "@/components/admin/ResourceTable";
 import { listCases } from "@/services/admin-api";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 type Row = Record<string, unknown>;
 
@@ -9,23 +12,35 @@ const str = (v: unknown): string => (v == null ? "—" : String(v));
 const columns: Column<Row>[] = [
   { header: "Title", cell: (r) => <span className="font-medium">{str(r.title)}</span> },
   { header: "Slug", cell: (r) => <span className="font-mono text-xs">{str(r.slug)}</span> },
-  { header: "Status", cell: (r) => <Badge variant="secondary">{str(r.status)}</Badge> },
+  { header: "Type", cell: (r) => str(r.case_type) },
+  { header: "State", cell: (r) => <Badge variant="secondary">{str(r.state ?? r.status)}</Badge> },
   { header: "Updated", cell: (r) => str(r.updated_at ?? r.modified) },
 ];
 
 const PAGE_SIZE = 25;
 
 export default function AdminCases() {
+  const navigate = useNavigate();
   return (
     <ResourceTable<Row>
       title="Jawafdehi Cases"
-      description="Accountability cases. Full create / edit / publish lands next; this is the read view."
+      description="Accountability / corruption cases. Full create / edit / delete."
       columns={columns}
       pageSize={PAGE_SIZE}
       rowKey={(r) => str(r.slug ?? r.id)}
-      fetchPage={(page) =>
-        listCases<Row>({ page, page_size: PAGE_SIZE })
+      headerAction={
+        <Button asChild size="sm">
+          <Link to="/admin/jawafdehi/cases/new">
+            <Plus className="mr-1 h-4 w-4" /> New case
+          </Link>
+        </Button>
       }
+      onRowClick={(r) => {
+        const slug = r.slug;
+        if (typeof slug === "string" && slug)
+          navigate(`/admin/jawafdehi/cases/${encodeURIComponent(slug)}/edit`);
+      }}
+      fetchPage={(page) => listCases<Row>({ page, page_size: PAGE_SIZE })}
     />
   );
 }

--- a/src/pages/admin/jawafdehi/AdminSourceForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminSourceForm.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  createSource,
+  getSource,
+  updateSource,
+  deleteSource,
+  adminErrorMessage,
+  type SourceWriteFields,
+} from "@/services/admin-api";
+import { SOURCE_TYPES, SOURCE_LINK_ROLES } from "@/lib/jawafdehi-forms";
+import DeleteButton from "@/components/admin/DeleteButton";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+import { ArrowLeft, Loader2, Plus, Save, X } from "lucide-react";
+
+const str = (v: unknown): string => (v == null ? "" : String(v));
+
+interface LinkRow {
+  link: string;
+  role: string;
+}
+
+// Create + edit a document source. Both go over multipart so an optional file
+// can ride alongside the metadata (the create route accepts an uploaded file;
+// an upload lands as a RAW source link). URL links carry an explicit role.
+export default function AdminSourceForm() {
+  const params = useParams();
+  const navigate = useNavigate();
+  const id = params.id ?? "";
+  const editing = id !== "";
+
+  const [loading, setLoading] = useState(editing);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [sourceType, setSourceType] = useState<string>("");
+  const [links, setLinks] = useState<LinkRow[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    let alive = true;
+    setLoading(true);
+    getSource<Record<string, unknown>>(id)
+      .then((s) => {
+        if (!alive) return;
+        setTitle(str(s.title));
+        setDescription(str(s.description));
+        setSourceType(str(s.source_type));
+        const urls = Array.isArray(s.urls) ? (s.urls as unknown[]) : [];
+        setLinks(
+          urls
+            .filter((u): u is { link?: unknown; role?: unknown } =>
+              Boolean(u) && typeof u === "object",
+            )
+            .map((u) => ({ link: str(u.link), role: str(u.role) || "PERMALINK" })),
+        );
+      })
+      .catch((err) => alive && setError(adminErrorMessage(err, "Failed to load source")))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [editing, id]);
+
+  const addLink = () =>
+    setLinks((ls) => [...ls, { link: "", role: "PERMALINK" }]);
+  const setLink = (i: number, patch: Partial<LinkRow>) =>
+    setLinks((ls) => ls.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+  const removeLink = (i: number) =>
+    setLinks((ls) => ls.filter((_, idx) => idx !== i));
+
+  const cleanLinks = links.filter((l) => l.link.trim() !== "");
+  const canSave = !saving && title.trim() !== "";
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+
+    const fields: SourceWriteFields = {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      source_type: sourceType || undefined,
+      urls: cleanLinks.length
+        ? cleanLinks.map((l) => ({ link: l.link.trim(), role: l.role }))
+        : undefined,
+    };
+
+    try {
+      if (editing) {
+        await updateSource(id, fields, file);
+        toast({ title: "Source updated" });
+      } else {
+        await createSource(fields, file);
+        toast({ title: "Source created" });
+      }
+      navigate("/admin/jawafdehi/sources");
+    } catch (err) {
+      setError(adminErrorMessage(err, "Failed to save source"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mb-2 -ml-2"
+          onClick={() => navigate("/admin/jawafdehi/sources")}
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" /> Sources
+        </Button>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {editing ? "Edit Source" : "New Source"}
+        </h1>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      <form onSubmit={onSubmit} className="space-y-5">
+        <div className="space-y-1">
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label>Source type</Label>
+          <Select value={sourceType} onValueChange={setSourceType}>
+            <SelectTrigger className="max-w-sm">
+              <SelectValue placeholder="Select a type" />
+            </SelectTrigger>
+            <SelectContent>
+              {SOURCE_TYPES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Links</Label>
+          {links.map((l, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Input
+                value={l.link}
+                onChange={(e) => setLink(i, { link: e.target.value })}
+                placeholder="https://…"
+                className="flex-1 text-xs"
+              />
+              <Select value={l.role} onValueChange={(v) => setLink(i, { role: v })}>
+                <SelectTrigger className="w-40">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SOURCE_LINK_ROLES.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeLink(i)}
+                aria-label="Remove link"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button type="button" variant="outline" size="sm" onClick={addLink}>
+            <Plus className="mr-1 h-4 w-4" /> Add link
+          </Button>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="file">
+            {editing ? "Replace file (optional)" : "File (optional)"}
+          </Label>
+          <Input
+            id="file"
+            type="file"
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          />
+          <p className="text-xs text-muted-foreground">
+            An uploaded file is stored and linked as a RAW source link.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" disabled={!canSave}>
+            {saving ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-1 h-4 w-4" />
+            )}
+            {editing ? "Save changes" : "Create source"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate("/admin/jawafdehi/sources")}
+          >
+            Cancel
+          </Button>
+          {editing && (
+            <div className="ml-auto">
+              <DeleteButton
+                resourceLabel="source"
+                onDelete={() => deleteSource(id)}
+                onDeleted={() => navigate("/admin/jawafdehi/sources")}
+              />
+            </div>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/admin/jawafdehi/AdminSources.tsx
+++ b/src/pages/admin/jawafdehi/AdminSources.tsx
@@ -1,6 +1,9 @@
+import { Link, useNavigate } from "react-router-dom";
 import ResourceTable, { type Column } from "@/components/admin/ResourceTable";
 import { listSources } from "@/services/admin-api";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 type Row = Record<string, unknown>;
 
@@ -12,7 +15,10 @@ const columns: Column<Row>[] = [
   {
     header: "URL",
     cell: (r) => {
-      const url = str(r.url);
+      // A source carries `urls` (link-role dicts); show the first link's target.
+      const urls = Array.isArray(r.urls) ? (r.urls as { link?: unknown }[]) : [];
+      const first = urls.find((u) => u && typeof u.link === "string");
+      const url = first ? String(first.link) : str(r.url);
       return url === "—" ? (
         url
       ) : (
@@ -20,6 +26,7 @@ const columns: Column<Row>[] = [
           href={url}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
           className="text-xs text-primary underline-offset-2 hover:underline"
         >
           {url.length > 60 ? `${url.slice(0, 57)}…` : url}
@@ -32,13 +39,25 @@ const columns: Column<Row>[] = [
 const PAGE_SIZE = 25;
 
 export default function AdminSources() {
+  const navigate = useNavigate();
   return (
     <ResourceTable<Row>
       title="Document Sources"
-      description="Document sources backing Jawafdehi cases."
+      description="Document sources backing Jawafdehi cases. Full create / edit / delete."
       columns={columns}
       pageSize={PAGE_SIZE}
       rowKey={(r) => str(r.id)}
+      headerAction={
+        <Button asChild size="sm">
+          <Link to="/admin/jawafdehi/sources/new">
+            <Plus className="mr-1 h-4 w-4" /> New source
+          </Link>
+        </Button>
+      }
+      onRowClick={(r) => {
+        if (r.id != null)
+          navigate(`/admin/jawafdehi/sources/${encodeURIComponent(String(r.id))}/edit`);
+      }}
       fetchPage={(page) => listSources<Row>({ page, page_size: PAGE_SIZE })}
     />
   );

--- a/src/pages/admin/nes/NesEntityEdit.tsx
+++ b/src/pages/admin/nes/NesEntityEdit.tsx
@@ -4,10 +4,12 @@ import {
   getNesEntity,
   patchNesEntity,
   getNesEntityVersions,
+  deleteNesEntity,
   adminErrorMessage,
   type NesEntity,
 } from "@/services/admin-api";
 import { diffToPatchOps } from "@/lib/nes-jsonld";
+import DeleteButton from "@/components/admin/DeleteButton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -259,6 +261,13 @@ export default function NesEntityEdit() {
               ? "No changes"
               : `${patchOps.length} change${patchOps.length === 1 ? "" : "s"} pending`}
           </span>
+          <div className="ml-auto">
+            <DeleteButton
+              resourceLabel="entity"
+              onDelete={() => deleteNesEntity(ref)}
+              onDeleted={() => navigate("/admin/nes/entities")}
+            />
+          </div>
         </div>
       </form>
     </div>

--- a/src/pages/admin/ngm/NgmCourtCaseForm.tsx
+++ b/src/pages/admin/ngm/NgmCourtCaseForm.tsx
@@ -4,11 +4,13 @@ import {
   createCourtCase,
   updateCourtCase,
   getCourtCase,
+  deleteCourtCase,
   listCourts,
   adminErrorMessage,
   type CourtCaseWrite,
 } from "@/services/admin-api";
 import { isValidEntityIri } from "@/lib/ngm-forms";
+import DeleteButton from "@/components/admin/DeleteButton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -286,6 +288,17 @@ export default function NgmCourtCaseForm() {
           >
             Cancel
           </Button>
+          {editing && (
+            <div className="ml-auto">
+              <DeleteButton
+                resourceLabel="court case"
+                onDelete={() =>
+                  deleteCourtCase(params.court!, params.caseNumber!)
+                }
+                onDeleted={() => navigate("/admin/ngm/courtcases")}
+              />
+            </div>
+          )}
         </div>
       </form>
     </div>

--- a/src/pages/admin/ngm/NgmMaterialForm.tsx
+++ b/src/pages/admin/ngm/NgmMaterialForm.tsx
@@ -4,6 +4,7 @@ import {
   createMaterial,
   replaceMaterial,
   getMaterialByPath,
+  deleteMaterial,
   adminErrorMessage,
 } from "@/services/admin-api";
 import {
@@ -11,6 +12,7 @@ import {
   isValidMaterialIri,
   parseMaterialIri,
 } from "@/lib/ngm-forms";
+import DeleteButton from "@/components/admin/DeleteButton";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -219,6 +221,23 @@ export default function NgmMaterialForm() {
           >
             Cancel
           </Button>
+          {editing && (
+            <div className="ml-auto">
+              <DeleteButton
+                resourceLabel="material"
+                onDelete={() => {
+                  // Delete keys on the route ref (source/ident) that loaded the
+                  // doc — the same components the PUT/DELETE routes expect.
+                  const lastSlash = refPath.lastIndexOf("/");
+                  return deleteMaterial(
+                    refPath.slice(0, lastSlash),
+                    refPath.slice(lastSlash + 1),
+                  );
+                }}
+                onDeleted={() => navigate("/admin/ngm/materials")}
+              />
+            </div>
+          )}
         </div>
       </form>
     </div>

--- a/src/pages/admin/ngm/NgmMaterials.tsx
+++ b/src/pages/admin/ngm/NgmMaterials.tsx
@@ -1,70 +1,105 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
-import { getMaterialByIri, adminErrorMessage } from "@/services/admin-api";
+import { Link, useNavigate } from "react-router-dom";
+import ResourceTable, { type Column } from "@/components/admin/ResourceTable";
+import {
+  listMaterials,
+  getMaterialByIri,
+  adminErrorMessage,
+} from "@/services/admin-api";
 import { parseMaterialIri } from "@/lib/ngm-forms";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Loader2, Pencil, Plus, Search } from "lucide-react";
 
-// NGM materials have NO list endpoint today — the read plane only resolves a
-// material by its @id IRI (GET /api/ngm/materials/?iri=… or the path form).
-// Materials enter the lake via bulk ingestion, so the admin surface here is a
-// single-material lookup, not a browse table. A browse view waits on a list
-// endpoint (tracked as a backend follow-up).
-export default function NgmMaterials() {
-  const [iri, setIri] = useState("");
-  const [result, setResult] = useState<Record<string, unknown> | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+type Row = Record<string, unknown>;
 
+const PAGE_SIZE = 25;
+
+// A material name is a bilingual language map {en, ne} or a plain string.
+function displayName(name: unknown): string {
+  if (!name) return "—";
+  if (typeof name === "string") return name;
+  if (typeof name === "object") {
+    const m = name as { en?: string; ne?: string };
+    return m.en || m.ne || "—";
+  }
+  return "—";
+}
+
+function typeLabel(t: unknown): string {
+  if (!t) return "—";
+  return Array.isArray(t) ? t.join(", ") : String(t);
+}
+
+// Route tail (source/ident) for the edit page, parsed from the material @id.
+function editTail(id: unknown): string | null {
+  if (typeof id !== "string") return null;
+  const parts = parseMaterialIri(id);
+  return parts ? `${parts.source}/${parts.ident}` : null;
+}
+
+const columns: Column<Row>[] = [
+  {
+    header: "Name",
+    cell: (r) => <span className="font-medium">{displayName(r.name)}</span>,
+  },
+  {
+    header: "Type",
+    cell: (r) => (
+      <Badge variant="secondary">
+        {typeLabel(r.additionalType ?? r["@type"])}
+      </Badge>
+    ),
+  },
+  {
+    header: "@id",
+    cell: (r) => (
+      <span className="font-mono text-xs text-muted-foreground">
+        {typeof r["@id"] === "string" ? (r["@id"] as string) : "—"}
+      </span>
+    ),
+  },
+];
+
+// Materials browse page. The backend now exposes a paginated list
+// (GET /api/materials -> {results, next}), so this is a proper ResourceTable
+// with an IRI look-up kept alongside for jumping straight to one material.
+export default function NgmMaterials() {
+  const navigate = useNavigate();
+  const [iri, setIri] = useState("");
+  const [lookupLoading, setLookupLoading] = useState(false);
+  const [lookupError, setLookupError] = useState<string | null>(null);
+
+  // Look up a single material by IRI and jump to its edit page.
   const lookup = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!iri.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
+    setLookupLoading(true);
+    setLookupError(null);
     try {
-      const data = await getMaterialByIri<Record<string, unknown>>(iri.trim());
-      setResult(data);
+      const doc = await getMaterialByIri<Record<string, unknown>>(iri.trim());
+      const tail = editTail(doc["@id"]);
+      if (tail) navigate(`/admin/ngm/materials/edit/${tail}`);
+      else setLookupError("Resolved material has no usable @id.");
     } catch (err) {
-      setError(adminErrorMessage(err, "Material not found"));
+      setLookupError(adminErrorMessage(err, "Material not found"));
     } finally {
-      setLoading(false);
+      setLookupLoading(false);
     }
   };
 
-  // The edit route is keyed on the resolved doc's own @id (source/ident tail),
-  // which is canonical even if the looked-up IRI used a different host.
-  const resultId =
-    typeof result?.["@id"] === "string" ? (result["@id"] as string) : "";
-  const editParts = resultId ? parseMaterialIri(resultId) : null;
-
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">NGM Materials</h1>
-          <p className="text-sm text-muted-foreground">
-            Materials are JSON-LD keyed by <code>@id</code>; there is no list
-            endpoint yet, so look one up by IRI — or create a new one.
-          </p>
-        </div>
-        <Button asChild size="sm">
-          <Link to="/admin/ngm/materials/new">
-            <Plus className="mr-1 h-4 w-4" /> New material
-          </Link>
-        </Button>
-      </div>
-
       <form onSubmit={lookup} className="flex gap-2">
         <Input
           value={iri}
           onChange={(e) => setIri(e.target.value)}
-          placeholder="https://jawafdehi.org/material/<source>/<ident>"
+          placeholder="Jump to a material by @id IRI…"
           className="max-w-xl font-mono text-xs"
         />
-        <Button type="submit" variant="secondary" disabled={loading}>
-          {loading ? (
+        <Button type="submit" variant="secondary" disabled={lookupLoading}>
+          {lookupLoading ? (
             <Loader2 className="mr-1 h-4 w-4 animate-spin" />
           ) : (
             <Search className="mr-1 h-4 w-4" />
@@ -72,27 +107,44 @@ export default function NgmMaterials() {
           Look up
         </Button>
       </form>
-
-      {error && (
+      {lookupError && (
         <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
-          {error}
+          {lookupError}
         </p>
       )}
 
-      {result != null && (
-        <div className="space-y-2">
-          {editParts && (
-            <Button asChild variant="outline" size="sm">
-              <Link to={`/admin/ngm/materials/edit/${editParts.source}/${editParts.ident}`}>
-                <Pencil className="mr-1 h-4 w-4" /> Edit this material
-              </Link>
-            </Button>
-          )}
-          <pre className="overflow-auto rounded-md border bg-white p-4 text-xs">
-            {JSON.stringify(result, null, 2)}
-          </pre>
-        </div>
-      )}
+      <ResourceTable<Row>
+        title="NGM Materials"
+        description="Governance documents (JSON-LD keyed by @id). Mostly bulk-ingested; you can create, edit, and delete by hand."
+        columns={columns}
+        pageSize={PAGE_SIZE}
+        rowKey={(r) =>
+          typeof r["@id"] === "string"
+            ? (r["@id"] as string)
+            : JSON.stringify(r)
+        }
+        headerAction={
+          <Button asChild size="sm">
+            <Link to="/admin/ngm/materials/new">
+              <Plus className="mr-1 h-4 w-4" /> New material
+            </Link>
+          </Button>
+        }
+        onRowClick={(r) => {
+          const tail = editTail(r["@id"]);
+          if (tail) navigate(`/admin/ngm/materials/edit/${tail}`);
+        }}
+        fetchPage={(page) =>
+          listMaterials<Row>({
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+          })
+        }
+      />
+
+      <p className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Pencil className="h-3 w-3" /> Click a row to edit.
+      </p>
     </div>
   );
 }

--- a/src/services/admin-api.test.ts
+++ b/src/services/admin-api.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The OIDC token fetch touches the browser UserManager; stub it so the request
+// interceptor is inert in tests.
+vi.mock("./oidc", () => ({ getAccessToken: vi.fn().mockResolvedValue(null) }));
+
+// Capture what the axios instance is asked to fetch. `axios.create` returns our
+// spy client; each verb records its (url, body) and resolves an empty body so
+// the wrappers just relay the shape. `vi.hoisted` lets the mock factory (which
+// is hoisted above imports) share the `calls` array with the test bodies.
+const { calls } = vi.hoisted(() => ({
+  calls: [] as { method: string; url: string; body?: unknown }[],
+}));
+
+vi.mock("axios", () => {
+  const record =
+    (method: string) =>
+    (url: string, body?: unknown) => {
+      calls.push({ method, url, body });
+      return Promise.resolve({ data: {} });
+    };
+  const instance = {
+    get: record("get"),
+    post: record("post"),
+    put: record("put"),
+    patch: record("patch"),
+    delete: record("delete"),
+    interceptors: { request: { use: () => undefined } },
+  };
+  return { default: { create: () => instance } };
+});
+
+import {
+  listNesEntities,
+  getNesEntity,
+  deleteNesEntity,
+  reindexNes,
+  listCourtCases,
+  listCourts,
+  deleteCourtCase,
+  listMaterials,
+  deleteMaterial,
+  listCases,
+  patchCase,
+  deleteCase,
+  createSource,
+  buildSourceFormData,
+} from "./admin-api";
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+// TASK A — the client must address the SINGLE unified /api root; the former
+// /api/nes and /api/ngm prefixes were hard-cut.
+describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
+  it("routes NES entities to /api/entities and reindex to /api/admin/reindex", async () => {
+    await listNesEntities();
+    await getNesEntity("person/ram-bahadur");
+    await deleteNesEntity("person/ram-bahadur");
+    await reindexNes();
+    expect(calls.map((c) => `${c.method} ${c.url}`)).toEqual([
+      "get /api/entities",
+      "get /api/entities/person/ram-bahadur",
+      "delete /api/entities/person/ram-bahadur",
+      "post /api/admin/reindex",
+    ]);
+  });
+
+  it("routes court cases to /api/courtcases and courts to /api/courts", async () => {
+    await listCourtCases();
+    await listCourts();
+    await deleteCourtCase("special", "081-CR-0060");
+    expect(calls.map((c) => c.url)).toEqual([
+      "/api/courtcases/",
+      "/api/courts/",
+      "/api/courtcases/special/081-CR-0060",
+    ]);
+  });
+
+  it("routes materials to /api/materials", async () => {
+    await listMaterials();
+    await deleteMaterial("ciaa", "press-2081-042");
+    expect(calls.map((c) => c.url)).toEqual([
+      "/api/materials/",
+      "/api/materials/ciaa/press-2081-042",
+    ]);
+  });
+
+  it("keeps Jawafdehi cases on /api/cases and PATCHes with RFC-6902 ops", async () => {
+    await listCases();
+    await patchCase("oxygen-plant", [{ op: "replace", path: "/title", value: "X" }]);
+    await deleteCase("oxygen-plant");
+    expect(calls[0].url).toBe("/api/cases/");
+    expect(calls[1]).toMatchObject({
+      method: "patch",
+      url: "/api/cases/oxygen-plant/",
+      body: [{ op: "replace", path: "/title", value: "X" }],
+    });
+    expect(calls[2]).toMatchObject({
+      method: "delete",
+      url: "/api/cases/oxygen-plant/",
+    });
+  });
+
+  it("posts a source create as multipart FormData to /api/sources/", async () => {
+    await createSource({ title: "Report" });
+    expect(calls[0].method).toBe("post");
+    expect(calls[0].url).toBe("/api/sources/");
+    expect(calls[0].body).toBeInstanceOf(FormData);
+  });
+});
+
+// TASK B — the source multipart body is the load-bearing write contract.
+describe("buildSourceFormData", () => {
+  it("puts scalar fields as form fields and JSON-encodes urls", () => {
+    const fd = buildSourceFormData({
+      title: "Charge sheet",
+      source_type: "LEGAL_PROCEDURAL",
+      urls: [{ link: "https://x/1", role: "PERMALINK" }],
+    });
+    expect(fd.get("title")).toBe("Charge sheet");
+    expect(fd.get("source_type")).toBe("LEGAL_PROCEDURAL");
+    expect(fd.get("urls")).toBe(
+      JSON.stringify([{ link: "https://x/1", role: "PERMALINK" }]),
+    );
+    // No file provided -> no file field.
+    expect(fd.get("file")).toBeNull();
+  });
+
+  it("omits empty/nullish fields and attaches a file when given", () => {
+    const file = new File(["data"], "doc.pdf", { type: "application/pdf" });
+    const fd = buildSourceFormData(
+      { title: "Doc", description: "", source_type: null },
+      file,
+    );
+    expect(fd.get("title")).toBe("Doc");
+    expect(fd.get("description")).toBeNull();
+    expect(fd.get("source_type")).toBeNull();
+    expect(fd.get("file")).toBeInstanceOf(File);
+  });
+});

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -2,11 +2,13 @@
 //
 // Unlike the legacy clients (api.ts -> nes.jawafdehi.org, jds-api.ts ->
 // portal.jawafdehi.org), the admin panel talks to the CONSOLIDATED monolith on
-// ONE host, addressing each former service by its URL path prefix:
+// ONE host under a SINGLE unified `/api` root — the former per-service prefixes
+// (`/api/nes`, `/api/ngm`) were hard-cut. Each resource lives at its own path:
 //
-//     /api/nes/...   NES entities (JSON-LD read/write + reindex)
-//     /api/ngm/...   NGM courts + materials (read plane + ingestion)
-//     /api/...       Jawafdehi cases / sources / casework
+//     /api/entities...     NES entities (JSON-LD read/write + reindex)
+//     /api/courtcases...   NGM court cases (composite-key read/write)
+//     /api/courts, /api/firms, /api/materials   NGM governance data
+//     /api/cases, /api/sources   Jawafdehi cases / document sources
 //
 // Auth is OIDC/Zitadel only (DRF token auth was dropped in the monolith): every
 // request carries `Authorization: Bearer <access>` from the shared oidc.ts.
@@ -82,7 +84,7 @@ export interface ListEntitiesParams {
 export async function listNesEntities(
   params: ListEntitiesParams = {},
 ): Promise<NesEntityListResponse> {
-  const { data } = await client.get<NesEntityListResponse>("/api/nes/entities", {
+  const { data } = await client.get<NesEntityListResponse>("/api/entities", {
     params,
   });
   return data;
@@ -100,7 +102,7 @@ function encodeRef(ref: string): string {
 // Detail by ref: a bare `<prefix>/<slug>` path or a url-encoded @id IRI.
 export async function getNesEntity(ref: string): Promise<NesEntity> {
   const { data } = await client.get<NesEntity>(
-    `/api/nes/entities/${encodeRef(ref)}`,
+    `/api/entities/${encodeRef(ref)}`,
   );
   return data;
 }
@@ -122,7 +124,7 @@ export interface CreateEntityPayload {
 export async function createNesEntity(
   payload: CreateEntityPayload,
 ): Promise<NesEntity> {
-  const { data } = await client.post<NesEntity>("/api/nes/entities", payload);
+  const { data } = await client.post<NesEntity>("/api/entities", payload);
   return data;
 }
 
@@ -135,14 +137,14 @@ export interface PatchOp {
   from?: string;
 }
 
-// EDIT is an RFC-6902 patch: PATCH /api/nes/entities/{ref} with { patch_ops }.
+// EDIT is an RFC-6902 patch: PATCH /api/entities/{ref} with { patch_ops }.
 export async function patchNesEntity(
   ref: string,
   patchOps: PatchOp[],
   changeDescription?: string,
 ): Promise<NesEntity> {
   const { data } = await client.patch<NesEntity>(
-    `/api/nes/entities/${encodeRef(ref)}`,
+    `/api/entities/${encodeRef(ref)}`,
     { patch_ops: patchOps, change_description: changeDescription },
   );
   return data;
@@ -153,20 +155,25 @@ export async function getNesEntityVersions(ref: string): Promise<{
   total: number;
 }> {
   const { data } = await client.get(
-    `/api/nes/entities/${encodeRef(ref)}/versions`,
+    `/api/entities/${encodeRef(ref)}/versions`,
   );
   return data;
 }
 
 export async function listNesEntityPrefixes(): Promise<{ prefixes: string[] }> {
-  const { data } = await client.get("/api/nes/entity_prefixes");
+  const { data } = await client.get("/api/entity_prefixes");
   return data;
 }
 
 // Trigger an OpenSearch reindex (admin only). Returns whatever the job emits.
 export async function reindexNes(): Promise<unknown> {
-  const { data } = await client.post("/api/nes/admin/reindex", {});
+  const { data } = await client.post("/api/admin/reindex", {});
   return data;
+}
+
+// Soft-delete an entity (backend flips it to removed; returns 204 No Content).
+export async function deleteNesEntity(ref: string): Promise<void> {
+  await client.delete(`/api/entities/${encodeRef(ref)}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -183,19 +190,19 @@ export interface Paginated<T> {
 export async function listCourtCases<T = Record<string, unknown>>(
   params: Record<string, unknown> = {},
 ): Promise<Paginated<T>> {
-  const { data } = await client.get<Paginated<T>>("/api/ngm/cases/", { params });
+  const { data } = await client.get<Paginated<T>>("/api/courtcases/", { params });
   return data;
 }
 
 export async function listCourts<T = Record<string, unknown>>(): Promise<Paginated<T>> {
-  const { data } = await client.get<Paginated<T>>("/api/ngm/courts/");
+  const { data } = await client.get<Paginated<T>>("/api/courts/");
   return data;
 }
 
 export async function listBlacklistedFirms<T = Record<string, unknown>>(): Promise<
   Paginated<T>
 > {
-  const { data } = await client.get<Paginated<T>>("/api/ngm/firms/");
+  const { data } = await client.get<Paginated<T>>("/api/firms/");
   return data;
 }
 
@@ -222,7 +229,7 @@ export async function getCourtCase<T = Record<string, unknown>>(
   caseNumber: string,
 ): Promise<T> {
   const { data } = await client.get<T>(
-    `/api/ngm/cases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`,
+    `/api/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`,
   );
   return data;
 }
@@ -230,7 +237,7 @@ export async function getCourtCase<T = Record<string, unknown>>(
 export async function createCourtCase<T = Record<string, unknown>>(
   payload: CourtCaseWrite,
 ): Promise<T> {
-  const { data } = await client.post<T>("/api/ngm/cases/", payload);
+  const { data } = await client.post<T>("/api/courtcases/", payload);
   return data;
 }
 
@@ -240,9 +247,30 @@ export async function updateCourtCase<T = Record<string, unknown>>(
   payload: Partial<CourtCaseWrite>,
 ): Promise<T> {
   const { data } = await client.patch<T>(
-    `/api/ngm/cases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`,
+    `/api/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`,
     payload,
   );
+  return data;
+}
+
+// Soft-delete a court case by its composite key (backend returns 204).
+export async function deleteCourtCase(
+  court: string,
+  caseNumber: string,
+): Promise<void> {
+  await client.delete(
+    `/api/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}`,
+  );
+}
+
+// List materials (paginated). The materials list is NGM/DRF-shaped {results,
+// next}; `count`/`previous` may be absent, so ResourceTable tolerates undefined.
+export async function listMaterials<T = Record<string, unknown>>(
+  params: Record<string, unknown> = {},
+): Promise<Paginated<T>> {
+  // Trailing slash required: the backend list endpoint is GET /api/materials/
+  // (no ?iri= param). Without the slash the route 404s.
+  const { data } = await client.get<Paginated<T>>("/api/materials/", { params });
   return data;
 }
 
@@ -250,7 +278,7 @@ export async function updateCourtCase<T = Record<string, unknown>>(
 export async function getMaterialByIri<T = Record<string, unknown>>(
   iri: string,
 ): Promise<T> {
-  const { data } = await client.get<T>("/api/ngm/materials/", {
+  const { data } = await client.get<T>("/api/materials/", {
     params: { iri },
   });
   return data;
@@ -264,7 +292,7 @@ export async function getMaterialByPath<T = Record<string, unknown>>(
   ident: string,
 ): Promise<T> {
   const { data } = await client.get<T>(
-    `/api/ngm/materials/${source}/${encodeURIComponent(ident)}`,
+    `/api/materials/${source}/${encodeURIComponent(ident)}`,
   );
   return data;
 }
@@ -279,7 +307,7 @@ export async function createMaterial<T = Record<string, unknown>>(
   const body = materialType
     ? { material: jsonld, material_type: materialType }
     : jsonld;
-  const { data } = await client.post<T>("/api/ngm/materials/", body);
+  const { data } = await client.post<T>("/api/materials/", body);
   return data;
 }
 
@@ -289,14 +317,26 @@ export async function replaceMaterial<T = Record<string, unknown>>(
   jsonld: Record<string, unknown>,
 ): Promise<T> {
   const { data } = await client.put<T>(
-    `/api/ngm/materials/${encodeURIComponent(source)}/${encodeURIComponent(ident)}`,
+    `/api/materials/${encodeURIComponent(source)}/${encodeURIComponent(ident)}`,
     jsonld,
   );
   return data;
 }
 
+// Soft-delete a material by its <source>/<ident> path components (204).
+export async function deleteMaterial(
+  source: string,
+  ident: string,
+): Promise<void> {
+  await client.delete(
+    `/api/materials/${encodeURIComponent(source)}/${encodeURIComponent(ident)}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
-// Jawafdehi — cases + sources (full CRUD lives here)
+// Jawafdehi — corruption cases (DISTINCT from NGM court cases) + sources.
+// Full CRUD: cases are keyed by slug, updated via RFC-6902 PATCH; sources are
+// keyed by numeric id and created via multipart (optional file upload).
 // ---------------------------------------------------------------------------
 
 export async function listCases<T = Record<string, unknown>>(
@@ -306,11 +346,116 @@ export async function listCases<T = Record<string, unknown>>(
   return data;
 }
 
+export async function getCase<T = Record<string, unknown>>(
+  slug: string,
+): Promise<T> {
+  const { data } = await client.get<T>(`/api/cases/${encodeURIComponent(slug)}/`);
+  return data;
+}
+
+// CREATE a corruption case. The backend accepts the case authoring fields
+// (title, case_type, state, …); we keep it loosely typed so the form owns the
+// exact shape while callers still get a typed result back.
+export async function createCase<T = Record<string, unknown>>(
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const { data } = await client.post<T>("/api/cases/", payload);
+  return data;
+}
+
+// UPDATE is an RFC-6902 patch (mirrors the NES entity contract): the body is a
+// bare array of patch ops.
+export async function patchCase<T = Record<string, unknown>>(
+  slug: string,
+  patchOps: PatchOp[],
+): Promise<T> {
+  const { data } = await client.patch<T>(
+    `/api/cases/${encodeURIComponent(slug)}/`,
+    patchOps,
+  );
+  return data;
+}
+
+// Soft-delete a case (backend flips state -> CLOSED, returns 204).
+export async function deleteCase(slug: string): Promise<void> {
+  await client.delete(`/api/cases/${encodeURIComponent(slug)}/`);
+}
+
 export async function listSources<T = Record<string, unknown>>(
   params: Record<string, unknown> = {},
 ): Promise<Paginated<T>> {
   const { data } = await client.get<Paginated<T>>("/api/sources/", { params });
   return data;
+}
+
+export async function getSource<T = Record<string, unknown>>(
+  id: number | string,
+): Promise<T> {
+  const { data } = await client.get<T>(`/api/sources/${id}/`);
+  return data;
+}
+
+// Build the multipart body for a source create/update. Scalar fields ride as
+// form fields; `urls` (link-role dicts) is JSON-encoded; an optional File is
+// attached under `file`. Kept a standalone helper so it's unit-testable without
+// the network (the FormData shape is the load-bearing contract).
+export interface SourceWriteFields {
+  title: string;
+  description?: string;
+  source_type?: string | null;
+  urls?: { link: string; role: string }[] | null;
+  [k: string]: unknown;
+}
+
+export function buildSourceFormData(
+  fields: SourceWriteFields,
+  file?: File | null,
+): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    if (v == null || v === "") continue;
+    if (k === "urls") {
+      fd.append("urls", JSON.stringify(v));
+    } else if (Array.isArray(v) || typeof v === "object") {
+      fd.append(k, JSON.stringify(v));
+    } else {
+      fd.append(k, String(v));
+    }
+  }
+  if (file) fd.append("file", file);
+  return fd;
+}
+
+// CREATE a document source. Multipart so an optional file can be uploaded
+// alongside the metadata. axios sets the multipart boundary from the FormData.
+export async function createSource<T = Record<string, unknown>>(
+  fields: SourceWriteFields,
+  file?: File | null,
+): Promise<T> {
+  const { data } = await client.post<T>(
+    "/api/sources/",
+    buildSourceFormData(fields, file),
+  );
+  return data;
+}
+
+// UPDATE a source. Also multipart (a replacement file may be attached). Uses
+// PATCH so partial field updates don't wipe unspecified fields.
+export async function updateSource<T = Record<string, unknown>>(
+  id: number | string,
+  fields: SourceWriteFields,
+  file?: File | null,
+): Promise<T> {
+  const { data } = await client.patch<T>(
+    `/api/sources/${id}/`,
+    buildSourceFormData(fields, file),
+  );
+  return data;
+}
+
+// Soft-delete a source (204).
+export async function deleteSource(id: number | string): Promise<void> {
+  await client.delete(`/api/sources/${id}/`);
 }
 
 export { client as adminClient };

--- a/src/services/ngm-api.ts
+++ b/src/services/ngm-api.ts
@@ -1,16 +1,15 @@
 /**
  * NGM API Client (governance / judicial materials + court cases)
  *
- * NGM data lives on the Think-Big monolith under the host-root `/api/ngm/` prefix
- * (distinct from the Jawafdehi `/api/` tree and the NES `/api/nes/` tree). Reads are
- * public — materials and court cases are derived from public-domain government
- * documents.
+ * NGM data lives on the Think-Big monolith under the SINGLE unified `/api` root
+ * (the former per-service `/api/ngm` prefix was hard-cut). Reads are public —
+ * materials and court cases are derived from public-domain government documents.
  *
- *   GET /api/ngm/materials/<source>/<ident>      -> material JSON-LD (schema.org)
- *   GET /api/ngm/cases/<court>/<case_number>/    -> court case (composite key)
- *   GET /api/ngm/cases/<court>/<case_number>/{hearings,entities,documents}
+ *   GET /api/materials/<source>/<ident>          -> material JSON-LD (schema.org)
+ *   GET /api/courtcases/<court>/<case_number>/   -> court case (composite key)
+ *   GET /api/courtcases/<court>/<case_number>/{hearings,entities,documents}
  *
- * Base URL defaults to the SAME-ORIGIN relative `/api/ngm` so the Vite dev proxy /
+ * Base URL defaults to the SAME-ORIGIN relative `/api` so the Vite dev proxy /
  * monolith ingress resolves it. An absolute override (VITE_NGM_API_BASE_URL) is
  * supported for split-host deployments. NOTE: keep the default RELATIVE — an
  * absolute prod default would make a containerized frontend bypass the proxy and
@@ -23,7 +22,7 @@ import type { CourtCase, CourtCaseHearing, CourtCaseEntity } from '@/types/jds';
 
 const NGM_API_BASE_URL =
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_NGM_API_BASE_URL) ||
-  '/api/ngm';
+  '/api';
 
 // A material @id IRI path component (`<source>/<ident>`) or a full IRI. The detail
 // route is a splat, so the tail may already be the `<source>/<ident>` form.
@@ -98,10 +97,10 @@ export async function getCourtCase(courtOrRef: string, caseNumber?: string): Pro
     caseNumber === undefined
       ? parseCourtCaseRef(courtOrRef)
       : { court: courtOrRef, caseNumber };
-  // Composite-key detail route is /cases/<court>/<case_number>/ (mounted at
-  // /api/ngm/), NOT nested under /courts/. Case numbers contain hyphens but no
+  // Composite-key detail route is /courtcases/<court>/<case_number>/ (mounted at
+  // /api/), NOT nested under /courts/. Case numbers contain hyphens but no
   // slashes; encode each segment.
-  const endpoint = `/cases/${encodeURIComponent(court)}/${encodeURIComponent(number)}/`;
+  const endpoint = `/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(number)}/`;
   try {
     const response = await axios.get<CourtCase>(`${NGM_API_BASE_URL}${endpoint}`);
     return response.data;
@@ -123,7 +122,7 @@ async function getCaseSubResource<T>(
   caseNumber: string,
   sub: 'hearings' | 'entities' | 'documents',
 ): Promise<T[]> {
-  const endpoint = `/cases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}/${sub}`;
+  const endpoint = `/courtcases/${encodeURIComponent(court)}/${encodeURIComponent(caseNumber)}/${sub}`;
   try {
     const response = await axios.get<Paginated<T> | T[]>(`${NGM_API_BASE_URL}${endpoint}`);
     const data = response.data;


### PR DESCRIPTION
## Frontend: unified `/api` paths + full admin CRUD (R4 + R5b)

Binds the SPA to the post-hard-cut unified API surface and completes admin CRUD for the 4 unified resources.

- **R4** — migrate all call sites off `/api/nes/*` + `/api/ngm/*` to the unified paths (`admin-api.ts` ~19 sites, `ngm-api.ts` base → `/api/courtcases` + `/api/materials`).
- **R5b** — full L/G/C/U/D in the React admin: add delete (confirm dialogs) for entities/courtcases, materials **list page** + delete, and create/edit forms for corruption-cases + sources.

Pairs with the backend control-plane PR on `JawafdehiAPI:v2`.
