### PR TITLE
Admin follow-up: address #163 review (pagination, dev-auth dedupe, SSR timeout, a11y, +10 more)

### DIFF
--- a/docs/testing/django-admin-decommission-plan.md
+++ b/docs/testing/django-admin-decommission-plan.md
@@ -50,7 +50,7 @@ replaced, the form cannot be deleted.
 | `CaseViewSet.create()` | `form = CaseAdminForm(data=…, request=request)` `api_views.py:351` | **Replace** with serializer + `Case.validate()` (Task A1) |
 | Django admin `CaseAdmin` | `form = CaseAdminForm`, inlines, `save_related` gate `admin.py:426,702` | **Delete** custom form/inlines → stock `ModelAdmin` or unregister (Task D) |
 | Django admin `DocumentSourceAdmin` | `form = DocumentSourceAdminForm` `admin.py:874` | **Delete** custom form → stock (Task D) |
-| Custom widgets | `ToastUIEditorWidget`, `MultiTimelineField`, `MultiEvidenceField`, `MultiCourtCaseField`, `MultiTextField`, Nepali date | only used by the admin forms | **Delete** with the forms (Task D) |
+| Custom widgets | `ToastUIEditorWidget`, `MultiTimelineField`, `MultiEvidenceField`, `MultiCourtCaseField`, `MultiTextField`, Nepali date (only used by the admin forms) | **Delete** with the forms (Task D) |
 | `CaseViewSet.partial_update()` | pure serializer + model rules already | keep; **extend** transitions (Task A2) |
 
 > Note the irony in the create docstring: *"delegating validation to the

--- a/src/components/admin/FormPageShell.tsx
+++ b/src/components/admin/FormPageShell.tsx
@@ -31,8 +31,13 @@ export default function FormPageShell({
 }: FormPageShellProps) {
   if (loading) {
     return (
-      <div className="flex min-h-[40vh] items-center justify-center">
+      <div
+        className="flex min-h-[40vh] items-center justify-center"
+        role="status"
+        aria-live="polite"
+      >
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        <span className="sr-only">Loading…</span>
       </div>
     );
   }

--- a/src/components/admin/datalake/MaterialFileUpload.tsx
+++ b/src/components/admin/datalake/MaterialFileUpload.tsx
@@ -44,6 +44,9 @@ export default function MaterialFileUpload({
   const [materialType, setMaterialType] = useState<string>("document");
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Bumped after a successful upload to remount the uncontrolled <input
+  // type="file"> so its displayed filename clears with the state.
+  const [inputKey, setInputKey] = useState(0);
 
   const upload = async () => {
     if (!file) return;
@@ -63,6 +66,7 @@ export default function MaterialFileUpload({
       );
       toast({ title: "File uploaded", description: file.name });
       setFile(null);
+      setInputKey((k) => k + 1);
       onUploaded?.(res);
     } catch (err) {
       setError(adminErrorMessage(err, "Upload failed"));
@@ -79,6 +83,7 @@ export default function MaterialFileUpload({
       </p>
 
       <input
+        key={inputKey}
         type="file"
         onChange={(e) => setFile(e.target.files?.[0] ?? null)}
         className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-slate-100 file:px-3 file:py-1.5 file:text-sm file:font-medium hover:file:bg-slate-200"

--- a/src/hooks/useAdminForm.ts
+++ b/src/hooks/useAdminForm.ts
@@ -24,6 +24,11 @@ interface UseAdminFormOptions<T> {
   listPath: string;
   // Human label for toasts + fallback error messages (e.g. "court").
   resourceLabel: string;
+  // Identity of the record being edited (e.g. the route PK). Included in the
+  // load effect's deps so navigating between two edit routes on the SAME mounted
+  // component (React Router reuses the instance) re-fetches the new record
+  // instead of keeping the previous one's field values.
+  recordKey?: string;
 }
 
 interface UseAdminFormResult {
@@ -46,6 +51,7 @@ export function useAdminForm<T>({
   hydrate,
   listPath,
   resourceLabel,
+  recordKey,
 }: UseAdminFormOptions<T>): UseAdminFormResult {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(editing);
@@ -79,7 +85,7 @@ export function useAdminForm<T>({
     return () => {
       alive = false;
     };
-  }, [editing, resourceLabel]);
+  }, [editing, resourceLabel, recordKey]);
 
   const handleSubmit = useCallback(
     (canSave: boolean, save: () => Promise<void>) =>

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -65,6 +65,9 @@ export default function CaseworkReviews() {
   const [submitting, setSubmitting] = useState(false);
   const [rerunningSlug, setRerunningSlug] = useState<string | null>(null);
   const [err, setErr] = useState("");
+  // Separate from `err` (which renders under the submit input) so a regrade-all
+  // failure surfaces next to the Regrade-all button, not the submit form.
+  const [regradeErr, setRegradeErr] = useState("");
   const [conflictId, setConflictId] = useState<number | null>(null);
 
   // Load the first page of cases. When called by polling (isPoll), only merge the
@@ -156,7 +159,7 @@ export default function CaseworkReviews() {
   // newly-queued runs appear.
   const onRegradeAll = async () => {
     setRegrading(true);
-    setErr("");
+    setRegradeErr("");
     try {
       const res = await regradeAll();
       toast({
@@ -165,7 +168,7 @@ export default function CaseworkReviews() {
       });
       await loadFirst(true);
     } catch (e: unknown) {
-      setErr(apiErrorMessage(e, "Regrade-all failed."));
+      setRegradeErr(apiErrorMessage(e, "Regrade-all failed."));
     } finally {
       setRegrading(false);
     }
@@ -185,20 +188,25 @@ export default function CaseworkReviews() {
             </p>
           </div>
           {isModerator && (
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={regrading}
-              title="Queue a fresh review for every reviewable case against the current rules"
-              onClick={onRegradeAll}
-            >
-              {regrading ? (
-                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-              ) : (
-                <Repeat className="mr-1 h-4 w-4" />
+            <div className="flex flex-col items-end gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={regrading}
+                title="Queue a fresh review for every reviewable case against the current rules"
+                onClick={onRegradeAll}
+              >
+                {regrading ? (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                ) : (
+                  <Repeat className="mr-1 h-4 w-4" />
+                )}
+                Regrade all
+              </Button>
+              {regradeErr && (
+                <p className="text-sm text-red-600 text-right">{regradeErr}</p>
               )}
-              Regrade all
-            </Button>
+            </div>
           )}
         </div>
 

--- a/src/pages/admin/datalake/CourtCaseForm.tsx
+++ b/src/pages/admin/datalake/CourtCaseForm.tsx
@@ -82,6 +82,7 @@ export default function CourtCaseForm() {
         }),
       listPath: LIST_PATH,
       resourceLabel: "case",
+      recordKey: `${params.court ?? ""}/${params.caseNumber ?? ""}`,
     });
 
   const nesIdValid = !form.nes_id || isValidEntityIri(form.nes_id);

--- a/src/pages/admin/datalake/CourtForm.tsx
+++ b/src/pages/admin/datalake/CourtForm.tsx
@@ -45,6 +45,7 @@ export default function CourtForm() {
         }),
       listPath: LIST_PATH,
       resourceLabel: "court",
+      recordKey: identifier,
     });
 
   const canSave = !saving && str(form.identifier).trim() !== "";
@@ -52,6 +53,9 @@ export default function CourtForm() {
   const onSubmit = handleSubmit(canSave, async () => {
     const payload: CourtWrite = {
       ...form,
+      // identifier is the natural key and immutable after create — trim so a
+      // stray leading/trailing space isn't baked into the record permanently.
+      identifier: str(form.identifier).trim(),
       full_name_english: form.full_name_english || null,
       full_name_nepali: form.full_name_nepali || null,
       court_type: form.court_type || null,

--- a/src/pages/admin/datalake/Courts.tsx
+++ b/src/pages/admin/datalake/Courts.tsx
@@ -20,6 +20,8 @@ const columns: Column<Row>[] = [
   { header: "Type", cell: (r) => str(r.court_type) },
 ];
 
+const PAGE_SIZE = 25;
+
 export default function Courts() {
   const navigate = useNavigate();
   return (
@@ -27,6 +29,7 @@ export default function Courts() {
       title="Courts"
       description="Courts. Create and edit court records."
       columns={columns}
+      pageSize={PAGE_SIZE}
       rowKey={(r) => str(r.identifier)}
       onRowClick={(r) => {
         const id = str(r.identifier);
@@ -37,7 +40,9 @@ export default function Courts() {
           <Plus className="mr-1 h-4 w-4" /> New Court
         </Button>
       }
-      fetchPage={() => listCourts<Row>()}
+      fetchPage={(page) =>
+        listCourts<Row>({ limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
+      }
     />
   );
 }

--- a/src/pages/admin/datalake/FirmForm.tsx
+++ b/src/pages/admin/datalake/FirmForm.tsx
@@ -62,6 +62,7 @@ export default function FirmForm() {
         }),
       listPath: LIST_PATH,
       resourceLabel: "firm",
+      recordKey: id,
     });
 
   const canSave = !saving && str(form.firm_name).trim() !== "";

--- a/src/pages/admin/datalake/Firms.tsx
+++ b/src/pages/admin/datalake/Firms.tsx
@@ -16,6 +16,8 @@ const columns: Column<Row>[] = [
   { header: "Blocklisted", cell: (r) => str(r.blacklist_date_ad ?? r.blacklist_date_bs) },
 ];
 
+const PAGE_SIZE = 25;
+
 // F7 — blocklisted firms list. Firms are keyed by their numeric `id` (the model
 // PK); firm names are not unique, so the row/route key is the id.
 export default function Firms() {
@@ -25,6 +27,7 @@ export default function Firms() {
       title="Blocklisted firms"
       description="Blocklisted firms. Create and edit firm records."
       columns={columns}
+      pageSize={PAGE_SIZE}
       rowKey={(r) => str(r.id)}
       onRowClick={(r) => {
         const id = str(r.id);
@@ -35,7 +38,9 @@ export default function Firms() {
           <Plus className="mr-1 h-4 w-4" /> New Firm
         </Button>
       }
-      fetchPage={() => listBlacklistedFirms<Row>()}
+      fetchPage={(page) =>
+        listBlacklistedFirms<Row>({ limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
+      }
     />
   );
 }

--- a/src/pages/admin/datalake/MaterialForm.tsx
+++ b/src/pages/admin/datalake/MaterialForm.tsx
@@ -220,8 +220,15 @@ export default function MaterialForm() {
         (() => {
           const parts = iri ? parseMaterialIri(iri) : null;
           const lastSlash = refPath.lastIndexOf("/");
-          const source = parts?.source ?? refPath.slice(0, lastSlash);
-          const ident = parts?.ident ?? refPath.slice(lastSlash + 1);
+          // Fall back to splitting refPath ONLY when it actually contains a
+          // slash — otherwise slice(0, -1) would silently truncate and ident
+          // would be the whole (wrong) string, passing the non-empty guard.
+          const fallback =
+            lastSlash > 0
+              ? { source: refPath.slice(0, lastSlash), ident: refPath.slice(lastSlash + 1) }
+              : { source: "", ident: "" };
+          const source = parts?.source ?? fallback.source;
+          const ident = parts?.ident ?? fallback.ident;
           if (!source || !ident) return null;
           return (
             <MaterialFileUpload

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -152,7 +152,7 @@ const allRels = [
 
 ### Allegation & Case Endpoints
 
-**Note:** The entity API provides entity data only. Allegations and cases will be handled by a separate API (Jawafdehi) to be integrated later.
+**Note:** Case and allegation handling is integrated via `jds-api.ts` and `casework-api.ts` (and the `/admin` panel), all on the unified `/api` surface through the shared `http` client. This section documents the entity endpoints; see those modules for case/allegation CRUD.
 
 ```typescript
 const allegations = await getEntityAllegations('entity-slug');

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -175,15 +175,17 @@ export async function listCourtCases<T = Record<string, unknown>>(
   return data;
 }
 
-export async function listCourts<T = Record<string, unknown>>(): Promise<Paginated<T>> {
-  const { data } = await client.get<Paginated<T>>("/api/courts/");
+export async function listCourts<T = Record<string, unknown>>(
+  params: Record<string, unknown> = {},
+): Promise<Paginated<T>> {
+  const { data } = await client.get<Paginated<T>>("/api/courts/", { params });
   return data;
 }
 
-export async function listBlacklistedFirms<T = Record<string, unknown>>(): Promise<
-  Paginated<T>
-> {
-  const { data } = await client.get<Paginated<T>>("/api/firms/");
+export async function listBlacklistedFirms<T = Record<string, unknown>>(
+  params: Record<string, unknown> = {},
+): Promise<Paginated<T>> {
+  const { data } = await client.get<Paginated<T>>("/api/firms/", { params });
   return data;
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -172,7 +172,7 @@ export async function getEntities(params?: EntitySearchParams): Promise<EntityLi
     });
     return response.data;
   } catch (error) {
-    handleApiError(error, '/entities');
+    handleApiError(error, '/api/entities');
   }
 }
 
@@ -225,7 +225,7 @@ export async function getEntityById(idOrSlug: string): Promise<Entity> {
     return response.data;
   } catch (error) {
     const encodedId = encodeURIComponent(idOrSlug);
-    handleApiError(error, `/entities/${encodedId}`);
+    handleApiError(error, `/api/entities/${encodedId}`);
   }
 }
 
@@ -420,7 +420,7 @@ export async function healthCheck(): Promise<{ status: string }> {
     const response = await http.get('/api/health', { timeout: 30000 });
     return response.data;
   } catch (error) {
-    handleApiError(error, '/health');
+    handleApiError(error, '/api/health');
   }
 }
 

--- a/src/services/dev-auth-constants.ts
+++ b/src/services/dev-auth-constants.ts
@@ -1,0 +1,10 @@
+// Shared DEV_AUTH constants. Both the unified HTTP client (http.ts, which
+// attaches X-CSRFToken on writes) and the dev-auth service (dev-auth.ts, which
+// stores the token) must agree on the exact localStorage keys and the flag, or
+// CSRF headers silently break with no compiler signal. Defined once here.
+
+export const DEV_AUTH_ENABLED = import.meta.env.VITE_DEV_AUTH === "true";
+
+// localStorage keys for the dev-auth session snapshot.
+export const DEV_AUTH_USER_KEY = "jawafdehi.devAuth.user";
+export const DEV_AUTH_CSRF_KEY = "jawafdehi.devAuth.csrf";

--- a/src/services/dev-auth.ts
+++ b/src/services/dev-auth.ts
@@ -11,12 +11,15 @@
 // user (and the CSRF token) in localStorage so a page reload stays logged in
 // without a token, and so admin-api.ts can attach X-CSRFToken to writes.
 import { http, API_BASE_URL } from "./http";
+import {
+  DEV_AUTH_ENABLED,
+  DEV_AUTH_USER_KEY as STORAGE_KEY,
+  DEV_AUTH_CSRF_KEY as CSRF_KEY,
+} from "./dev-auth-constants";
 import type { CaseworkUser } from "@/types/casework";
 
-export const DEV_AUTH_ENABLED = import.meta.env.VITE_DEV_AUTH === "true";
-
-const STORAGE_KEY = "jawafdehi.devAuth.user";
-const CSRF_KEY = "jawafdehi.devAuth.csrf";
+// Re-exported for existing importers (CaseworkAuthContext, CaseworkLogin).
+export { DEV_AUTH_ENABLED };
 
 // Dev-login runs the unified client with `withCredentials` forced per-call, so
 // the browser includes the sessionid cookie even before any token exists

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -18,6 +18,7 @@
 // SSO/OIDC-only — the dev-auth branch is inert without the flag.
 import axios, { type AxiosInstance } from "axios";
 import { getAccessToken } from "./oidc";
+import { DEV_AUTH_ENABLED, DEV_AUTH_CSRF_KEY } from "./dev-auth-constants";
 
 // Resolve the monolith origin. An explicit override wins; else same-origin.
 export const API_BASE_URL: string = (() => {
@@ -27,12 +28,18 @@ export const API_BASE_URL: string = (() => {
   return "";
 })();
 
-const DEV_AUTH_ENABLED = import.meta.env.VITE_DEV_AUTH === "true";
-const CSRF_STORAGE_KEY = "jawafdehi.devAuth.csrf";
 const UNSAFE_METHODS = new Set(["post", "put", "patch", "delete"]);
 
+// Default request timeout (ms). Bounds every call — most importantly the SSR
+// prefetches in entry-server.tsx, where a stalled backend would otherwise block
+// server rendering indefinitely. Per-call `timeout` overrides still win.
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 /** The shared axios instance. Import this (or the `http` alias) everywhere. */
-export const http: AxiosInstance = axios.create({ baseURL: API_BASE_URL });
+export const http: AxiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: DEFAULT_TIMEOUT_MS,
+});
 
 http.interceptors.request.use(async (config) => {
   const token = await getAccessToken();
@@ -42,7 +49,7 @@ http.interceptors.request.use(async (config) => {
     // DEV_AUTH session: no bearer — ride the session cookie + CSRF on writes.
     config.withCredentials = true;
     const method = (config.method || "get").toLowerCase();
-    const csrf = window.localStorage.getItem(CSRF_STORAGE_KEY);
+    const csrf = window.localStorage.getItem(DEV_AUTH_CSRF_KEY);
     if (csrf && UNSAFE_METHODS.has(method)) {
       config.headers["X-CSRFToken"] = csrf;
     }

--- a/src/services/jds-api.ts
+++ b/src/services/jds-api.ts
@@ -316,8 +316,9 @@ export async function submitFeedback(feedback: FeedbackSubmission): Promise<Feed
       if (feedback.relatedPage) formData.append('relatedPage', feedback.relatedPage);
       if (feedback.contactInfo) formData.append('contactInfo', JSON.stringify(feedback.contactInfo));
       formData.append('attachment', feedback.attachment);
+      // Let axios derive the multipart Content-Type from the FormData so it
+      // includes the required boundary (an explicit header omits it).
       const response = await http.post<FeedbackResponse>('/api/feedback/', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
         timeout: 10000,
       });
       return response.data;


### PR DESCRIPTION
Post-merge follow-up to #163, addressing the CodeRabbit review (13 inline comments) plus findings from an independent review pass. Branched off the merged `v2`.

## Correctness
- **Courts + Firms list pagination was a no-op** — `fetchPage` ignored the page arg, so "Next" re-fetched page 1. `listCourts`/`listBlacklistedFirms` now accept params; both pages forward `limit`/`offset` (matching `CourtCases`).
- **CourtForm** — trim `identifier` before submit; it's the immutable natural key, so a stray space would be baked in permanently (`FirmForm` already trimmed `firm_name`).
- **MaterialForm** — guard the `source`/`ident` fallback when the route ref has no slash (`lastIndexOf` → `-1` made `slice(0,-1)` silently truncate; the non-empty guard didn't catch it, so the upload targeted a bogus `source`/`ident`).
- **useAdminForm** — include the record key in the load effect's deps, so navigating between two edit routes on the same mounted component re-fetches instead of reusing stale field values (edit→edit / edit→new). *(Found in follow-up review, not CodeRabbit — latent today since every form is reached via its list page, but a data-corruption risk the moment such a link is added.)*
- **CaseworkReviews** — regrade-all errors reused the submit form's error state and surfaced next to the unrelated slug input; gave it its own state next to the button.

## Robustness / consistency
- **http.ts** — 30s default timeout on the shared client (bounds the SSR prefetches in `entry-server` so a stalled backend can't block server render).
- **dev-auth** — dedupe the `DEV_AUTH` flag + CSRF/user localStorage keys into `services/dev-auth-constants.ts` (`http.ts` and `dev-auth.ts` must agree on the CSRF key or write headers silently break).
- **jds-api** — drop the explicit multipart `Content-Type` so axios sets the boundary.
- **api.ts** — error `endpoint` labels now match the actual `/api`-prefixed paths.

## Minor / UX / a11y
- `FormPageShell` loading spinner gets `role="status"` + sr-only text.
- `MaterialFileUpload` remounts the file input after upload so the filename clears.
- README: case/allegation API is integrated (was "to be integrated later").
- Fixed a malformed 4-cell row in the decommission-plan markdown table.

## Verification
- `tsc` + `eslint` clean; **93 tests pass**; client + SSR builds pass.

Companion backend PR: JawafdehiAPI #267 (the endpoints the merged admin panel calls).