### PR TITLE
Frontend contract catch-up: migrate evidence to embedded materials, drop /api/sources, fix entity links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,24 @@
 # API Configuration
-# Nepal Entity Service (Tundikhel) API URL
-VITE_API_BASE_URL=http://localhost:8000/api
+# Origin of the consolidated Jawafdehi API (the monolith serving /api/*).
+# All service clients share this base (entities, cases, courts, materials,
+# search, statistics, feedback). When unset, the app talks to the same origin
+# it is served from. For local dev, point it at your backend, e.g.:
+#   VITE_JAWAFDEHI_API_BASE_URL=http://127.0.0.1:48010
+VITE_JAWAFDEHI_API_BASE_URL=
 
-# Jawafdehi (Accountability) API URL
-VITE_JDS_API_BASE_URL=https://portal.jawafdehi.org/api
-
-# OIDC Configuration (auth provider for the casework portal)
-# Authority / issuer URL of the OIDC provider
+# OIDC Configuration (auth provider for the casework/admin portal)
+# Authority / issuer URL of the OIDC provider.
 VITE_OIDC_AUTHORITY=https://auth.jawafdehi.org
 
-# OIDC client id for the casework portal SPA
+# OIDC client id for the portal SPA.
 VITE_OIDC_CLIENT_ID=your_client_id_here
 
 # Token audience — the provider's project/resource id, used in the OIDC scope.
-# Required.
 VITE_OIDC_AUDIENCE=your_audience_here
 
-# Sentry error monitoring (set in GitHub Secrets for CI, optional for local dev)
-# VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+# DEV-ONLY: enable the username/password login form (dev-auth). Production is
+# OIDC/Zitadel only; set to "true" ONLY for local development.
+# VITE_DEV_AUTH=false
 
 # Feature Flags
 # Enable the online case submission form (true) or show template download links (false)

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -20,8 +20,8 @@ interface CaseCardProps {
   tags?: string[];
   description: string;
   allegations?: string[]; // Key allegations array
-  entityIds?: number[]; // Jawaf entity IDs
-  locationIds?: number[]; // Jawaf entity IDs
+  entityIds?: string[]; // NES entity @id IRIs (used to link to /entity/:id)
+  locationIds?: string[]; // NES entity @id IRIs
   thumbnailUrl?: string; //Thumbnail image
   viewMode?: "grid" | "list";
   hideDescription?: boolean;
@@ -197,13 +197,13 @@ function CaseCardTags({ tags }: Readonly<{ tags: string[] }>) {
   );
 }
 
-function EntityRow({ icon: Icon, label, title, ids }: Readonly<{ icon: typeof User; label: string; title?: string; ids?: number[] }>) {
+function EntityRow({ icon: Icon, label, title, ids }: Readonly<{ icon: typeof User; label: string; title?: string; ids?: string[] }>) {
   return (
     <div className="flex min-w-0 items-center">
       <Icon className="mr-2 h-4 w-4 flex-shrink-0" aria-hidden="true" />
       {ids && ids.length > 0 ? (
         <Link
-          to={`/entity/${ids[0]}`}
+          to={`/entity/${encodeURIComponent(ids[0])}`}
           className="block min-w-0 truncate rounded-sm transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           title={title}
           onClick={(e) => e.stopPropagation()}

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MapPin, User } from "lucide-react";
+import { entityPath } from "@/lib/entity-links";
 
 const nepaliDigits = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
 
@@ -198,12 +199,13 @@ function CaseCardTags({ tags }: Readonly<{ tags: string[] }>) {
 }
 
 function EntityRow({ icon: Icon, label, title, ids }: Readonly<{ icon: typeof User; label: string; title?: string; ids?: string[] }>) {
+  const to = ids && ids.length > 0 ? entityPath(ids[0]) : null;
   return (
     <div className="flex min-w-0 items-center">
       <Icon className="mr-2 h-4 w-4 flex-shrink-0" aria-hidden="true" />
-      {ids && ids.length > 0 ? (
+      {to ? (
         <Link
-          to={`/entity/${encodeURIComponent(ids[0])}`}
+          to={to}
           className="block min-w-0 truncate rounded-sm transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           title={title}
           onClick={(e) => e.stopPropagation()}

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -21,8 +21,8 @@ interface CaseCardProps {
   tags?: string[];
   description: string;
   allegations?: string[]; // Key allegations array
-  entityIds?: string[]; // NES entity @id IRIs (used to link to /entity/:id)
-  locationIds?: string[]; // NES entity @id IRIs
+  entityIds?: string[]; // NES entity @id IRIs (used to link to /entity/*)
+  locationIds?: string[]; // NES entity @id IRIs (used to link to /entity/*)
   thumbnailUrl?: string; //Thumbnail image
   viewMode?: "grid" | "list";
   hideDescription?: boolean;

--- a/src/components/CaseDetailBanner.tsx
+++ b/src/components/CaseDetailBanner.tsx
@@ -125,14 +125,21 @@ export function CaseDetailBanner({
             <div className="flex flex-wrap gap-1">
               <span className="sr-only">{t("entityCard.location")}: </span>
               {locationEntities.length > 0
-                ? locationEntities.map((entity, index) => (
-                  <span key={entity.id}>
-                    <Link to={`/entity/${entity.id}`} className="text-white hover:underline">
-                      {getEntityDisplayName(entity)}
-                    </Link>
-                    {index < locationEntities.length - 1 && ", "}
-                  </span>
-                ))
+                ? locationEntities.map((entity, index) => {
+                  const key = entity.nes_id ?? `${entity.display_name ?? 'location'}-${index}`;
+                  return (
+                    <span key={key}>
+                      {entity.nes_id ? (
+                        <Link to={`/entity/${encodeURIComponent(entity.nes_id)}`} className="text-white hover:underline">
+                          {getEntityDisplayName(entity)}
+                        </Link>
+                      ) : (
+                        <span>{getEntityDisplayName(entity)}</span>
+                      )}
+                      {index < locationEntities.length - 1 && ", "}
+                    </span>
+                  );
+                })
                 : notAvailableLabel}
             </div>
           </div>

--- a/src/components/CaseDetailBanner.tsx
+++ b/src/components/CaseDetailBanner.tsx
@@ -11,6 +11,7 @@ import { getPrimaryName } from "@/utils/entity-helpers";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { formatBigo } from "@/utils/number";
 import { getCaseTypeLabelKey } from "@/utils/case-entities";
+import { entityPath } from "@/lib/entity-links";
 
 interface CaseDetailBannerProps {
   caseData: CaseDetail;
@@ -127,10 +128,11 @@ export function CaseDetailBanner({
               {locationEntities.length > 0
                 ? locationEntities.map((entity, index) => {
                   const key = entity.nes_id ?? `${entity.display_name ?? 'location'}-${index}`;
+                  const to = entityPath(entity.nes_id);
                   return (
                     <span key={key}>
-                      {entity.nes_id ? (
-                        <Link to={`/entity/${encodeURIComponent(entity.nes_id)}`} className="text-white hover:underline">
+                      {to ? (
+                        <Link to={to} className="text-white hover:underline">
                           {getEntityDisplayName(entity)}
                         </Link>
                       ) : (

--- a/src/components/CaseEntityChips.tsx
+++ b/src/components/CaseEntityChips.tsx
@@ -78,7 +78,7 @@ export function CaseEntityChips({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-x-4 gap-y-2 justify-center sm:justify-start">
-        {displayedEntities.map((jawafEntity) => {
+        {displayedEntities.map((jawafEntity, index) => {
           const entity = jawafEntity.nes_id ? resolvedEntities[jawafEntity.nes_id] ?? null : null;
           const displayName = getDisplayName(jawafEntity, entity, language);
           const imageUrl = getEntityImage(entity);
@@ -87,13 +87,13 @@ export function CaseEntityChips({
             ? jawafEntity.notes.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim()
             : "";
           const strippedNotes = rawNotes ? translateDynamicText(rawNotes, language) : "";
+          // Case entities are keyed on their NES @id IRI (the backend no longer
+          // returns a numeric id). Fall back to display_name/index for id-less binds.
+          const key = jawafEntity.nes_id ?? `${jawafEntity.display_name ?? 'entity'}-${index}`;
+          const to = jawafEntity.nes_id ? `/entity/${encodeURIComponent(jawafEntity.nes_id)}` : undefined;
 
-          return (
-            <Link
-              key={jawafEntity.id}
-              to={`/entity/${jawafEntity.id}`}
-              className="group flex w-[11rem] flex-col items-center gap-2 rounded-2xl px-3 py-3 text-center transition-all duration-200 hover:bg-muted/40"
-            >
+          const inner = (
+            <>
               <Avatar className="h-16 w-16 border border-border/80 shadow-sm transition-transform group-hover:scale-105">
                 {imageUrl ? (
                   <AvatarImage src={imageUrl} alt={displayName} className="object-cover" />
@@ -110,6 +110,27 @@ export function CaseEntityChips({
                   {strippedNotes}
                 </span>
               )}
+            </>
+          );
+
+          if (!to) {
+            return (
+              <div
+                key={key}
+                className="group flex w-[11rem] flex-col items-center gap-2 rounded-2xl px-3 py-3 text-center"
+              >
+                {inner}
+              </div>
+            );
+          }
+
+          return (
+            <Link
+              key={key}
+              to={to}
+              className="group flex w-[11rem] flex-col items-center gap-2 rounded-2xl px-3 py-3 text-center transition-all duration-200 hover:bg-muted/40"
+            >
+              {inner}
             </Link>
           );
         })}

--- a/src/components/CaseEntityChips.tsx
+++ b/src/components/CaseEntityChips.tsx
@@ -7,6 +7,7 @@ import type { Entity } from "@/types/entity";
 import { getPrimaryName } from "@/utils/entity-helpers";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { cn } from "@/lib/utils";
+import { entityPath } from "@/lib/entity-links";
 
 interface CaseEntityChipsProps {
   entities: JawafEntity[];
@@ -90,7 +91,7 @@ export function CaseEntityChips({
           // Case entities are keyed on their NES @id IRI (the backend no longer
           // returns a numeric id). Fall back to display_name/index for id-less binds.
           const key = jawafEntity.nes_id ?? `${jawafEntity.display_name ?? 'entity'}-${index}`;
-          const to = jawafEntity.nes_id ? `/entity/${encodeURIComponent(jawafEntity.nes_id)}` : undefined;
+          const to = entityPath(jawafEntity.nes_id) ?? undefined;
 
           const inner = (
             <>

--- a/src/components/DocumentSourceCard.tsx
+++ b/src/components/DocumentSourceCard.tsx
@@ -3,8 +3,8 @@ import type { ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import type {
-  DocumentSource,
   DocumentSourceType,
+  EvidenceMaterial,
   SourceLink,
   SourceLinkRole,
 } from "@/types/jds";
@@ -12,8 +12,13 @@ import { DocumentSourceTypeKeys } from "@/types/jds";
 import { getSourceTypeBadgeClass } from "@/utils/source-type-badge";
 
 interface DocumentSourceCardProps {
-  source: DocumentSource | null;
-  sourceId: number;
+  /**
+   * The resolved material embedded on the case-detail evidence entry
+   * (`{display_name, material_type, urls}`), or null when not yet available.
+   */
+  material: EvidenceMaterial | null;
+  /** The material @id IRI; used for a stable fallback title/key. */
+  materialIri: string;
   itemNumber: number;
   evidenceDescription?: string;
 }
@@ -44,16 +49,16 @@ const normalizeRole = (
 };
 
 /**
- * Build a clean, role-tagged list of links from a source's `urls` field.
+ * Build a clean, role-tagged list of links from a material's `urls` field.
  *
  * `urls` is the canonical source of links: each entry is a `{link, role}` dict
  * with an explicit role (RAW/MARKDOWN/PERMALINK). Invalid or non-http(s)
  * entries are dropped.
  */
-const resolveLinks = (source: DocumentSource | null): SourceLink[] => {
-  if (!source || !Array.isArray(source.urls)) return [];
+const resolveLinks = (material: EvidenceMaterial | null): SourceLink[] => {
+  if (!material || !Array.isArray(material.urls)) return [];
 
-  return source.urls
+  return material.urls
     .filter((u): u is SourceLink => Boolean(u?.link) && isAllowedScheme(u.link))
     .map((u) => ({ link: u.link.trim(), role: normalizeRole(u.role, u.link) }));
 };
@@ -112,22 +117,26 @@ const partitionLinks = (links: SourceLink[]) => {
 };
 
 export function DocumentSourceCard({
-  source,
-  sourceId,
+  material,
+  materialIri,
   itemNumber,
   evidenceDescription,
 }: DocumentSourceCardProps) {
   const { t } = useTranslation();
-  const links = resolveLinks(source);
+  const links = resolveLinks(material);
   const { primaryLinks, alternateLinks, markdownLinks } = partitionLinks(links);
 
+  // The material's type drives the source-type badge/tiering (it carries the
+  // same DocumentSourceType vocabulary as the former DocumentSource.source_type).
+  const materialType = material?.material_type ?? null;
+
   // Get source type label with i18n support and fallback for legacy types
-  const sourceTypeLabel = source?.source_type
-    ? DocumentSourceTypeKeys[source.source_type as DocumentSourceType]
-      ? t(DocumentSourceTypeKeys[source.source_type as DocumentSourceType])
-      : source.source_type
+  const sourceTypeLabel = materialType
+    ? DocumentSourceTypeKeys[materialType as DocumentSourceType]
+      ? t(DocumentSourceTypeKeys[materialType as DocumentSourceType])
+      : materialType
     : null;
-  const sourceTypeClass = getSourceTypeBadgeClass(source?.source_type);
+  const sourceTypeClass = getSourceTypeBadgeClass(materialType);
 
   // Only number a given role's links when there's more than one of that role,
   // so a lone "View original" doesn't get an awkward "1" suffix.
@@ -148,7 +157,7 @@ export function DocumentSourceCard({
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                 <h3 className="font-medium leading-snug text-foreground break-words">
-                  {source?.title || t("documentSource.fallbackTitle", { id: sourceId })}
+                  {material?.display_name || t("documentSource.fallbackTitle", { id: materialIri })}
                 </h3>
                 {sourceTypeLabel && (
                   <Badge variant="outline" className={`rounded-full px-2 py-0.5 text-xs font-medium ${sourceTypeClass}`}>
@@ -186,12 +195,6 @@ export function DocumentSourceCard({
               </div>
             )}
           </div>
-
-          {source?.description && source.description.trim() !== '.' && source.description.trim() && (
-            <p className="mt-1 text-sm leading-5 text-muted-foreground break-words">
-              {source.description}
-            </p>
-          )}
 
           {evidenceDescription && evidenceDescription.trim() !== '.' && evidenceDescription.trim() && (
             <p className="mt-2 text-sm leading-6 text-muted-foreground break-words">

--- a/src/components/guest/GuestCaseChatDrawer.tsx
+++ b/src/components/guest/GuestCaseChatDrawer.tsx
@@ -10,17 +10,14 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CaseTimeline } from "@/components/CaseTimeline";
 import { useGuestCaseChat } from "@/hooks/useGuestCaseChat";
-import type { CaseDetail, DocumentSource } from "@/types/jds";
+import type { GuestCaseSourceEntry } from "@/services/guest-chat-adapter";
+import type { CaseDetail } from "@/types/jds";
 
 interface GuestCaseChatDrawerProps {
   caseId: number;
   caseTitle: string;
   caseData: CaseDetail;
-  sources: Array<{
-    sourceId: number;
-    source: DocumentSource | null;
-    evidenceDescription?: string;
-  }>;
+  sources: GuestCaseSourceEntry[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }

--- a/src/lib/entity-links.test.ts
+++ b/src/lib/entity-links.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { matchRoutes } from "react-router-dom";
+import { entityPath } from "./entity-links";
+
+describe("entityPath", () => {
+  it("keeps the prefix/slug tail as multiple path segments (not %2F)", () => {
+    expect(entityPath("https://jawafdehi.org/entity/person/ram-shah")).toBe(
+      "/entity/person/ram-shah",
+    );
+  });
+
+  it("returns null for null/undefined/empty and non-entity IRIs", () => {
+    expect(entityPath(null)).toBeNull();
+    expect(entityPath(undefined)).toBeNull();
+    expect(entityPath("")).toBeNull();
+    expect(entityPath("https://jawafdehi.org/material/ciaa/doc-1")).toBeNull();
+  });
+
+  it("produces a path that matches the IRI-aware /entity/* splat route, not the numeric /entity/:id", () => {
+    // Mirror the two routes App.tsx registers for entities.
+    const routes = [
+      { path: "/entity/:id" },
+      { path: "/entity/*" },
+    ];
+    const path = entityPath("https://jawafdehi.org/entity/person/ram-shah");
+    expect(path).not.toBeNull();
+    const matched = matchRoutes(routes, path!);
+    expect(matched).not.toBeNull();
+    // The splat route (EntityRecordProfile) must win — its param "*" carries the
+    // full prefix/slug tail. The numeric ":id" route would parseInt() -> NaN.
+    const last = matched![matched!.length - 1];
+    expect(last.route.path).toBe("/entity/*");
+    expect(last.params["*"]).toBe("person/ram-shah");
+  });
+});

--- a/src/lib/entity-links.ts
+++ b/src/lib/entity-links.ts
@@ -1,0 +1,16 @@
+// Single source of truth for building the SPA path to an entity record page.
+//
+// Entity binds are keyed on the canonical NES `@id` IRI, e.g.
+//   https://jawafdehi.org/entity/person/ram-shah
+// The `/entity/*` route (EntityRecordProfile) reads the splat (`params["*"]`)
+// and fetches `/api/entities/<prefix>/<slug>`, so the link MUST keep the
+// `<prefix>/<slug>` tail as multiple path segments. Do NOT `encodeURIComponent`
+// the whole IRI — that turns the `/` into `%2F`, collapsing it to one segment
+// that instead matches the numeric `/entity/:id` route and fails to resolve.
+const ENTITY_MARKER = "/entity/";
+
+export function entityPath(iri: string | null | undefined): string | null {
+  if (!iri) return null;
+  const i = iri.indexOf(ENTITY_MARKER);
+  return i === -1 ? null : `/entity/${iri.slice(i + ENTITY_MARKER.length)}`;
+}

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -42,6 +42,7 @@ import { JAWAFDEHI_WHATSAPP_NUMBER, JAWAFDEHI_EMAIL } from "@/config/constants";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { trackEvent } from "@/utils/analytics";
 import { cn } from "@/lib/utils";
+import { entityPath } from "@/lib/entity-links";
 import { formatBigo } from "@/utils/number";
 import { resolveLegacyCaseSlug } from "@/utils/legacyCaseMap";
 import { isCourtCaseRef } from "@/utils/courtCaseRef";
@@ -400,10 +401,11 @@ const CaseDetail = () => {
                     let displayName = entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id || t('common.notAvailable');
                     displayName = translateDynamicText(displayName, currentLang);
                     const key = e.nes_id ?? `${e.display_name ?? 'entity'}-${index}`;
+                    const to = entityPath(e.nes_id);
                     return (
                       <span key={key}>
-                        {e.nes_id ? (
-                          <Link to={`/entity/${encodeURIComponent(e.nes_id)}`} className="text-primary hover:underline">{displayName}</Link>
+                        {to ? (
+                          <Link to={to} className="text-primary hover:underline">{displayName}</Link>
                         ) : (
                           <span className="text-foreground">{displayName}</span>
                         )}
@@ -428,10 +430,11 @@ const CaseDetail = () => {
                       let displayName = entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id || t('common.notAvailable');
                       displayName = translateDynamicText(displayName, currentLang);
                       const key = e.nes_id ?? `${e.display_name ?? 'location'}-${index}`;
+                      const to = entityPath(e.nes_id);
                       return (
                         <span key={key}>
-                          {e.nes_id ? (
-                            <Link to={`/entity/${encodeURIComponent(e.nes_id)}`} className="text-primary hover:underline">{displayName}</Link>
+                          {to ? (
+                            <Link to={to} className="text-primary hover:underline">{displayName}</Link>
                           ) : (
                             <span className="text-foreground">{displayName}</span>
                           )}

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -26,11 +26,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Banknote, Calendar, FileText, AlertTriangle, ArrowLeft, ExternalLink, AlertCircle, Info, Mail, MapPin, MessageCircle, Scale, StickyNote, User, Share2 } from "lucide-react";
-import { getCaseById, getCaseByCourtRef, getDocumentSourceById } from "@/services/jds-api";
+import { getCaseById, getCaseByCourtRef } from "@/services/jds-api";
 import { API_BASE_URL } from "@/services/http";
 import { getCourtCase } from "@/services/datalake-api";
 import { getEntityById } from "@/services/api";
-import type { CourtCase, DocumentSource, JawafEntity } from "@/types/jds";
+import type { CourtCase, JawafEntity } from "@/types/jds";
 import type { Entity } from "@/types/entity";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { formatCaseDateRange } from "@/utils/date";
@@ -59,11 +59,14 @@ const RELATION_PRIORITY: Record<string, number> = {
 };
 
 function getGroupedEntities(entities: JawafEntity[]) {
-  const seen = new Set<number>();
+  // Case entities are keyed on their NES @id IRI (the backend no longer returns
+  // a numeric id). Fall back to display_name so id-less binds still dedupe.
+  const seen = new Set<string>();
   return entities.reduce((groups, entity) => {
-    if (seen.has(entity.id) || entity.type === "location") return groups;
+    const key = entity.nes_id ?? entity.display_name ?? "";
+    if ((key && seen.has(key)) || entity.type === "location") return groups;
 
-    seen.add(entity.id);
+    if (key) seen.add(key);
     const type = entity.type || "unknown";
 
     if (!groups[type]) groups[type] = [];
@@ -189,15 +192,6 @@ const CaseDetail = () => {
   const visibleAccusedEntities = collapsedAccused ? bannerEntities.slice(0, BANNER_ACCUSED_LIMIT) : bannerEntities;
   const hiddenAccusedCount = accusedCount - visibleAccusedEntities.length;
 
-  const sourceQueries = useQueries({
-    queries: (caseData?.evidence ?? []).map((evidence) => ({
-      queryKey: ['source', evidence.source_id],
-      queryFn: () => getDocumentSourceById(evidence.source_id),
-      staleTime: 10 * 60 * 1000,
-      retry: false,
-    })),
-  });
-
   const uniqueNesIds = caseData
     ? [...new Set(caseData.entities.filter(e => e.nes_id).map(e => e.nes_id!))]
     : [];
@@ -234,12 +228,6 @@ const CaseDetail = () => {
     trackedCaseIdRef.current = loadedCaseId;
   }, [id, caseData?.id, isError]);
 
-  const resolvedSources: Record<number, DocumentSource> = {};
-  (caseData?.evidence ?? []).forEach((evidence, i) => {
-    const data = sourceQueries[i]?.data;
-    if (data) resolvedSources[evidence.source_id] = data;
-  });
-
   const resolvedEntities: Record<string, Entity> = {};
   uniqueNesIds.forEach((nesId, i) => {
     const data = entityQueries[i]?.data;
@@ -260,8 +248,7 @@ const CaseDetail = () => {
   };
 
   (caseData?.evidence ?? []).forEach((evidence, index) => {
-    const source = resolvedSources[evidence.source_id];
-    const group = getEvidenceGroup(source?.source_type);
+    const group = getEvidenceGroup(evidence.material?.material_type);
     groupedEvidence[group].push({ ...evidence, originalIndex: index });
   });
 
@@ -412,9 +399,14 @@ const CaseDetail = () => {
                     const entity = e.nes_id ? resolvedEntities[e.nes_id] : null;
                     let displayName = entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id || t('common.notAvailable');
                     displayName = translateDynamicText(displayName, currentLang);
+                    const key = e.nes_id ?? `${e.display_name ?? 'entity'}-${index}`;
                     return (
-                      <span key={e.id}>
-                        <Link to={`/entity/${e.id}`} className="text-primary hover:underline">{displayName}</Link>
+                      <span key={key}>
+                        {e.nes_id ? (
+                          <Link to={`/entity/${encodeURIComponent(e.nes_id)}`} className="text-primary hover:underline">{displayName}</Link>
+                        ) : (
+                          <span className="text-foreground">{displayName}</span>
+                        )}
                         {index < arr.length - 1 && ', '}
                       </span>
                     );
@@ -435,9 +427,14 @@ const CaseDetail = () => {
                       const entity = e.nes_id ? resolvedEntities[e.nes_id] : null;
                       let displayName = entity?.names?.[0]?.en?.full || entity?.names?.[0]?.ne?.full || e.display_name || e.nes_id || t('common.notAvailable');
                       displayName = translateDynamicText(displayName, currentLang);
+                      const key = e.nes_id ?? `${e.display_name ?? 'location'}-${index}`;
                       return (
-                        <span key={e.id}>
-                          <Link to={`/entity/${e.id}`} className="text-primary hover:underline">{displayName}</Link>
+                        <span key={key}>
+                          {e.nes_id ? (
+                            <Link to={`/entity/${encodeURIComponent(e.nes_id)}`} className="text-primary hover:underline">{displayName}</Link>
+                          ) : (
+                            <span className="text-foreground">{displayName}</span>
+                          )}
                           {index < locations.length - 1 && ', '}
                         </span>
                       );
@@ -597,18 +594,15 @@ const CaseDetail = () => {
                         </CardHeader>
                         <CardContent>
                           <div>
-                            {caseData.evidence.map((evidence, index) => {
-                              const source = resolvedSources[evidence.source_id] ?? null;
-                              return (
-                                <DocumentSourceCard
-                                  key={`${evidence.source_id}-${index}`}
-                                  source={source}
-                                  sourceId={evidence.source_id}
-                                  itemNumber={index + 1}
-                                  evidenceDescription={evidence.description}
-                                />
-                              );
-                            })}
+                            {caseData.evidence.map((evidence, index) => (
+                              <DocumentSourceCard
+                                key={`${evidence.material_iri}-${index}`}
+                                material={evidence.material ?? null}
+                                materialIri={evidence.material_iri}
+                                itemNumber={index + 1}
+                                evidenceDescription={evidence.additional_details}
+                              />
+                            ))}
                           </div>
                         </CardContent>
                       </Card>

--- a/src/pages/Cases.tsx
+++ b/src/pages/Cases.tsx
@@ -307,8 +307,8 @@ function CaseResults({
             tags={caseItem.tags || []}
             description={(caseItem.short_description ?? '').replace(/<[^>]*>/g, '').substring(0, 200)}
             allegations={caseItem.key_allegations}
-            entityIds={(caseItem.entities?.filter(e => e.type === 'accused') || []).map(e => e.id)}
-            locationIds={(caseItem.entities?.filter(e => e.type === 'location') || []).map(e => e.id)}
+            entityIds={(caseItem.entities?.filter(e => e.type === 'accused') || []).map(e => e.nes_id).filter((id): id is string => Boolean(id))}
+            locationIds={(caseItem.entities?.filter(e => e.type === 'location') || []).map(e => e.nes_id).filter((id): id is string => Boolean(id))}
             thumbnailUrl={caseItem.thumbnail_url ?? undefined}
             viewMode={viewMode}
           />

--- a/src/pages/EntityRecordProfile.tsx
+++ b/src/pages/EntityRecordProfile.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, AlertTriangle, ArrowLeft, ExternalLink } from "lucide-react";
 
 import { http } from "@/services/http";
+import { entityPath } from "@/lib/entity-links";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -48,13 +49,6 @@ interface EntityRecord {
   [key: string]: unknown;
 }
 
-// Entity IRI -> relative SPA path the /entity/* route resolves.
-const ENTITY_MARKER = "/entity/";
-function entityPath(iri: string | undefined): string | null {
-  if (!iri) return null;
-  const i = iri.indexOf(ENTITY_MARKER);
-  return i === -1 ? null : `/entity/${iri.slice(i + ENTITY_MARKER.length)}`;
-}
 // Human label from the last segment of an IRI (when we can't resolve the name).
 function iriLabel(iri: string | undefined): string {
   if (!iri) return "";

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -123,8 +123,8 @@ const Index = () => {
         allegations: caseItem.key_allegations, // Pass key allegations to CaseCard
         thumbnailUrl: caseItem.thumbnail_url ?? undefined,
         tags: caseItem.tags,
-        entityIds: namedEntities.map(e => e.id),
-        locationIds: locationEntities.map(l => l.id),
+        entityIds: namedEntities.map(e => e.nes_id).filter((id): id is string => Boolean(id)),
+        locationIds: locationEntities.map(l => l.nes_id).filter((id): id is string => Boolean(id)),
       };
     });
   }, [casesData, resolvedEntities, currentLang]);

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -14,7 +14,7 @@ This directory contains the API client and adapters for the entity backend integ
 `http` client (`src/services/http.ts`), which resolves the monolith origin from
 `VITE_JAWAFDEHI_API_BASE_URL` (or falls back to same-origin) and handles auth
 and error extraction. Entities are served under the unified `/api` root
-(`/api/entities`, `/api/relationships`).
+(`/api/entities`).
 
 For local development, set the override in your `.env`:
 ```env
@@ -37,10 +37,12 @@ List or search entities with optional filters.
 **Parameters:**
 - `query?: string` - Text query to search in entity names
 - `entity_type?: string` - Filter by entity type (person, organization, location)
-- `sub_type?: string` - Filter by entity subtype
-- `attributes?: Record<string, any>` - Filter by attributes (JSON object)
 - `limit?: number` - Maximum number of results (default: 100, max: 1000)
 - `offset?: number` - Number of results to skip (default: 0)
+- `entity_ids?: string[]` - Batch retrieval by @id IRI (sent as the `ids` param)
+
+> Note: `sub_type` / `attributes` are accepted on the params object for caller
+> ergonomics but are NOT sent to the backend (no such filter exists there).
 
 **Returns:** `Promise<EntityListResponse>`
 
@@ -57,16 +59,9 @@ const results = await getEntities({
   offset: 0
 });
 
-// Filter by type and subtype
-const parties = await getEntities({
-  entity_type: 'organization',
-  sub_type: 'political_party',
-  limit: 20
-});
-
-// Filter by attributes
-const ncMembers = await getEntities({
-  attributes: { party: 'nepali-congress' }
+// Batch retrieval by @id IRI
+const batch = await getEntities({
+  entity_ids: ['entity:person/ram', 'entity:organization/acme'],
 });
 ```
 
@@ -111,41 +106,6 @@ Get version history for an entity.
 **Example:**
 ```typescript
 const versions = await getEntityVersions('pushpa-kamal-dahal-prachanda');
-```
-
----
-
-### Relationship Endpoints
-
-#### `getRelationships(params?)`
-Get relationships with optional filters.
-
-**Backend Endpoint:** `GET /relationships`
-
-**Parameters:**
-- `source_id?: string` - Filter by source entity
-- `target_id?: string` - Filter by target entity
-- `type?: string` - Filter by relationship type
-- `limit?: number` - Maximum number of results
-- `offset?: number` - Number of results to skip
-
-**Example:**
-```typescript
-// Get relationships where entity is source
-const sourceRels = await getRelationships({
-  source_id: 'entity-slug'
-});
-
-// Get relationships where entity is target
-const targetRels = await getRelationships({
-  target_id: 'entity-slug'
-});
-
-// Get all relationships for an entity
-const allRels = [
-  ...(await getRelationships({ source_id: 'entity-slug' })).relationships,
-  ...(await getRelationships({ target_id: 'entity-slug' })).relationships
-];
 ```
 
 ---
@@ -249,17 +209,6 @@ curl -X GET "http://localhost:8000/api/entity/pushpa-kamal-dahal-prachanda" \
 ### Get Entity Versions
 ```bash
 curl -X GET "http://localhost:8000/api/entity/pushpa-kamal-dahal-prachanda/versions" \
-  -H "Content-Type: application/json"
-```
-
-### Get Relationships
-```bash
-# As source
-curl -X GET "http://localhost:8000/api/relationship?source_id=entity-slug" \
-  -H "Content-Type: application/json"
-
-# As target
-curl -X GET "http://localhost:8000/api/relationship?target_id=entity-slug" \
   -H "Content-Type: application/json"
 ```
 

--- a/src/services/admin-api.test.ts
+++ b/src/services/admin-api.test.ts
@@ -51,8 +51,6 @@ import {
   listCases,
   patchCase,
   deleteCase,
-  createSource,
-  buildSourceFormData,
 } from "./admin-api";
 
 beforeEach(() => {
@@ -111,13 +109,6 @@ describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
     });
   });
 
-  it("posts a source create as multipart FormData to /api/sources/", async () => {
-    await createSource({ title: "Report" });
-    expect(calls[0].method).toBe("post");
-    expect(calls[0].url).toBe("/api/sources/");
-    expect(calls[0].body).toBeInstanceOf(FormData);
-  });
-
   it("routes the entity picker (searchEntities) to /api/entities (not /api/nes)", async () => {
     await searchEntities("ram", 10);
     expect(calls[0]).toMatchObject({ method: "get", url: "/api/entities" });
@@ -154,36 +145,6 @@ describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
     const fd = calls[0].body as FormData;
     expect(fd.get("role")).toBe("RAW");
     expect(fd.get("material_type")).toBe("official_report");
-    expect(fd.get("file")).toBeInstanceOf(File);
-  });
-});
-
-// TASK B — the source multipart body is the load-bearing write contract.
-describe("buildSourceFormData", () => {
-  it("puts scalar fields as form fields and JSON-encodes urls", () => {
-    const fd = buildSourceFormData({
-      title: "Charge sheet",
-      source_type: "LEGAL_PROCEDURAL",
-      urls: [{ link: "https://x/1", role: "PERMALINK" }],
-    });
-    expect(fd.get("title")).toBe("Charge sheet");
-    expect(fd.get("source_type")).toBe("LEGAL_PROCEDURAL");
-    expect(fd.get("urls")).toBe(
-      JSON.stringify([{ link: "https://x/1", role: "PERMALINK" }]),
-    );
-    // No file provided -> no file field.
-    expect(fd.get("file")).toBeNull();
-  });
-
-  it("omits empty/nullish fields and attaches a file when given", () => {
-    const file = new File(["data"], "doc.pdf", { type: "application/pdf" });
-    const fd = buildSourceFormData(
-      { title: "Doc", description: "", source_type: null },
-      file,
-    );
-    expect(fd.get("title")).toBe("Doc");
-    expect(fd.get("description")).toBeNull();
-    expect(fd.get("source_type")).toBeNull();
     expect(fd.get("file")).toBeInstanceOf(File);
   });
 });

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -8,7 +8,7 @@
 //     /api/entities...     entities (JSON-LD read/write + reindex)
 //     /api/courtcases...   court cases (composite-key read/write)
 //     /api/courts, /api/firms, /api/materials   data-lake records
-//     /api/cases, /api/sources   Jawafdehi cases / document sources
+//     /api/cases                 Jawafdehi cases (evidence references materials)
 //
 // Auth is OIDC/Zitadel only (DRF token auth was dropped in the monolith): every
 // request carries `Authorization: Bearer <access>` from the shared oidc.ts.
@@ -315,9 +315,9 @@ export async function deleteMaterial(
 }
 
 // ---------------------------------------------------------------------------
-// Jawafdehi — corruption cases (DISTINCT from data-lake court cases) + sources.
-// Full CRUD: cases are keyed by slug, updated via RFC-6902 PATCH; sources are
-// keyed by numeric id and created via multipart (optional file upload).
+// Jawafdehi — corruption cases (DISTINCT from data-lake court cases).
+// Full CRUD: cases are keyed by slug, updated via RFC-6902 PATCH. Case evidence
+// references materials by @id IRI (managed via the materials write surface).
 // ---------------------------------------------------------------------------
 
 export async function listCases<T = Record<string, unknown>>(
@@ -374,82 +374,10 @@ export async function deleteCase(slug: string): Promise<void> {
   await client.delete(`/api/cases/${encodeURIComponent(slug)}/`);
 }
 
-export async function listSources<T = Record<string, unknown>>(
-  params: Record<string, unknown> = {},
-): Promise<Paginated<T>> {
-  const { data } = await client.get<Paginated<T>>("/api/sources/", { params });
-  return data;
-}
-
-export async function getSource<T = Record<string, unknown>>(
-  id: number | string,
-): Promise<T> {
-  const { data } = await client.get<T>(`/api/sources/${id}/`);
-  return data;
-}
-
-// Build the multipart body for a source create/update. Scalar fields ride as
-// form fields; `urls` (link-role dicts) is JSON-encoded; an optional File is
-// attached under `file`. Kept a standalone helper so it's unit-testable without
-// the network (the FormData shape is the load-bearing contract).
-export interface SourceWriteFields {
-  title: string;
-  description?: string;
-  source_type?: string | null;
-  urls?: { link: string; role: string }[] | null;
-  [k: string]: unknown;
-}
-
-export function buildSourceFormData(
-  fields: SourceWriteFields,
-  file?: File | null,
-): FormData {
-  const fd = new FormData();
-  for (const [k, v] of Object.entries(fields)) {
-    if (v == null || v === "") continue;
-    if (k === "urls") {
-      fd.append("urls", JSON.stringify(v));
-    } else if (Array.isArray(v) || typeof v === "object") {
-      fd.append(k, JSON.stringify(v));
-    } else {
-      fd.append(k, String(v));
-    }
-  }
-  if (file) fd.append("file", file);
-  return fd;
-}
-
-// CREATE a document source. Multipart so an optional file can be uploaded
-// alongside the metadata. axios sets the multipart boundary from the FormData.
-export async function createSource<T = Record<string, unknown>>(
-  fields: SourceWriteFields,
-  file?: File | null,
-): Promise<T> {
-  const { data } = await client.post<T>(
-    "/api/sources/",
-    buildSourceFormData(fields, file),
-  );
-  return data;
-}
-
-// UPDATE a source. Also multipart (a replacement file may be attached). Uses
-// PATCH so partial field updates don't wipe unspecified fields.
-export async function updateSource<T = Record<string, unknown>>(
-  id: number | string,
-  fields: SourceWriteFields,
-  file?: File | null,
-): Promise<T> {
-  const { data } = await client.patch<T>(
-    `/api/sources/${id}/`,
-    buildSourceFormData(fields, file),
-  );
-  return data;
-}
-
-// Soft-delete a source (204).
-export async function deleteSource(id: number | string): Promise<void> {
-  await client.delete(`/api/sources/${id}/`);
-}
+// NOTE: Case "document sources" (the former /api/sources CRUD) were removed with
+// the "cases own no documents" ADR. Case evidence now references MATERIALS by
+// their @id IRI; manage evidence documents via the materials write surface
+// above (createMaterial / replaceMaterial / uploadMaterialFile / deleteMaterial).
 
 // ---------------------------------------------------------------------------
 // Data Lake — courts + blocklisted firms write surface (data-lake role). Flat /api/

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,8 +4,8 @@
  * This module provides typed API functions to interact with the entity backend.
  *
  * Entities live on the consolidated monolith under the unified `/api`
- * root (`/api/entities`, `/api/relationships`). Auth, base-URL resolution, and
- * error extraction are handled by the shared `http` client (./http).
+ * root (`/api/entities`). Auth, base-URL resolution, and error extraction are
+ * handled by the shared `http` client (./http).
  */
 
 import { http, extractErrorMessage } from './http';
@@ -31,11 +31,6 @@ export interface EntityListResponse {
   has_more?: boolean;
 }
 
-export interface RelationshipListResponse {
-  relationships: Relationship[];
-  total?: number;
-}
-
 export interface VersionListResponse {
   versions: VersionSummary[];
   entity_id: string;
@@ -48,19 +43,15 @@ export interface VersionListResponse {
 export interface EntitySearchParams {
   query?: string;       // Search query
   entity_type?: string; // Entity type: person, organization, location
-  sub_type?: string;    // Entity subtype
-  attributes?: Record<string, unknown>; // Filter by attributes (JSON object)
+  /** @deprecated Not sent to the backend (no such filter); accepted for caller
+   * ergonomics but ignored by getEntities. */
+  sub_type?: string;
+  /** @deprecated Not sent to the backend (no such filter); accepted for caller
+   * ergonomics but ignored by getEntities. */
+  attributes?: Record<string, unknown>;
   limit?: number;       // Maximum number of results (default: 100, max: 1000)
   offset?: number;      // Number of results to skip (default: 0)
-  entity_ids?: string[]; // Filter by specific entity IDs (for batch retrieval)
-}
-
-export interface RelationshipSearchParams {
-  source_id?: string;   // Source entity ID
-  target_id?: string;   // Target entity ID
-  type?: string;        // Relationship type
-  limit?: number;       // Maximum number of results
-  offset?: number;      // Number of results to skip
+  entity_ids?: string[]; // Filter by specific entity IDs (batch retrieval; sent as `ids`)
 }
 
 // ============================================================================
@@ -156,14 +147,12 @@ export async function getEntities(params?: EntitySearchParams): Promise<EntityLi
 
     if (params?.query) queryParams.query = params.query;
     if (params?.entity_type) queryParams.entity_type = params.entity_type;
-    if (params?.sub_type) queryParams.sub_type = params.sub_type;
-    if (params?.attributes) queryParams.attributes = JSON.stringify(params.attributes);
     if (params?.limit) queryParams.limit = params.limit;
     if (params?.offset !== undefined) queryParams.offset = params.offset;
 
-    // Handle entity_ids for batch retrieval
+    // Batch retrieval: the backend reads the `ids` param (entities/views.py).
     if (params?.entity_ids && params.entity_ids.length > 0) {
-      queryParams['entity-id'] = params.entity_ids.join(',');
+      queryParams.ids = params.entity_ids.join(',');
     }
 
     const response = await http.get<EntityListResponse>('/api/entities', {
@@ -268,42 +257,6 @@ export async function getEntityVersions(idOrSlug: string): Promise<VersionListRe
 }
 
 // ============================================================================
-// Relationship Endpoints
-// ============================================================================
-
-/**
- * Get relationships with optional filters
- *
- * Backend endpoint: GET /relationships?source_id={id}&target_id={id}&type={type}
- *
- * @param params - Relationship search parameters
- * @returns Promise<RelationshipListResponse>
- *
- * @example
- * ```typescript
- * // Get all relationships where entity is the source
- * const rels = await getRelationships({ source_id: 'entity-slug' });
- *
- * // Get all relationships where entity is the target
- * const rels = await getRelationships({ target_id: 'entity-slug' });
- * ```
- */
-export async function getRelationships(
-  params?: RelationshipSearchParams
-): Promise<RelationshipListResponse> {
-  try {
-    const response = await http.get<RelationshipListResponse>('/api/relationships', {
-      params,
-      timeout: 30000,
-    });
-    return response.data;
-  } catch (error) {
-    console.warn('Relationships endpoint returned error, returning empty list');
-    return { relationships: [] };
-  }
-}
-
-// ============================================================================
 // Allegation & Case API Functions
 // ============================================================================
 // Note: the entity API provides entity data only. Allegations and cases will be
@@ -330,7 +283,7 @@ export async function getEntityAllegations(idOrSlug: string): Promise<Allegation
       status: 'ongoing', // Cases are published cases
       severity: jdsCase.case_type, // Map type to severity
       summary: jdsCase.key_allegations.join('; '),
-      evidence: (jdsCase.evidence ?? []).map(e => e.description),
+      evidence: (jdsCase.evidence ?? []).map(e => e.additional_details),
       date: jdsCase.created_at,
     }));
   } catch (error) {
@@ -357,7 +310,7 @@ export async function getEntityCases(idOrSlug: string): Promise<Case[]> {
       // `c` is list-sourced, so the full `description` is absent; fall back to
       // `short_description` (and ultimately '') for the required PAP field.
       description: c.description ?? c.short_description ?? '',
-      documents: (c.evidence ?? []).map(e => e.source_id.toString()),
+      documents: (c.evidence ?? []).map(e => e.material_iri),
       timeline: (c.timeline ?? []).map(t => ({
         date: t.date,
         event: t.title,

--- a/src/services/guest-chat-adapter.ts
+++ b/src/services/guest-chat-adapter.ts
@@ -1,7 +1,7 @@
 import { GUEST_TOPIC_KNOWLEDGE, type GuestTopicId } from "@/data/guest-knowledge";
 import { searchEntities } from "@/services/api";
-import { getCaseById, getCases, getDocumentSourceById } from "@/services/jds-api";
-import type { Case, CaseDetail, DocumentSource } from "@/types/jds";
+import { getCaseById, getCases } from "@/services/jds-api";
+import type { Case, CaseDetail, EvidenceMaterial } from "@/types/jds";
 import { stripMarkdown } from "@/utils/markdown";
 import type {
   GuestAskResponse,
@@ -24,8 +24,10 @@ const DEFAULT_FOLLOWUPS_NE = [
 const CIAA_TRACKER_2081_2082_TOTAL_CASES = 135;
 
 export interface GuestCaseSourceEntry {
-  sourceId: number;
-  source: DocumentSource | null;
+  // The material @id IRI identifies the evidence source (materials replaced the
+  // former numeric DocumentSource id per the "cases own no documents" ADR).
+  sourceId: string;
+  source: EvidenceMaterial | null;
   evidenceDescription?: string;
 }
 
@@ -800,24 +802,13 @@ function getTopicFollowups(topicId: GuestTopicId, language: GuestLanguage): stri
 
 async function resolveCaseSources(caseId: number) {
   const caseData = await getCaseById(caseId);
-  const sourceEntries = await Promise.all(
-    caseData.evidence.map(async (entry) => {
-      try {
-        const source = await getDocumentSourceById(entry.source_id);
-        return {
-          sourceId: entry.source_id,
-          source,
-          evidenceDescription: entry.description,
-        };
-      } catch {
-        return {
-          sourceId: entry.source_id,
-          source: null,
-          evidenceDescription: entry.description,
-        };
-      }
-    })
-  );
+  // The case DETAIL response embeds the resolved material on each evidence
+  // entry, so no per-source fetch is needed (the /api/sources route is gone).
+  const sourceEntries: GuestCaseSourceEntry[] = caseData.evidence.map((entry) => ({
+    sourceId: entry.material_iri,
+    source: entry.material ?? null,
+    evidenceDescription: entry.additional_details,
+  }));
 
   return { caseData, sourceEntries };
 }
@@ -842,8 +833,7 @@ function findRelevantSources(
   const matches = sources.filter(({ source, evidenceDescription }) => {
     const haystack = normalize(
       [
-        source?.title,
-        source?.description,
+        source?.display_name,
         evidenceDescription,
         Array.isArray(source?.urls)
           ? source.urls.map((u) => u?.link).filter(Boolean).join(" ")
@@ -874,8 +864,8 @@ function findRelevantSources(
 
   return matches.slice(0, 3).map(({ sourceId, source, evidenceDescription }) => ({
     sourceId,
-    sourceTitle: source?.title || `Source ${sourceId}`,
-    reason: evidenceDescription || source?.description || undefined,
+    sourceTitle: source?.display_name || `Source ${sourceId}`,
+    reason: evidenceDescription || undefined,
   }));
 }
 
@@ -1155,10 +1145,10 @@ export async function askGuestCaseQuestion(params: {
       sourceEntries.length > 0
         ? language === "ne"
           ? `यस मुद्दामा अहिले ${sourceEntries.length} वटा सार्वजनिक स्रोत उल्लेख छन्: ${sourceEntries
-              .map(({ source, sourceId }) => source?.title || `स्रोत ${sourceId}`)
+              .map(({ source, sourceId }) => source?.display_name || `स्रोत ${sourceId}`)
               .join(", ")}।`
           : `This case currently references ${sourceEntries.length} public source${sourceEntries.length === 1 ? "" : "s"}: ${sourceEntries
-              .map(({ source, sourceId }) => source?.title || `Source ${sourceId}`)
+              .map(({ source, sourceId }) => source?.display_name || `Source ${sourceId}`)
               .join(", ")}.`
         : language === "ne"
         ? "यो सार्वजनिक मुद्दा पृष्ठमा कागजात स्रोतहरू अझै सूचीबद्ध छैनन्।"
@@ -1180,14 +1170,14 @@ export async function askGuestCaseQuestion(params: {
     const chargeSheet = sourceEntries.find(({ source, evidenceDescription }) =>
       ["charge sheet", "आरोपपत्र"].some((term) =>
         normalize(
-          `${source?.title || ""} ${source?.description || ""} ${evidenceDescription || ""}`
+          `${source?.display_name || ""} ${evidenceDescription || ""}`
         ).includes(normalize(term))
       )
     );
     answer = chargeSheet?.source
       ? language === "ne"
-        ? `${chargeSheet.source.title} यो सार्वजनिक मुद्दासँग सम्बन्धित आरोपपत्रको सबैभन्दा प्रत्यक्ष स्रोत हो।`
-        : `${chargeSheet.source.title} is the source most directly related to the charge sheet for this public case.`
+        ? `${chargeSheet.source.display_name} यो सार्वजनिक मुद्दासँग सम्बन्धित आरोपपत्रको सबैभन्दा प्रत्यक्ष स्रोत हो।`
+        : `${chargeSheet.source.display_name} is the source most directly related to the charge sheet for this public case.`
       : language === "ne"
       ? "यो मुद्दा पृष्ठमा आरोपपत्रलाई स्पष्ट रूपमा उल्लेख गर्ने सार्वजनिक स्रोत मैले भेटिनँ।"
       : "I could not identify a public source on this case page that explicitly mentions a charge sheet.";

--- a/src/services/guest-chat-adapter.ts
+++ b/src/services/guest-chat-adapter.ts
@@ -1174,10 +1174,12 @@ export async function askGuestCaseQuestion(params: {
         ).includes(normalize(term))
       )
     );
+    const chargeSheetName = chargeSheet?.source?.display_name
+      || (chargeSheet ? (language === "ne" ? `स्रोत ${chargeSheet.sourceId}` : `Source ${chargeSheet.sourceId}`) : "");
     answer = chargeSheet?.source
       ? language === "ne"
-        ? `${chargeSheet.source.display_name} यो सार्वजनिक मुद्दासँग सम्बन्धित आरोपपत्रको सबैभन्दा प्रत्यक्ष स्रोत हो।`
-        : `${chargeSheet.source.display_name} is the source most directly related to the charge sheet for this public case.`
+        ? `${chargeSheetName} यो सार्वजनिक मुद्दासँग सम्बन्धित आरोपपत्रको सबैभन्दा प्रत्यक्ष स्रोत हो।`
+        : `${chargeSheetName} is the source most directly related to the charge sheet for this public case.`
       : language === "ne"
       ? "यो मुद्दा पृष्ठमा आरोपपत्रलाई स्पष्ट रूपमा उल्लेख गर्ने सार्वजनिक स्रोत मैले भेटिनँ।"
       : "I could not identify a public source on this case page that explicitly mentions a charge sheet.";

--- a/src/services/jds-api.ts
+++ b/src/services/jds-api.ts
@@ -19,10 +19,7 @@ import type {
   CaseDetail,
   CaseSearchParams,
   CaseStatistics,
-  DocumentSource,
-  DocumentSourceSearchParams,
   PaginatedCaseList,
-  PaginatedDocumentSourceList,
 } from '@/types/jds';
 
 // ============================================================================
@@ -194,62 +191,6 @@ export async function getCasesByEntity(entityId: string, params?: CaseSearchPara
     return filteredCases;
   } catch (error) {
     handleApiError(error, '/cases/');
-  }
-}
-
-/**
- * Get a Jawaf entity by its database ID.
- * Searches through cases to find the entity with the matching ID.
- */
-export async function getJawafEntityById(entityId: number): Promise<import('@/types/jds').JawafEntity | null> {
-  try {
-    const response = await http.get<PaginatedCaseList>('/api/cases/', {
-      timeout: 10000,
-    });
-
-    // Search through all cases to find the entity in the unified entities array
-    for (const caseItem of response.data.results) {
-      const entity = caseItem.entities?.find(e => e.id === entityId);
-      if (entity) return entity;
-    }
-    
-    return null;
-  } catch (error) {
-    handleApiError(error, '/cases/');
-  }
-}
-
-// ============================================================================
-// Document Source API Functions
-// ============================================================================
-
-/**
- * Retrieve a paginated list of document sources.
- * Only sources associated with published cases are accessible.
- */
-export async function getDocumentSources(params?: DocumentSourceSearchParams): Promise<PaginatedDocumentSourceList> {
-  try {
-    const response = await http.get<PaginatedDocumentSourceList>('/api/sources/', {
-      params,
-      timeout: 10000,
-    });
-    return response.data;
-  } catch (error) {
-    handleApiError(error, '/sources/');
-  }
-}
-
-/**
- * Retrieve detailed information about a specific document source.
- */
-export async function getDocumentSourceById(id: number): Promise<DocumentSource> {
-  try {
-    const response = await http.get<DocumentSource>(`/api/sources/${id}/`, {
-      timeout: 10000,
-    });
-    return response.data;
-  } catch (error) {
-    handleApiError(error, `/sources/${id}/`);
   }
 }
 

--- a/src/types/guest-chat.ts
+++ b/src/types/guest-chat.ts
@@ -34,7 +34,9 @@ export interface GuestAskResponse {
 }
 
 export interface GuestCaseChatCitation {
-  sourceId: number;
+  // Material @id IRI of the cited evidence source (materials replaced numeric
+  // DocumentSource ids per the "cases own no documents" ADR).
+  sourceId: string;
   sourceTitle: string;
   reason?: string;
 }

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -60,7 +60,10 @@ export const DocumentSourceTypeKeys: Record<DocumentSourceType, string> = {
 // ============================================================================
 
 export interface JawafEntity {
-  id: number;
+  // Numeric primary key is NOT returned by the backend for case-bound entities
+  // (the case serializer keys entity binds on `nes_id`); optional for the rare
+  // callers that still carry a synthesized id. Prefer `nes_id` for lookups/links.
+  id?: number;
   nes_id: string | null; // Entity ID from Nepal Entity Service
   display_name: string | null; // Display name for the entity
   type?: string; // Relationship type: 'accused', 'alleged', 'related', 'witness', 'location', 'respondent', 'petitioner', etc.
@@ -83,9 +86,30 @@ export interface TimelineEntry {
   end_date_bs?: string; // Bikram Sambat date (YYYY-MM-DD) for the span's end
 }
 
+/**
+ * Resolved material embedded on each case-detail evidence entry.
+ *
+ * The case DETAIL serializer enriches every CaseMaterialReference with the
+ * resolved NGM material: `{display_name, material_type, urls}` (a stub with
+ * null fields / empty urls when the material can't be resolved). `urls` is the
+ * roled link list (RAW/PERMALINK/MARKDOWN/…). See cases/serializers.py
+ * CaseDetailSerializer.get_evidence.
+ */
+export interface EvidenceMaterial {
+  display_name: string | null;
+  material_type: string | null;
+  urls: SourceLink[];
+}
+
+/**
+ * A case evidence entry: a reference to a material (`material_iri`) plus a
+ * per-case note (`additional_details`). The DETAIL endpoint additionally embeds
+ * the resolved `material`; the LIST endpoint omits it.
+ */
 export interface EvidenceEntry {
-  source_id: number;
-  description: string;
+  material_iri: string;
+  additional_details: string;
+  material?: EvidenceMaterial;
 }
 
 export interface CourtCaseHearing {
@@ -140,7 +164,6 @@ export interface CourtCase {
 
 export interface Case {
   id: number;
-  case_id: string; // Unique identifier shared across versions
   slug: string | null; // URL-friendly slug; older cases may not have one yet
   case_type: CaseType;
   state: CaseState; // Current state in the workflow
@@ -189,17 +212,10 @@ export interface SourceLink {
   role: SourceLinkRole;
 }
 
-export interface DocumentSource {
-  id: number;
-  source_id: string;
-  title: string;
-  description: string;
-  source_type: DocumentSourceType | string | null; // DocumentSourceType for known values; plain string covers legacy/unknown backend values; null if not classified
-  urls?: SourceLink[] | null; // Link dicts with explicit role (RAW/MARKDOWN/PERMALINK/SOURCE_PAGE/ALTERNATE); includes uploaded-file URL when present
-  related_entities: JawafEntity[]; // Related entities
-  created_at: string;
-  updated_at: string;
-}
+// NOTE: The standalone DocumentSource resource (and its /api/sources routes)
+// was removed with the "cases own no documents" ADR. Case evidence now
+// references MATERIALS by @id IRI; the resolved material is embedded on each
+// evidence entry (see EvidenceMaterial / EvidenceEntry above).
 
 // ============================================================================
 // API Response Types
@@ -212,13 +228,6 @@ export interface PaginatedCaseList {
   results: Case[];
 }
 
-export interface PaginatedDocumentSourceList {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: DocumentSource[];
-}
-
 // ============================================================================
 // Search/Filter Parameters
 // ============================================================================
@@ -227,10 +236,6 @@ export interface CaseSearchParams {
   case_type?: CaseType;
   tags?: string;
   search?: string;
-  page?: number;
-}
-
-export interface DocumentSourceSearchParams {
   page?: number;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,14 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_BASE_URL?: string;
+  // Origin of the consolidated Jawafdehi API (serves /api/*). Same-origin when unset.
+  readonly VITE_JAWAFDEHI_API_BASE_URL?: string;
+  // OIDC auth provider config for the portal SPA.
+  readonly VITE_OIDC_AUTHORITY?: string;
+  readonly VITE_OIDC_CLIENT_ID?: string;
+  readonly VITE_OIDC_AUDIENCE?: string;
+  // DEV-ONLY: enables the username/password login form ("true"/"false").
+  readonly VITE_DEV_AUTH?: string;
   readonly VITE_ENABLE_CASE_SUBMISSION_FORM?: string;
   readonly VITE_SENTRY_DSN?: string;
 }


### PR DESCRIPTION
## What & why

The SPA is on `v2` but hadn't caught up to the `v2` backend, which completed the "cases own no documents" ADR and the R1 collapse. This PR fixes the resulting runtime breakages.

### H1 — `/api/sources` was removed backend-side
Cases now reference materials via `CaseMaterialReference` (`material_iri`), and the case-detail serializer **embeds** each evidence entry's resolved material inline: `{material_iri, additional_details, material: {display_name, material_type, urls:[{link,role}]}}`.
- Removed all `/api/sources` client calls (`getDocumentSources`/`getDocumentSourceById`, admin source CRUD) — admin already has the materials write surface.
- `CaseDetail` + guest chat now render evidence from the embedded `material` (no per-source fetch). `DocumentSourceCard` takes `material` + `materialIri`, fully guarded for null/unresolved materials.

### H5 — removed references to removed fields
- `EvidenceEntry` → `{material_iri, additional_details, material?}`; dropped `Case.case_id`; `JawafEntity.id` optional; entity lookups keyed on `nes_id`. Removed dead `DocumentSource*`/`Relationship*` types + `getRelationships`.

### Entity links (fix from code review)
Switching links to `nes_id` initially built `/entity/${encodeURIComponent(nes_id)}` — but `nes_id` is a full IRI, and encoding the `/` to `%2F` collapsed it to one segment matching the numeric `/entity/:id` route (→ "invalid entity ID"). Extracted `entityPath()` into `src/lib/entity-links.ts` and routed all 5 link sites through it so the tail stays multi-segment and matches the IRI-aware `/entity/*` route. Added `entity-links.test.ts` (matchRoutes assertion).

### M7 — `getEntities` query params
Renamed batch param `entity-id` → `ids` (what the backend reads); stopped sending `sub_type`/`attributes` (no backend filter).

### Doc/env drift
- `.env.example` + `vite-env.d.ts`: document the actually-read vars (`VITE_JAWAFDEHI_API_BASE_URL`, `VITE_DEV_AUTH`, `VITE_OIDC_*`), remove dead `VITE_API_BASE_URL`/`VITE_JDS_API_BASE_URL`.
- `src/services/README.md`: removed the nonexistent `GET /relationships` entry.

## Testing
- `tsc --noEmit`: no new errors (22 pre-existing, unchanged). `eslint src/`: clean.
- `vitest run`: **93 passed** (21 files), incl. the new entity-links test.
- Independent code review: the entity-link regression above was caught and fixed; no other issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)