### PR TITLE
Admin role gating: teach roles.ts the NES/NGM domain roles, drop stale 'contributor'

### DIFF
--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -104,7 +104,7 @@ function Sidebar({ roles }: { roles: string[] }) {
     <nav className="flex flex-col gap-5 p-4">
       {NAV.map((group) => {
         const visible = group.items.filter((it) => {
-          if (it.roles && !it.roles.some((r) => lower.includes(r))) return false;
+          if (it.roles && !it.roles.some((r) => lower.includes(r.toLowerCase()))) return false;
           if (it.canAccess && !it.canAccess(roles)) return false;
           return true;
         });

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -7,7 +7,11 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
-import { hasAdminAccess } from "@/lib/roles";
+import {
+  hasAdminAccess,
+  hasNesWriteAccess,
+  hasNgmWriteAccess,
+} from "@/lib/roles";
 import { Button } from "@/components/ui/button";
 import {
   Building2,
@@ -26,14 +30,17 @@ import {
 // authority; this gate (hasAdminAccess, see lib/roles) just keeps role-less
 // users out of a UI that would 403 on every call.
 
-// Sidebar groups. `roles` (when set) narrows a link to those roles; links
-// without it show for anyone who cleared the panel gate.
+// Sidebar groups. A link shows for anyone who cleared the panel gate unless it
+// narrows itself: `roles` (case-insensitive membership) or `canAccess` (an
+// arbitrary predicate over the user's roles, used for the write-gated sections
+// whose backend role set is more than a flat name match — see lib/roles).
 interface NavItem {
   to: string;
   label: string;
   icon: typeof LayoutDashboard;
   end?: boolean;
   roles?: string[];
+  canAccess?: (roles: string[]) => boolean;
 }
 interface NavGroup {
   heading: string;
@@ -46,16 +53,28 @@ const NAV: NavGroup[] = [
     items: [{ to: "/admin", label: "Dashboard", icon: LayoutDashboard, end: true }],
   },
   {
+    // NES writes are gated on NES_Contributor / NES_Admin (+ superuser) by the
+    // backend (entities/permissions.py); platform readonly/caseworker/moderator
+    // are NOT accepted, so don't offer the (write) Entities section to them.
     heading: "Entities",
-    items: [{ to: "/admin/entities", label: "Entities", icon: Network }],
+    items: [
+      {
+        to: "/admin/entities",
+        label: "Entities",
+        icon: Network,
+        canAccess: hasNesWriteAccess,
+      },
+    ],
   },
   {
+    // Data Lake (court/material/firm) writes are gated on the NGM role set
+    // (courts/permissions.py HasNgmRole): Admin/Moderator/Caseworker + NGM tiers.
     heading: "Data Lake",
     items: [
-      { to: "/admin/datalake/courtcases", label: "Court cases", icon: Gavel },
-      { to: "/admin/datalake/courts", label: "Courts", icon: Building2 },
-      { to: "/admin/datalake/firms", label: "Blocklisted firms", icon: Building2 },
-      { to: "/admin/datalake/materials", label: "Materials", icon: ScrollText },
+      { to: "/admin/datalake/courtcases", label: "Court cases", icon: Gavel, canAccess: hasNgmWriteAccess },
+      { to: "/admin/datalake/courts", label: "Courts", icon: Building2, canAccess: hasNgmWriteAccess },
+      { to: "/admin/datalake/firms", label: "Blocklisted firms", icon: Building2, canAccess: hasNgmWriteAccess },
+      { to: "/admin/datalake/materials", label: "Materials", icon: ScrollText, canAccess: hasNgmWriteAccess },
     ],
   },
   {
@@ -84,9 +103,11 @@ function Sidebar({ roles }: { roles: string[] }) {
   return (
     <nav className="flex flex-col gap-5 p-4">
       {NAV.map((group) => {
-        const visible = group.items.filter(
-          (it) => !it.roles || it.roles.some((r) => lower.includes(r)),
-        );
+        const visible = group.items.filter((it) => {
+          if (it.roles && !it.roles.some((r) => lower.includes(r))) return false;
+          if (it.canAccess && !it.canAccess(roles)) return false;
+          return true;
+        });
         if (!visible.length) return null;
         return (
           <div key={group.heading} className="space-y-1">

--- a/src/lib/roles.test.ts
+++ b/src/lib/roles.test.ts
@@ -1,16 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { hasAdminAccess, isModerator, isAdmin } from "./roles";
+import {
+  hasAdminAccess,
+  isModerator,
+  isAdmin,
+  hasNesWriteAccess,
+  hasNgmWriteAccess,
+} from "./roles";
 
 describe("roles helpers", () => {
   it("hasAdminAccess: true for any admin-panel role, case-insensitive", () => {
     expect(hasAdminAccess(["Caseworker"])).toBe(true);
     expect(hasAdminAccess(["READONLY"])).toBe(true);
-    expect(hasAdminAccess(["contributor"])).toBe(true);
     expect(hasAdminAccess(["admin"])).toBe(true);
     expect(hasAdminAccess(["moderator"])).toBe(true);
   });
 
-  it("hasAdminAccess: false for unknown roles or none", () => {
+  it("hasAdminAccess: false for the retired 'contributor' role, unknowns, or none", () => {
+    // "contributor" was renamed to "caseworker" platform-wide; no backend path
+    // emits it any more, so it must NOT admit anyone.
+    expect(hasAdminAccess(["contributor"])).toBe(false);
     expect(hasAdminAccess(["viewer"])).toBe(false);
     expect(hasAdminAccess([])).toBe(false);
     expect(hasAdminAccess(undefined)).toBe(false);
@@ -29,5 +37,41 @@ describe("roles helpers", () => {
     expect(isAdmin(["ADMIN", "moderator"])).toBe(true);
     expect(isAdmin(["moderator"])).toBe(false);
     expect(isAdmin(undefined)).toBe(false);
+  });
+
+  it("hasNesWriteAccess: only NES roles (both OIDC + group spellings) or admin", () => {
+    // OIDC claim keys
+    expect(hasNesWriteAccess(["nes_contributor"])).toBe(true);
+    expect(hasNesWriteAccess(["nes_admin"])).toBe(true);
+    // Django group names (from dev-login / me_view), case-insensitive
+    expect(hasNesWriteAccess(["NES_Contributor"])).toBe(true);
+    expect(hasNesWriteAccess(["NES_Admin"])).toBe(true);
+    // admin -> Django superuser, which bypasses the NES permission classes
+    expect(hasNesWriteAccess(["admin"])).toBe(true);
+    // Platform roles WITHOUT an NES group are backend-403'd — must be hidden.
+    expect(hasNesWriteAccess(["caseworker"])).toBe(false);
+    expect(hasNesWriteAccess(["moderator"])).toBe(false);
+    expect(hasNesWriteAccess(["readonly"])).toBe(false);
+    expect(hasNesWriteAccess(["ReadOnly"])).toBe(false);
+    expect(hasNesWriteAccess([])).toBe(false);
+    expect(hasNesWriteAccess(undefined)).toBe(false);
+  });
+
+  it("hasNgmWriteAccess: NGM role set (Admin/Moderator/Caseworker + tiers)", () => {
+    expect(hasNgmWriteAccess(["admin"])).toBe(true);
+    expect(hasNgmWriteAccess(["moderator"])).toBe(true);
+    expect(hasNgmWriteAccess(["caseworker"])).toBe(true);
+    expect(hasNgmWriteAccess(["Caseworker"])).toBe(true);
+    // NGM tier roles — OIDC claim keys and Django group names.
+    expect(hasNgmWriteAccess(["ngm_silver"])).toBe(true);
+    expect(hasNgmWriteAccess(["ngm_gold"])).toBe(true);
+    expect(hasNgmWriteAccess(["ngm_platinum"])).toBe(true);
+    // readonly is NOT in the NGM set -> hidden.
+    expect(hasNgmWriteAccess(["readonly"])).toBe(false);
+    expect(hasNgmWriteAccess(["ReadOnly"])).toBe(false);
+    // NES-only roles do NOT grant NGM writes.
+    expect(hasNgmWriteAccess(["nes_contributor"])).toBe(false);
+    expect(hasNgmWriteAccess([])).toBe(false);
+    expect(hasNgmWriteAccess(undefined)).toBe(false);
   });
 });

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -2,15 +2,30 @@
 // authority — these checks only decide which controls/pages the UI offers, so a
 // role-less user isn't dropped into a panel that 403s on every call.
 //
-// Role strings arrive from OIDC claims or the dev-login payload in mixed case;
-// every check here is case-insensitive.
+// SOURCE OF TRUTH for role names: the backend's role->group mapping in
+// jawafdehi-api/jawafdehi_shared/auth/oidc.py (DEFAULT_ROLE_TO_GROUP). The FE can
+// receive roles in EITHER spelling depending on the auth path:
+//   - OIDC (prod): profile.roles are the Zitadel *role-claim keys*, lowercase —
+//     e.g. "admin", "moderator", "caseworker", "readonly", "nes_contributor",
+//     "nes_admin", "ngm_silver", "ngm_gold", "ngm_platinum".
+//     (see src/context/CaseworkAuthContext.tsx toCaseworkUser)
+//   - dev-login / /api/casework/auth/me/: the backend returns the *Django Group
+//     names* (user.groups) — e.g. "Admin", "Moderator", "Caseworker", "ReadOnly",
+//     "NES_Contributor", "NES_Admin", "NGM_SilverTier", "NGM_GoldTier",
+//     "NGM_PlatinumTier". (see review/views.py _user_roles_payload)
+// The two differ by MORE than case (e.g. "nes_contributor" vs "NES_Contributor",
+// "ngm_gold" vs "NGM_GoldTier"), so each allow-list below carries BOTH spellings
+// and all matching is case-insensitive.
 
-// Roles that may enter the admin panel at all (the panel-level gate).
+// Roles that may enter the admin panel at all (the panel-level gate). Mirrors the
+// platform role->group rows in DEFAULT_ROLE_TO_GROUP:
+//   admin/Admin, moderator/Moderator, caseworker/Caseworker, readonly/ReadOnly.
+// ("contributor" was renamed to "caseworker" platform-wide — no backend path
+// emits a "contributor" claim any more, so it is intentionally absent here.)
 export const ADMIN_ROLES = [
   "admin",
   "moderator",
   "caseworker",
-  "contributor",
   "readonly",
 ] as const;
 
@@ -18,13 +33,46 @@ export const ADMIN_ROLES = [
 // moderation queue, regrade-all).
 export const MODERATOR_ROLES = ["admin", "moderator"] as const;
 
+// Roles the backend accepts for NES entity WRITES (create / edit / add-name /
+// bulk-ingest / reindex). Backend gate: entities/permissions.py
+// HasNesContributorRole / HasNesAdminRole — groups NES_Contributor / NES_Admin
+// ONLY (superuser bypasses). Platform admin/moderator/caseworker are DELIBERATELY
+// excluded from NES writes per that module's DECISION note, so the ONLY platform
+// role that also clears this gate is "admin" (which the backend maps to Django
+// superuser via the OIDC authenticator's admin-role -> is_superuser sync).
+export const NES_WRITE_ROLES = [
+  "nes_contributor", // OIDC claim key / NES_Contributor group (case-insensitive)
+  "nes_admin", // OIDC claim key / NES_Admin group
+  "admin", // -> Django superuser, which bypasses the NES permission classes
+] as const;
+
+// Roles the backend accepts for NGM / "Data Lake" WRITES (court cases, courts,
+// firms, materials). Backend gate: courts/permissions.py HasNgmRole — groups
+// Admin, Moderator, Caseworker, and the three NGM rate-limit tiers (superuser
+// bypasses). The tier role-claim keys are ngm_silver/ngm_gold/ngm_platinum
+// (Groups NGM_SilverTier/NGM_GoldTier/NGM_PlatinumTier).
+export const NGM_WRITE_ROLES = [
+  "admin",
+  "moderator",
+  "caseworker",
+  // NGM tier roles. Matching is exact-element (case-insensitive), not substring,
+  // so BOTH the OIDC claim keys AND the Django group names are listed.
+  "ngm_silver", // OIDC claim key
+  "ngm_gold",
+  "ngm_platinum",
+  "ngm_silvertier", // Django group NGM_SilverTier (from dev-login / me_view)
+  "ngm_goldtier",
+  "ngm_platinumtier",
+] as const;
+
 function normalize(roles: readonly string[] | undefined): string[] {
   return (roles ?? []).map((r) => r.toLowerCase());
 }
 
 function hasAny(roles: readonly string[] | undefined, allowed: readonly string[]): boolean {
   const lower = normalize(roles);
-  return allowed.some((r) => lower.includes(r));
+  const allowedLower = allowed.map((r) => r.toLowerCase());
+  return allowedLower.some((r) => lower.includes(r));
 }
 
 // May the user open the admin panel at all?
@@ -40,4 +88,17 @@ export function isModerator(roles: readonly string[] | undefined): boolean {
 // Is the user specifically an admin?
 export function isAdmin(roles: readonly string[] | undefined): boolean {
   return normalize(roles).includes("admin");
+}
+
+// May the user WRITE NES entities (create/edit/reindex)? Gates the Entities
+// section. The backend (entities/permissions.py) accepts only NES_Contributor /
+// NES_Admin (+ superuser); readonly/caseworker/moderator do NOT clear it.
+export function hasNesWriteAccess(roles: readonly string[] | undefined): boolean {
+  return hasAny(roles, NES_WRITE_ROLES);
+}
+
+// May the user WRITE NGM / Data Lake records (courts, cases, firms, materials)?
+// Gates the Data Lake section. Backend gate: courts/permissions.py HasNgmRole.
+export function hasNgmWriteAccess(roles: readonly string[] | undefined): boolean {
+  return hasAny(roles, NGM_WRITE_ROLES);
 }

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -70,9 +70,8 @@ function normalize(roles: readonly string[] | undefined): string[] {
 }
 
 function hasAny(roles: readonly string[] | undefined, allowed: readonly string[]): boolean {
-  const lower = normalize(roles);
-  const allowedLower = allowed.map((r) => r.toLowerCase());
-  return allowedLower.some((r) => lower.includes(r));
+  const lower = new Set(normalize(roles));
+  return allowed.some((r) => lower.has(r.toLowerCase()));
 }
 
 // May the user open the admin panel at all?


### PR DESCRIPTION
## What & why

The admin panel's only gate was a flat `hasAdminAccess` (admin/moderator/caseworker/readonly), but the backend requires **different** roles for the write sections — so e.g. a `readonly` user saw the Entities editor, filled the form, and got a **403** on save. This PR aligns the FE gating with the backend permission model.

### M4 — stale role name
Removed the dead `"contributor"` from `ADMIN_ROLES` (renamed to `caseworker` platform-wide; no backend path emits `contributor` anymore). Added a comment tying the list to the backend `DEFAULT_ROLE_TO_GROUP`.

### M3 — gate write sections on the roles the backend actually requires
- New `hasNesWriteAccess` = `nes_contributor` / `nes_admin` / `admin` (superuser). Backend `entities/permissions.py` deliberately **excludes** platform moderator/caseworker from NES writes.
- New `hasNgmWriteAccess` = `admin` / `moderator` / `caseworker` / the 3 NGM tiers. Matches `courts/permissions.py` `HasNgmRole`.
- Gated the Entities nav on NES write access and the 4 Data Lake items on NGM write access in `AdminLayout.tsx`.

**Two role spellings handled:** OIDC emits role-claim keys (`nes_contributor`, `ngm_gold`, …) while dev-login / `/api/casework/auth/me/` emits Django group names (`NES_Contributor`, `NGM_GoldTier`, …). Both spellings are listed (lowercased); `hasAny` matches array elements exactly, so both are required. Strings derived from `oidc.py` + the permission modules + `create_groups.py` — not invented.

## Testing
- `vitest run src/lib/roles.test.ts` 6/6; full `vitest run` **95 passed**. `eslint`: clean. `tsc`: no new errors.
- Independent code review: clean — both spellings verified exact against backend; NES exclude / NGM include semantics confirmed correct; admin/superuser still sees all sections.

## Follow-ups (documented, out of scope)
- Route-level guards (nav-only today, matching the existing Moderation pattern — a `readonly` user typing `/admin/entities` still loads the page but every write 403s).
- Optionally drive gating off `/api/casework/auth/me/` for one canonical role form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)