### PR TITLE
fix(case): guard CourtCaseCard against core court-case shape (case page crash)

### DIFF
--- a/src/components/CourtCaseCard.test.tsx
+++ b/src/components/CourtCaseCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { CourtCaseCard } from "@/components/CourtCaseCard";
+import type { CourtCase } from "@/types/jds";
+
+// Passthrough translations so assertions don't depend on i18n resources.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | { count?: number }) =>
+      typeof fallback === "string" ? fallback : key,
+    i18n: { language: "en" },
+  }),
+}));
+
+// The composite-key core endpoint (getCourtCase) — the shape the case-detail
+// page passes to CourtCaseCard. It carries plaintiff/defendant STRINGS but has
+// NO `entities` or `hearings` sub-resources. Iterating them unguarded is what
+// crashed the whole case page with "entities is not iterable".
+const coreCase = {
+  case_number: "080-C4-2408",
+  court_identifier: "kathmandudc",
+  registration_date_bs: null,
+  registration_date_ad: null,
+  case_type: "Cooperative Fraud",
+  division: null,
+  category: null,
+  section: null,
+  plaintiff: "Nepal Government",
+  defendant: "Rabi Lamichhane",
+  original_case_number: "080-C4-2408",
+  case_id: null,
+  priority: null,
+  registration_number: "",
+  case_status: "Ongoing",
+  verdict_date_bs: null,
+  verdict_date_ad: null,
+  verdict_judge: null,
+  status: "",
+} as CourtCase;
+
+describe("CourtCaseCard", () => {
+  it("renders the core (no entities/hearings) shape without crashing", () => {
+    render(
+      <MemoryRouter>
+        <CourtCaseCard courtCaseId="kathmandudc:080-C4-2408" courtCase={coreCase} isLoading={false} />
+      </MemoryRouter>,
+    );
+
+    // Falls back to the plaintiff/defendant string fields when `entities` is absent.
+    expect(screen.getByText("Nepal Government")).toBeTruthy();
+    expect(screen.getByText("Rabi Lamichhane")).toBeTruthy();
+    // No hearings sub-resource on the core shape → no hearings collapsible.
+    expect(screen.queryByText(/Hearings/)).toBeNull();
+  });
+
+  it("prefers party entities and renders hearings on the assembled full shape", () => {
+    const fullCase = {
+      ...coreCase,
+      entities: [
+        { name: "CIAA", side: "plaintiff" },
+        { name: "Gitendra Babu Rai", side: "defendant" },
+      ],
+      hearings: [{ id: 1, hearing_date_ad: "2025-01-10", case_status: "Heard" }],
+    } as unknown as CourtCase;
+
+    render(
+      <MemoryRouter>
+        <CourtCaseCard courtCaseId="kathmandudc:080-C4-2408" courtCase={fullCase} isLoading={false} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("CIAA")).toBeTruthy();
+    expect(screen.getByText("Gitendra Babu Rai")).toBeTruthy();
+    expect(screen.getByText(/Hearings/)).toBeTruthy();
+  });
+});

--- a/src/components/CourtCaseCard.tsx
+++ b/src/components/CourtCaseCard.tsx
@@ -52,7 +52,10 @@ function getPartiesByRole(courtCase: CourtCase): {
   const plaintiffs: string[] = [];
   const defendants: string[] = [];
 
-  for (const entity of courtCase.entities) {
+  // `entities` is only populated on the assembled "full" court case; the core
+  // shape used on the case-detail page omits it. Default to [] so the string
+  // plaintiff/defendant fallback below still renders instead of crashing.
+  for (const entity of courtCase.entities ?? []) {
     const side = entity.side?.toLowerCase();
     if (side === "plaintiff" || side === "वादी") {
       plaintiffs.push(entity.name);
@@ -194,13 +197,13 @@ export function CourtCaseCard({ courtCaseId, courtCase, isLoading, linkToDetail 
             );
           })()}
 
-          {/* Hearings collapsible */}
-          {courtCase.hearings.length > 0 && (
+          {/* Hearings collapsible — absent on the core shape (case-detail page). */}
+          {(courtCase.hearings?.length ?? 0) > 0 && (
             <Collapsible className="mt-3">
               <CollapsibleTrigger className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted transition-colors">
                 <ChevronDown className="h-4 w-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
                 <span>
-                  {t("caseDetail.courtHearings", "Hearings")} ({courtCase.hearings.length})
+                  {t("caseDetail.courtHearings", "Hearings")} ({courtCase.hearings?.length ?? 0})
                 </span>
               </CollapsibleTrigger>
               <CollapsibleContent className="mt-2">
@@ -223,7 +226,7 @@ export function CourtCaseCard({ courtCaseId, courtCase, isLoading, linkToDetail 
                       </tr>
                     </thead>
                     <tbody>
-                      {[...courtCase.hearings]
+                      {[...(courtCase.hearings ?? [])]
                         .sort((a, b) => a.hearing_date_ad.localeCompare(b.hearing_date_ad))
                         .map((hearing: CourtCaseHearing) => (
                           <tr key={hearing.id} className="border-b border-border/50 last:border-0">

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -158,8 +158,11 @@ export interface CourtCase {
   verdict_date_ad: string | null;
   verdict_judge: string | null;
   status: string;
-  hearings: CourtCaseHearing[];
-  entities: CourtCaseEntity[];
+  // Sub-resources present only on the assembled "full" shape (getCourtCaseFull).
+  // The composite-key core endpoint (getCourtCase) omits them entirely, so every
+  // reader must treat them as optional and default to [].
+  hearings?: CourtCaseHearing[];
+  entities?: CourtCaseEntity[];
 }
 
 export interface Case {


### PR DESCRIPTION
## Problem

The case-detail page white-screens with `TypeError: e.entities is not iterable` (React ErrorBoundary) on any case that cites court cases — e.g. https://jawafdehi.org/case/rabi-lamichhane-cooperative-fr-11ccd7.

## Root cause

`CaseDetail.tsx` fetches each cited court case via `getCourtCase()` — the composite-key **core** endpoint `/api/courtcases/<court>/<case_number>/`, which returns **no `entities` or `hearings` keys**. Those sub-resources only exist on the *assembled* shape from `getCourtCaseFull()` (used by the standalone `/courtcase/*` profile page).

The shared `CourtCaseCard.getPartiesByRole()` did `for (const entity of courtCase.entities)`. On the core shape `entities` is `undefined`, so the `for...of` throws `entities is not iterable` (minified: `e.entities is not iterable`) and takes down the whole page. The `CourtCase` type declared `entities`/`hearings` as **required** arrays, so TypeScript never flagged the mismatch. The case's own data is fine — this is purely a frontend data-shape bug, and it affects **every** case that cites court cases.

## Fix

- **`types/jds.ts`** — make `CourtCase.hearings`/`entities` optional (present only on the full shape), forcing readers to guard.
- **`CourtCaseCard.tsx`** — guard the `entities` `for...of` and the `hearings` `.length`/spread with `?? []`. On the core shape the card gracefully falls back to the `plaintiff`/`defendant` string fields the core endpoint *does* provide, and omits the (empty) hearings collapsible.
- **`CourtCaseCard.test.tsx`** — regression test covering the core shape (no crash + string fallback, no hearings) and the full shape (party entities + hearings render).

## Verification

- `eslint` clean on changed files (husky pre-commit `eslint --fix` passed)
- `vitest run`: **108 passed** (106 existing + 2 new)
- New test fails without the guard, passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Court case cards now handle cases with missing party details or hearings without errors.
  * Hearing information only appears when available, and counts/listing are shown correctly.
  * Party names continue to display properly from either structured party data or fallback text.

* **Tests**
  * Added coverage for both minimal and fully populated court case views to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->