### PR TITLE
Court-case refs as @id IRIs (Case.court_cases IRI cutover)

### DIFF
--- a/src/components/CaseDetailBanner.tsx
+++ b/src/components/CaseDetailBanner.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import type { CaseDetail, JawafEntity } from "@/types/jds";
 import type { Entity } from "@/types/entity";
 import { formatCaseDateRange } from "@/utils/date";
+import { parseCourtCaseRef } from "@/utils/courtCaseRef";
 import { getPrimaryName } from "@/utils/entity-helpers";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { formatBigo } from "@/utils/number";
@@ -165,28 +166,24 @@ export function CaseDetailBanner({
               <span>
                 {t("caseDetail.courtCases")}:{" "}
                 {caseData.court_cases.map((courtCase, index) => {
-                  // Parse court identifier defensively - split only on first colon
-                  const colonIndex = courtCase.indexOf(":");
-                  if (colonIndex === -1) {
-                    // No colon found - skip this entry
+                  // Refs arrive as the canonical @id IRI or the legacy
+                  // `<court>:<number>` form; skip anything unparseable.
+                  const parts = parseCourtCaseRef(courtCase);
+                  if (!parts) {
                     return null;
                   }
-                  
-                  const courtId = courtCase.substring(0, colonIndex).trim();
-                  const caseNumber = courtCase.substring(colonIndex + 1).trim();
-                  
-                  // Skip if either part is empty
-                  if (!courtId || !caseNumber) {
-                    return null;
-                  }
-                  
+
+                  const courtId = parts.court.toLowerCase();
+                  // IRIs carry the number lowercased; display it uppercase.
+                  const caseNumber = parts.caseNumber.toUpperCase();
+
                   const courtNameMap: Record<string, { en: string; ne: string }> = {
                     supreme: { en: "Supreme Court", ne: "सर्वोच्च अदालत" },
                     special: { en: "Special Court", ne: "विशेष अदालत" },
                   };
                   const courtName = courtNameMap[courtId]?.[currentLang] || courtId;
                   const displayText = `${caseNumber} (${courtName})`;
-                  
+
                   return (
                     <span key={index}>
                       {displayText}

--- a/src/components/CourtCaseCard.test.tsx
+++ b/src/components/CourtCaseCard.test.tsx
@@ -75,4 +75,25 @@ describe("CourtCaseCard", () => {
     expect(screen.getByText("Gitendra Babu Rai")).toBeTruthy();
     expect(screen.getByText(/Hearings/)).toBeTruthy();
   });
+
+  it("parses @id IRI refs: court name, uppercased number, detail link", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <CourtCaseCard
+          courtCaseId="https://jawafdehi.org/courtcase/special/080-cr-0111"
+          courtCase={coreCase}
+          isLoading={false}
+          linkToDetail
+        />
+      </MemoryRouter>,
+    );
+
+    // The IRI carries the number lowercased; the card displays it uppercase
+    // with the mapped court name, and links to the composite-key detail page.
+    expect(screen.getAllByText(/080-CR-0111/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Special Court/).length).toBeGreaterThan(0);
+    expect(
+      container.querySelector('a[href="/courtcase/special/080-cr-0111"]'),
+    ).toBeTruthy();
+  });
 });

--- a/src/components/CourtCaseCard.test.tsx
+++ b/src/components/CourtCaseCard.test.tsx
@@ -44,7 +44,7 @@ describe("CourtCaseCard", () => {
   it("renders the core (no entities/hearings) shape without crashing", () => {
     render(
       <MemoryRouter>
-        <CourtCaseCard courtCaseId="kathmandudc:080-C4-2408" courtCase={coreCase} isLoading={false} />
+        <CourtCaseCard courtCaseId="https://jawafdehi.org/courtcase/kathmandudc/080-c4-2408" courtCase={coreCase} isLoading={false} />
       </MemoryRouter>,
     );
 
@@ -67,7 +67,7 @@ describe("CourtCaseCard", () => {
 
     render(
       <MemoryRouter>
-        <CourtCaseCard courtCaseId="kathmandudc:080-C4-2408" courtCase={fullCase} isLoading={false} />
+        <CourtCaseCard courtCaseId="https://jawafdehi.org/courtcase/kathmandudc/080-c4-2408" courtCase={fullCase} isLoading={false} />
       </MemoryRouter>,
     );
 

--- a/src/components/CourtCaseCard.tsx
+++ b/src/components/CourtCaseCard.tsx
@@ -4,6 +4,7 @@ import { Scale, ChevronDown } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import type { CourtCase, CourtCaseHearing } from "@/types/jds";
+import { parseCourtCaseRef } from "@/utils/courtCaseRef";
 import { formatDateWithBS } from "@/utils/date";
 
 // ── Court identifier parsing ──────────────────────────────────────────────
@@ -25,19 +26,21 @@ function parseCourtIdentifier(
   courtIdentifier: string,
   lang: string
 ): { courtName: string; caseNumber: string } {
-  const colonIdx = courtIdentifier.indexOf(":");
-  if (colonIdx === -1) {
+  // Refs arrive as the canonical @id IRI or the legacy `<court>:<number>` form.
+  const parts = parseCourtCaseRef(courtIdentifier);
+  if (!parts) {
     return { courtName: courtIdentifier, caseNumber: "" };
   }
 
-  const prefix = courtIdentifier.slice(0, colonIdx).toLowerCase();
-  const caseNumber = courtIdentifier.slice(colonIdx + 1);
+  const prefix = parts.court.toLowerCase();
+  // IRIs carry the number lowercased; display it in its natural uppercase.
+  const caseNumber = parts.caseNumber.toUpperCase();
 
   let courtName: string;
   if (lang === "ne" && COURT_NAMES_NE[prefix]) {
     courtName = COURT_NAMES_NE[prefix];
   } else {
-    courtName = COURT_NAMES_EN[prefix] ?? courtIdentifier.slice(0, colonIdx);
+    courtName = COURT_NAMES_EN[prefix] ?? parts.court;
   }
 
   return { courtName, caseNumber };
@@ -86,15 +89,12 @@ interface CourtCaseCardProps {
   linkToDetail?: boolean;
 }
 
-// The /courtcase/* detail path for a `<court>:<case_number>` id (or null if the
-// id isn't in that composite form).
+// The /courtcase/* detail path for a court-case ref — @id IRI or
+// `<court>:<case_number>` (or null if the id is in neither form).
 function courtCaseDetailPath(courtCaseId: string): string | null {
-  const colonIdx = courtCaseId.indexOf(":");
-  if (colonIdx === -1) return null;
-  const court = courtCaseId.slice(0, colonIdx);
-  const caseNumber = courtCaseId.slice(colonIdx + 1);
-  if (!court || !caseNumber) return null;
-  return `/courtcase/${court}/${encodeURIComponent(caseNumber)}`;
+  const parts = parseCourtCaseRef(courtCaseId);
+  if (!parts) return null;
+  return `/courtcase/${parts.court}/${encodeURIComponent(parts.caseNumber)}`;
 }
 
 export function CourtCaseCard({ courtCaseId, courtCase, isLoading, linkToDetail }: CourtCaseCardProps) {

--- a/src/lib/jawafdehi-forms.test.ts
+++ b/src/lib/jawafdehi-forms.test.ts
@@ -48,9 +48,15 @@ describe("isValidCourtCaseRef", () => {
     expect(isValidCourtCaseRef("special:081-CR-0136")).toBe(true);
     expect(isValidCourtCaseRef("e2e-district-court:E2E-001")).toBe(true);
   });
-  it("rejects missing colon or scheme", () => {
+  it("accepts canonical court-case @id IRIs (the stored wire format)", () => {
+    expect(
+      isValidCourtCaseRef("https://jawafdehi.org/courtcase/special/080-cr-0111"),
+    ).toBe(true);
+  });
+  it("rejects missing colon or non-courtcase IRIs", () => {
     expect(isValidCourtCaseRef("special")).toBe(false);
     expect(isValidCourtCaseRef("https://x/y")).toBe(false);
+    expect(isValidCourtCaseRef("https://jawafdehi.org/entity/person/foo")).toBe(false);
   });
 });
 

--- a/src/lib/jawafdehi-forms.test.ts
+++ b/src/lib/jawafdehi-forms.test.ts
@@ -44,16 +44,13 @@ describe("isValidDateField", () => {
 });
 
 describe("isValidCourtCaseRef", () => {
-  it("accepts court:case_number", () => {
-    expect(isValidCourtCaseRef("special:081-CR-0136")).toBe(true);
-    expect(isValidCourtCaseRef("e2e-district-court:E2E-001")).toBe(true);
-  });
-  it("accepts canonical court-case @id IRIs (the stored wire format)", () => {
+  it("accepts canonical court-case @id IRIs (the only format)", () => {
     expect(
       isValidCourtCaseRef("https://jawafdehi.org/courtcase/special/080-cr-0111"),
     ).toBe(true);
   });
-  it("rejects missing colon or non-courtcase IRIs", () => {
+  it("rejects the retired colon spelling and non-courtcase IRIs", () => {
+    expect(isValidCourtCaseRef("special:081-CR-0136")).toBe(false);
     expect(isValidCourtCaseRef("special")).toBe(false);
     expect(isValidCourtCaseRef("https://x/y")).toBe(false);
     expect(isValidCourtCaseRef("https://jawafdehi.org/entity/person/foo")).toBe(false);

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -124,11 +124,8 @@ export function isValidDateField(value: string): boolean {
   return v === "" || /^\d{4}-\d{1,2}-\d{1,2}$/.test(v);
 }
 
-// A court-case reference INPUT: the "<court>:<case_number>" short form or the
-// canonical court-case @id IRI — exactly what parseCourtCaseRef accepts (ONE
-// grammar; a second regex here would drift from the submit converter). The
-// API accepts IRIs only — the editor converts chips via courtCaseInputToIri
-// on submit.
+// A court-case reference: the canonical @id IRI — the ONLY format, exactly
+// what parseCourtCaseRef accepts (one grammar, shared with the renderers).
 export function isValidCourtCaseRef(value: string): boolean {
   return parseCourtCaseRef(value) !== null;
 }

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/types/jds";
 import type { PatchOp } from "@/services/admin-api";
 import { isValidEntityIri } from "@/lib/datalake-forms";
+import { parseCourtCaseRef } from "@/utils/courtCaseRef";
 
 // Corruption-case type + workflow-state choices (see types/jds.ts).
 export const CASE_TYPES: readonly CaseType[] = [
@@ -123,13 +124,13 @@ export function isValidDateField(value: string): boolean {
   return v === "" || /^\d{4}-\d{1,2}-\d{1,2}$/.test(v);
 }
 
-// A court-case reference is "<court>:<case_number>" — lowercase-alnum court id,
-// then a hyphen/alnum case number, no slashes/scheme (mirrors the /court_cases
-// patch value shape).
-export const COURT_CASE_REF_RE = /^[a-z0-9-]+:[A-Za-z0-9-]+$/;
-
+// A court-case reference INPUT: the "<court>:<case_number>" short form or the
+// canonical court-case @id IRI — exactly what parseCourtCaseRef accepts (ONE
+// grammar; a second regex here would drift from the submit converter). The
+// API accepts IRIs only — the editor converts chips via courtCaseInputToIri
+// on submit.
 export function isValidCourtCaseRef(value: string): boolean {
-  return COURT_CASE_REF_RE.test(value.trim());
+  return parseCourtCaseRef(value) !== null;
 }
 
 // An entity-relationship row is complete when it has a valid entity IRI and a

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -37,6 +37,7 @@ import EvidenceEditor from "@/components/admin/case/EvidenceEditor";
 import ChipListEditor from "@/components/admin/case/ChipListEditor";
 import CaseStateControl from "@/components/admin/case/CaseStateControl";
 import DatePairInput from "@/components/admin/DatePairInput";
+import { courtCaseInputToIri, shortCourtCaseRef } from "@/utils/courtCaseRef";
 import { FormError, FieldError } from "@/components/admin/FormError";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -158,7 +159,11 @@ function fromCase(c: Record<string, unknown>): CaseFormState {
     thumbnail_url: str(c.thumbnail_url),
     banner_url: str(c.banner_url),
     tags: strList(c.tags),
-    court_cases: strList(c.court_cases),
+    // Stored refs are canonical @id IRIs; edit them in the compact
+    // `<court>:<CASE-NUMBER>` form (converted back to IRIs on submit — the
+    // API accepts IRIs only). Both `form` and `original` come through this
+    // mapping, so the diff comparison stays consistent.
+    court_cases: strList(c.court_cases).map((ref) => shortCourtCaseRef(ref) ?? ref),
     case_start_date: str(c.case_start_date),
     case_start_date_bs: str(c.case_start_date_bs),
     case_end_date: str(c.case_end_date),
@@ -244,6 +249,11 @@ export default function AdminCaseForm() {
   const entityRowsValid = form.entities.every(
     (r) => r.nes_id.trim() === "" || isValidEntityRow(r),
   );
+  // An invalid court-case chip would 422 the whole PATCH (they are sent
+  // verbatim rather than silently dropped) — block save until fixed.
+  const courtCaseRowsValid = form.court_cases.every(
+    (c) => c.trim() === "" || isValidCourtCaseRef(c),
+  );
   const canSave =
     !saving &&
     form.title.trim() !== "" &&
@@ -252,7 +262,8 @@ export default function AdminCaseForm() {
     bigoValid &&
     datesValid &&
     timelineRowsValid &&
-    entityRowsValid;
+    entityRowsValid &&
+    courtCaseRowsValid;
 
   // Build the RFC-6902 patch, emitting an op only for fields that changed.
   // Scalars use replace; sub-resources (entities/timeline/evidence) use a
@@ -288,7 +299,17 @@ export default function AdminCaseForm() {
     if (changed(form.tags, original.tags))
       ops.push(buildStringListPatch("/tags", form.tags));
     if (changed(form.court_cases, original.court_cases))
-      ops.push(buildStringListPatch("/court_cases", form.court_cases));
+      // Chips are edited in the compact <court>:<NUMBER> form; the API takes
+      // canonical @id IRIs only, so convert on submit.
+      ops.push(
+        buildStringListPatch(
+          "/court_cases",
+          // NEVER silently drop a chip: an unconvertible ref (possible for
+          // dirty legacy data surfaced verbatim by fromCase) is sent as-is so
+          // the API rejects it loudly instead of the replace op deleting it.
+          form.court_cases.map((ref) => courtCaseInputToIri(ref) ?? ref),
+        ),
+      );
     if (form.case_start_date !== original.case_start_date)
       ops.push(replaceOp("/case_start_date", form.case_start_date || null));
     if (form.case_start_date_bs !== original.case_start_date_bs)

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -37,7 +37,6 @@ import EvidenceEditor from "@/components/admin/case/EvidenceEditor";
 import ChipListEditor from "@/components/admin/case/ChipListEditor";
 import CaseStateControl from "@/components/admin/case/CaseStateControl";
 import DatePairInput from "@/components/admin/DatePairInput";
-import { courtCaseInputToIri, shortCourtCaseRef } from "@/utils/courtCaseRef";
 import { FormError, FieldError } from "@/components/admin/FormError";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -159,11 +158,8 @@ function fromCase(c: Record<string, unknown>): CaseFormState {
     thumbnail_url: str(c.thumbnail_url),
     banner_url: str(c.banner_url),
     tags: strList(c.tags),
-    // Stored refs are canonical @id IRIs; edit them in the compact
-    // `<court>:<CASE-NUMBER>` form (converted back to IRIs on submit — the
-    // API accepts IRIs only). Both `form` and `original` come through this
-    // mapping, so the diff comparison stays consistent.
-    court_cases: strList(c.court_cases).map((ref) => shortCourtCaseRef(ref) ?? ref),
+    // Canonical @id IRIs — the only court-case reference format.
+    court_cases: strList(c.court_cases),
     case_start_date: str(c.case_start_date),
     case_start_date_bs: str(c.case_start_date_bs),
     case_end_date: str(c.case_end_date),
@@ -299,17 +295,7 @@ export default function AdminCaseForm() {
     if (changed(form.tags, original.tags))
       ops.push(buildStringListPatch("/tags", form.tags));
     if (changed(form.court_cases, original.court_cases))
-      // Chips are edited in the compact <court>:<NUMBER> form; the API takes
-      // canonical @id IRIs only, so convert on submit.
-      ops.push(
-        buildStringListPatch(
-          "/court_cases",
-          // NEVER silently drop a chip: an unconvertible ref (possible for
-          // dirty legacy data surfaced verbatim by fromCase) is sent as-is so
-          // the API rejects it loudly instead of the replace op deleting it.
-          form.court_cases.map((ref) => courtCaseInputToIri(ref) ?? ref),
-        ),
-      );
+      ops.push(buildStringListPatch("/court_cases", form.court_cases));
     if (form.case_start_date !== original.case_start_date)
       ops.push(replaceOp("/case_start_date", form.case_start_date || null));
     if (form.case_start_date_bs !== original.case_start_date_bs)
@@ -553,10 +539,10 @@ export default function AdminCaseForm() {
           label="Court-case references"
           items={form.court_cases}
           onChange={(items) => set("court_cases", items)}
-          placeholder="court:case_number (e.g. special:081-CR-0136)"
-          help="Link related court cases as <court>:<case_number>."
+          placeholder="https://jawafdehi.org/courtcase/special/081-cr-0136"
+          help="Link related court cases by their canonical @id IRI."
           validate={isValidCourtCaseRef}
-          invalidHint="Use the form <court>:<case_number>."
+          invalidHint="Use the canonical court-case @id IRI."
         />
 
         <DatePairInput

--- a/src/services/datalake-api.ts
+++ b/src/services/datalake-api.ts
@@ -16,6 +16,7 @@
 
 import { http, extractErrorMessage } from './http';
 import { JDSApiError } from './jds-api';
+import { parseCourtCaseRef as parseRefParts } from '@/utils/courtCaseRef';
 import type { CourtCase, CourtCaseHearing, CourtCaseEntity } from '@/types/jds';
 
 // A material @id IRI path component (`<source>/<ident>`) or a full IRI. The detail
@@ -70,14 +71,15 @@ export async function getMaterial(iriOrTail: string): Promise<Material> {
 }
 
 /**
- * Parse a court-case ref into its composite key. Refs travel as `<court>:<number>`
- * (e.g. `special:081-CR-0060`, the form `Case.court_cases[]` carries); a bare number
- * with no court prefix is returned with an empty court.
+ * Parse a court-case ref into its composite key. Refs travel as the canonical
+ * @id IRI (`https://<host>/courtcase/special/081-cr-0060`, the form
+ * `Case.court_cases[]` carries) or the legacy `<court>:<number>` short form; a
+ * bare number with no court prefix is returned with an empty court.
  */
 export function parseCourtCaseRef(ref: string): { court: string; caseNumber: string } {
-  const idx = ref.indexOf(':');
-  if (idx === -1) return { court: '', caseNumber: ref };
-  return { court: ref.slice(0, idx), caseNumber: ref.slice(idx + 1) };
+  const parts = parseRefParts(ref);
+  if (parts) return { court: parts.court, caseNumber: parts.caseNumber };
+  return { court: '', caseNumber: ref };
 }
 
 /**

--- a/src/services/datalake-api.ts
+++ b/src/services/datalake-api.ts
@@ -71,14 +71,22 @@ export async function getMaterial(iriOrTail: string): Promise<Material> {
 }
 
 /**
- * Parse a court-case ref into its composite key. Refs travel as the canonical
- * @id IRI (`https://<host>/courtcase/special/081-cr-0060`, the form
- * `Case.court_cases[]` carries) or the legacy `<court>:<number>` short form; a
- * bare number with no court prefix is returned with an empty court.
+ * Parse a court-case lookup id into its composite key. Ids are the canonical
+ * @id IRI (`https://<host>/courtcase/special/081-cr-0060`, the only form
+ * `Case.court_cases[]` carries) or an INTERNAL `<court>:<number>` lookup key
+ * (what `courtRefCandidates` builds when probing a bare number from the URL —
+ * a URL-construction detail, not a reference format); a bare number with no
+ * court is returned with an empty court.
  */
 export function parseCourtCaseRef(ref: string): { court: string; caseNumber: string } {
   const parts = parseRefParts(ref);
   if (parts) return { court: parts.court, caseNumber: parts.caseNumber };
+  if (!ref.includes('://')) {
+    const idx = ref.indexOf(':');
+    if (idx > 0 && idx < ref.length - 1) {
+      return { court: ref.slice(0, idx), caseNumber: ref.slice(idx + 1) };
+    }
+  }
   return { court: '', caseNumber: ref };
 }
 

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -179,7 +179,7 @@ export interface Case {
   entities: JawafEntity[]; // Unified entity relationships with type field
   tags: string[]; // Tags for categorization (e.g., 'land-encroachment', 'national-interest')
   key_allegations: string[]; // List of key allegation statements
-  court_cases: string[]; // Court case IDs (e.g., "special:081-CR-0060")
+  court_cases: string[]; // Canonical court-case @id IRIs (e.g., "https://jawafdehi.org/courtcase/special/081-cr-0060"); legacy "<court>:<number>" tolerated on read
   bigo?: number | null;
   created_at: string; // ISO datetime
   updated_at: string; // ISO datetime

--- a/src/utils/courtCaseRef.test.ts
+++ b/src/utils/courtCaseRef.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { isCourtCaseRef, courtRefCandidates } from './courtCaseRef';
+import {
+  isCourtCaseRef,
+  courtRefCandidates,
+  courtCaseInputToIri,
+  parseCourtCaseRef,
+  shortCourtCaseRef,
+} from './courtCaseRef';
 
 describe('isCourtCaseRef', () => {
   it('matches bare court case numbers', () => {
@@ -22,5 +28,57 @@ describe('courtRefCandidates', () => {
       'special:081-CR-0116',
       'supreme:081-CR-0116',
     ]);
+  });
+});
+
+describe('parseCourtCaseRef', () => {
+  it('parses canonical @id IRIs', () => {
+    expect(
+      parseCourtCaseRef('https://jawafdehi.org/courtcase/special/080-cr-0111'),
+    ).toEqual({ court: 'special', caseNumber: '080-cr-0111' });
+    expect(
+      parseCourtCaseRef('https://jawafdehi.org/courtcase/supreme/078-wc-0123/'),
+    ).toEqual({ court: 'supreme', caseNumber: '078-wc-0123' });
+  });
+
+  it('parses the legacy short form', () => {
+    expect(parseCourtCaseRef('special:081-CR-0116')).toEqual({
+      court: 'special',
+      caseNumber: '081-CR-0116',
+    });
+    expect(parseCourtCaseRef('  supreme:078-WC-0123 ')).toEqual({
+      court: 'supreme',
+      caseNumber: '078-WC-0123',
+    });
+  });
+
+  it('rejects non-court refs', () => {
+    expect(parseCourtCaseRef(undefined)).toBeNull();
+    expect(parseCourtCaseRef('')).toBeNull();
+    expect(parseCourtCaseRef('081-CR-0116')).toBeNull();
+    expect(parseCourtCaseRef('special:')).toBeNull();
+    expect(parseCourtCaseRef('https://jawafdehi.org/entity/person/foo')).toBeNull();
+  });
+});
+
+describe('shortCourtCaseRef', () => {
+  it('re-emits IRIs as <court>:<CASE-NUMBER>', () => {
+    expect(
+      shortCourtCaseRef('https://jawafdehi.org/courtcase/special/080-cr-0111'),
+    ).toBe('special:080-CR-0111');
+    expect(shortCourtCaseRef('supreme:078-wc-0123')).toBe('supreme:078-WC-0123');
+    expect(shortCourtCaseRef('garbage')).toBeNull();
+  });
+});
+
+describe('courtCaseInputToIri', () => {
+  it('builds the canonical lowercase IRI from either input form', () => {
+    expect(courtCaseInputToIri('special:080-CR-0111')).toBe(
+      'https://jawafdehi.org/courtcase/special/080-cr-0111',
+    );
+    expect(
+      courtCaseInputToIri('https://jawafdehi.org/courtcase/special/080-cr-0111'),
+    ).toBe('https://jawafdehi.org/courtcase/special/080-cr-0111');
+    expect(courtCaseInputToIri('garbage')).toBeNull();
   });
 });

--- a/src/utils/courtCaseRef.test.ts
+++ b/src/utils/courtCaseRef.test.ts
@@ -59,6 +59,15 @@ describe('parseCourtCaseRef', () => {
     expect(parseCourtCaseRef('special:')).toBeNull();
     expect(parseCourtCaseRef('https://jawafdehi.org/entity/person/foo')).toBeNull();
   });
+
+  it('fails closed on malformed input instead of throwing', () => {
+    // Lone % in an IRI segment would make decodeURIComponent throw URIError.
+    expect(
+      parseCourtCaseRef('https://jawafdehi.org/courtcase/special/080%-cr'),
+    ).toBeNull();
+    // Slashes in the short form would corrupt the IRI path structure.
+    expect(parseCourtCaseRef('special:080/81-CR-0111')).toBeNull();
+  });
 });
 
 describe('shortCourtCaseRef', () => {

--- a/src/utils/courtCaseRef.test.ts
+++ b/src/utils/courtCaseRef.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isCourtCaseRef,
   courtRefCandidates,
-  courtCaseInputToIri,
   parseCourtCaseRef,
-  shortCourtCaseRef,
 } from './courtCaseRef';
 
 describe('isCourtCaseRef', () => {
@@ -41,15 +39,9 @@ describe('parseCourtCaseRef', () => {
     ).toEqual({ court: 'supreme', caseNumber: '078-wc-0123' });
   });
 
-  it('parses the legacy short form', () => {
-    expect(parseCourtCaseRef('special:081-CR-0116')).toEqual({
-      court: 'special',
-      caseNumber: '081-CR-0116',
-    });
-    expect(parseCourtCaseRef('  supreme:078-WC-0123 ')).toEqual({
-      court: 'supreme',
-      caseNumber: '078-WC-0123',
-    });
+  it('rejects the retired colon spelling (IRIs are the only format)', () => {
+    expect(parseCourtCaseRef('special:081-CR-0116')).toBeNull();
+    expect(parseCourtCaseRef('supreme:078-WC-0123')).toBeNull();
   });
 
   it('rejects non-court refs', () => {
@@ -65,29 +57,7 @@ describe('parseCourtCaseRef', () => {
     expect(
       parseCourtCaseRef('https://jawafdehi.org/courtcase/special/080%-cr'),
     ).toBeNull();
-    // Slashes in the short form would corrupt the IRI path structure.
-    expect(parseCourtCaseRef('special:080/81-CR-0111')).toBeNull();
   });
 });
 
-describe('shortCourtCaseRef', () => {
-  it('re-emits IRIs as <court>:<CASE-NUMBER>', () => {
-    expect(
-      shortCourtCaseRef('https://jawafdehi.org/courtcase/special/080-cr-0111'),
-    ).toBe('special:080-CR-0111');
-    expect(shortCourtCaseRef('supreme:078-wc-0123')).toBe('supreme:078-WC-0123');
-    expect(shortCourtCaseRef('garbage')).toBeNull();
-  });
-});
 
-describe('courtCaseInputToIri', () => {
-  it('builds the canonical lowercase IRI from either input form', () => {
-    expect(courtCaseInputToIri('special:080-CR-0111')).toBe(
-      'https://jawafdehi.org/courtcase/special/080-cr-0111',
-    );
-    expect(
-      courtCaseInputToIri('https://jawafdehi.org/courtcase/special/080-cr-0111'),
-    ).toBe('https://jawafdehi.org/courtcase/special/080-cr-0111');
-    expect(courtCaseInputToIri('garbage')).toBeNull();
-  });
-});

--- a/src/utils/courtCaseRef.ts
+++ b/src/utils/courtCaseRef.ts
@@ -37,64 +37,24 @@ export interface CourtCaseRefParts {
 }
 
 /**
- * Parse a court-case reference in either form — the canonical @id IRI
- * (`https://<host>/courtcase/special/081-cr-0116`) or the legacy
- * `<court>:<case_number>` short form. Returns null when it is neither.
+ * Parse a canonical court-case @id IRI
+ * (`https://<host>/courtcase/special/081-cr-0116`) — the ONLY court-case
+ * reference format. Returns null for anything else.
  */
 export function parseCourtCaseRef(
   ref: string | null | undefined,
 ): CourtCaseRefParts | null {
   if (!ref) return null;
-  const trimmed = ref.trim();
-  const iri = COURTCASE_IRI_RE.exec(trimmed);
-  if (iri) {
-    // Malformed percent-encoding throws URIError — this parser runs during
-    // render and validation, so fail closed instead of crashing the UI.
-    try {
-      return {
-        court: decodeURIComponent(iri[1]),
-        caseNumber: decodeURIComponent(iri[2]),
-      };
-    } catch {
-      return null;
-    }
+  const iri = COURTCASE_IRI_RE.exec(ref.trim());
+  if (!iri) return null;
+  // Malformed percent-encoding throws URIError — this parser runs during
+  // render and validation, so fail closed instead of crashing the UI.
+  try {
+    return {
+      court: decodeURIComponent(iri[1]),
+      caseNumber: decodeURIComponent(iri[2]),
+    };
+  } catch {
+    return null;
   }
-  if (trimmed.includes('://')) return null;
-  const idx = trimmed.indexOf(':');
-  if (idx === -1) return null;
-  const court = trimmed.slice(0, idx).trim();
-  const caseNumber = trimmed.slice(idx + 1).trim();
-  if (!court || !caseNumber) return null;
-  // A slash would change the IRI's path structure (and the backend grammar
-  // rejects it anyway) — treat such input as invalid here so the editor
-  // flags the chip inline instead of building a malformed IRI.
-  if (court.includes('/') || caseNumber.includes('/')) return null;
-  return { court, caseNumber };
-}
-
-/**
- * Compact `<court>:<CASE-NUMBER>` spelling for a ref in either form (IRIs are
- * lowercase; case numbers read naturally uppercased). Null when unparseable.
- */
-export function shortCourtCaseRef(ref: string | null | undefined): string | null {
-  const parts = parseCourtCaseRef(ref);
-  return parts ? `${parts.court}:${parts.caseNumber.toUpperCase()}` : null;
-}
-
-// The platform identity authority for @id IRIs. This is the IRI NAMESPACE
-// (the same value in every environment), not the serving host.
-export const COURTCASE_IRI_BASE = 'https://jawafdehi.org';
-
-/**
- * Build the canonical court-case @id IRI (lowercased) from a ref in either
- * input form — a short `<court>:<number>` editor chip or an already-full IRI.
- * The API accepts canonical IRIs only, so the editor converts on submit.
- * Null when unparseable.
- */
-export function courtCaseInputToIri(ref: string | null | undefined): string | null {
-  const parts = parseCourtCaseRef(ref);
-  if (!parts) return null;
-  const court = parts.court.toLowerCase();
-  const caseNumber = parts.caseNumber.toLowerCase();
-  return `${COURTCASE_IRI_BASE}/courtcase/${court}/${caseNumber}`;
 }

--- a/src/utils/courtCaseRef.ts
+++ b/src/utils/courtCaseRef.ts
@@ -26,3 +26,65 @@ export function isCourtCaseRef(id: string | undefined): boolean {
 export function courtRefCandidates(ref: string): string[] {
   return COURT_IDENTIFIERS.map((court) => `${court}:${ref}`);
 }
+
+// Canonical court-case @id IRI (the form `Case.court_cases[]` carries):
+// https://<host>/courtcase/<court>/<case_number>
+const COURTCASE_IRI_RE = /^https?:\/\/[^/]+\/courtcase\/([^/]+)\/([^/]+)\/?$/;
+
+export interface CourtCaseRefParts {
+  court: string;
+  caseNumber: string;
+}
+
+/**
+ * Parse a court-case reference in either form — the canonical @id IRI
+ * (`https://<host>/courtcase/special/081-cr-0116`) or the legacy
+ * `<court>:<case_number>` short form. Returns null when it is neither.
+ */
+export function parseCourtCaseRef(
+  ref: string | null | undefined,
+): CourtCaseRefParts | null {
+  if (!ref) return null;
+  const trimmed = ref.trim();
+  const iri = COURTCASE_IRI_RE.exec(trimmed);
+  if (iri) {
+    return {
+      court: decodeURIComponent(iri[1]),
+      caseNumber: decodeURIComponent(iri[2]),
+    };
+  }
+  if (trimmed.includes('://')) return null;
+  const idx = trimmed.indexOf(':');
+  if (idx === -1) return null;
+  const court = trimmed.slice(0, idx).trim();
+  const caseNumber = trimmed.slice(idx + 1).trim();
+  if (!court || !caseNumber) return null;
+  return { court, caseNumber };
+}
+
+/**
+ * Compact `<court>:<CASE-NUMBER>` spelling for a ref in either form (IRIs are
+ * lowercase; case numbers read naturally uppercased). Null when unparseable.
+ */
+export function shortCourtCaseRef(ref: string | null | undefined): string | null {
+  const parts = parseCourtCaseRef(ref);
+  return parts ? `${parts.court}:${parts.caseNumber.toUpperCase()}` : null;
+}
+
+// The platform identity authority for @id IRIs. This is the IRI NAMESPACE
+// (the same value in every environment), not the serving host.
+export const COURTCASE_IRI_BASE = 'https://jawafdehi.org';
+
+/**
+ * Build the canonical court-case @id IRI (lowercased) from a ref in either
+ * input form — a short `<court>:<number>` editor chip or an already-full IRI.
+ * The API accepts canonical IRIs only, so the editor converts on submit.
+ * Null when unparseable.
+ */
+export function courtCaseInputToIri(ref: string | null | undefined): string | null {
+  const parts = parseCourtCaseRef(ref);
+  if (!parts) return null;
+  const court = parts.court.toLowerCase();
+  const caseNumber = parts.caseNumber.toLowerCase();
+  return `${COURTCASE_IRI_BASE}/courtcase/${court}/${caseNumber}`;
+}

--- a/src/utils/courtCaseRef.ts
+++ b/src/utils/courtCaseRef.ts
@@ -48,10 +48,16 @@ export function parseCourtCaseRef(
   const trimmed = ref.trim();
   const iri = COURTCASE_IRI_RE.exec(trimmed);
   if (iri) {
-    return {
-      court: decodeURIComponent(iri[1]),
-      caseNumber: decodeURIComponent(iri[2]),
-    };
+    // Malformed percent-encoding throws URIError — this parser runs during
+    // render and validation, so fail closed instead of crashing the UI.
+    try {
+      return {
+        court: decodeURIComponent(iri[1]),
+        caseNumber: decodeURIComponent(iri[2]),
+      };
+    } catch {
+      return null;
+    }
   }
   if (trimmed.includes('://')) return null;
   const idx = trimmed.indexOf(':');
@@ -59,6 +65,10 @@ export function parseCourtCaseRef(
   const court = trimmed.slice(0, idx).trim();
   const caseNumber = trimmed.slice(idx + 1).trim();
   if (!court || !caseNumber) return null;
+  // A slash would change the IRI's path structure (and the backend grammar
+  // rejects it anyway) — treat such input as invalid here so the editor
+  // flags the chip inline instead of building a malformed IRI.
+  if (court.includes('/') || caseNumber.includes('/')) return null;
   return { court, caseNumber };
 }
 


### PR DESCRIPTION
## What

Companion to Jawafdehi/JawafdehiAPI#284: the API now stores, returns, and accepts `Case.court_cases` exclusively as canonical court-case `@id` IRIs (`https://<host>/courtcase/<court>/<case_number>`, lowercased).

- `utils/courtCaseRef.parseCourtCaseRef` is the ONE ref grammar (`isValidCourtCaseRef` delegates to it — no second regex to drift). Used by the datalake composite-key lookup, `CourtCaseCard` (court name + `/courtcase/*` detail link), and the `CaseDetailBanner` display; numbers from IRIs display uppercased.
- The admin editor displays and edits **raw canonical IRIs** (the `court:number` spelling is fully retired per follow-up direction — `shortCourtCaseRef`/`courtCaseInputToIri` deleted); save is blocked while any chip is invalid. Companion backend follow-up: Jawafdehi/JawafdehiAPI#287.
- `COURTCASE_IRI_BASE` is hardcoded deliberately: it's the platform identity namespace (constant across environments), not the serving host — same convention as material/entity IRIs the SPA already round-trips.

## Deploy

Must ship together with JawafdehiAPI#284 — after the API's migration, the wire format is IRIs only (the old colon form 422s).

Tests: 115 passed (vitest), tsc + eslint clean. Reviewed by the same multi-agent pass as the API PR; the silent-chip-drop and dual-regex findings from that review are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Court case references now work in both canonical link form and the shorter `court:number` format.
  * Court case names and numbers are shown more consistently, with clearer formatting and localized court labels.

* **Bug Fixes**
  * Improved handling of malformed court case references by skipping invalid entries instead of showing broken output.
  * Admin editing now validates court case entries more reliably and converts them into the expected format when saving.
  * Added coverage for court case links and formatting to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

