### PR TITLE
fix(cms): drop case_id from related-case types

### DIFF
--- a/src/components/ArticleView.test.tsx
+++ b/src/components/ArticleView.test.tsx
@@ -27,7 +27,7 @@ const article: Article = {
     { type: "paragraph", value: "<p>Body paragraph</p>", id: "b2" },
   ],
   related_cases: [
-    { id: 3, case_id: "080-CR-0165", title: "Related case title", slug: "a-case" },
+    { id: 3, title: "Related case title", slug: "a-case" },
   ],
 };
 

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -27,7 +27,7 @@ export interface StreamDocumentValue {
 }
 
 export interface StreamCaseValue {
-  case: { id: number; case_id: string; title: string; slug: string } | null;
+  case: { id: number; title: string; slug: string } | null;
   note?: string;
 }
 
@@ -48,7 +48,6 @@ export type StreamBlock =
 
 export interface RelatedCase {
   id: number;
-  case_id: string;
   title: string;
   slug: string;
 }

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -27,7 +27,7 @@ export interface StreamDocumentValue {
 }
 
 export interface StreamCaseValue {
-  case: { id: number; title: string; slug: string } | null;
+  case: RelatedCase | null;
   note?: string;
 }
 


### PR DESCRIPTION
## Why

The platform `Case` model dropped its `case_id` column in favor of `slug`, and Jawafdehi/JawafdehiAPI#285 removes the field from the CMS article payloads (it was a latent 500 on the backend). The frontend never rendered `case_id` — `ArticleView` and `StreamField` use only `id`/`title`/`slug` — so this just brings the TypeScript types and one test fixture in line with the actual API contract.

## What

- `types/cms.ts`: remove `case_id` from `RelatedCase` and `StreamCaseValue`
- `ArticleView.test.tsx`: fixture updated accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)