### PR TITLE
fix(reviews): demand a case/court-case IRI to submit a review

### DIFF
--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -5,6 +5,7 @@ import {
   listReviewsGrouped,
   submitReview,
   buildSubmitPayload,
+  looksLikeReviewIri,
   regradeAll,
   apiErrorMessage,
 } from "@/services/casework-api";
@@ -183,7 +184,7 @@ export default function CaseworkReviews() {
           <div>
             <h1 className="text-xl font-bold">Case reviews</h1>
             <p className="text-sm text-muted-foreground">
-              Submit a case slug, court case number, or case URL to run a multi-dimensional
+              Submit a Jawafdehi case IRI or a court-case IRI to run a multi-dimensional
               quality review.
             </p>
           </div>
@@ -215,8 +216,14 @@ export default function CaseworkReviews() {
             <Input
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder="slug, court case no. (special:081-CR-0136), or case URL"
+              placeholder="https://jawafdehi.org/case/<slug> or …/courtcase/<court>/<case-no>"
             />
+            {input.trim() && !looksLikeReviewIri(input) && !err && (
+              <p className="text-sm text-amber-600 mt-1">
+                Enter a case IRI (https://jawafdehi.org/case/&lt;slug&gt;) or a court-case
+                IRI (…/courtcase/&lt;court&gt;/&lt;case-number&gt;).
+              </p>
+            )}
             {err && (
               <p className="text-sm text-red-600 mt-1">
                 {err}

--- a/src/services/casework-api.test.ts
+++ b/src/services/casework-api.test.ts
@@ -1,29 +1,43 @@
 import { describe, it, expect } from "vitest";
-import { buildSubmitPayload } from "./casework-api";
+import { buildSubmitPayload, looksLikeReviewIri } from "./casework-api";
 
 describe("buildSubmitPayload", () => {
-  it("routes a court case ref to court_case_number", () => {
-    expect(buildSubmitPayload("special:081-CR-0079")).toEqual({
-      court_case_number: "special:081-CR-0079",
-    });
-  });
-
-  it("routes a bare slug to slug", () => {
-    expect(buildSubmitPayload("case-081-cr-0136-oxygen-plant")).toEqual({
-      slug: "case-081-cr-0136-oxygen-plant",
-    });
-  });
-
-  it("routes a full case URL to slug (backend extracts the slug)", () => {
+  it("sends a Jawafdehi case IRI as `iri`", () => {
     expect(buildSubmitPayload("https://jawafdehi.org/case/alpha-case")).toEqual({
-      slug: "https://jawafdehi.org/case/alpha-case",
+      iri: "https://jawafdehi.org/case/alpha-case",
     });
+  });
+
+  it("sends a court-case IRI as `iri`", () => {
+    expect(
+      buildSubmitPayload("https://jawafdehi.org/courtcase/special/080-cr-0111")
+    ).toEqual({ iri: "https://jawafdehi.org/courtcase/special/080-cr-0111" });
   });
 
   it("trims surrounding whitespace", () => {
-    expect(buildSubmitPayload("  special:081-CR-0079  ")).toEqual({
-      court_case_number: "special:081-CR-0079",
+    expect(buildSubmitPayload("  https://jawafdehi.org/case/alpha-case  ")).toEqual({
+      iri: "https://jawafdehi.org/case/alpha-case",
     });
-    expect(buildSubmitPayload("  alpha-case  ")).toEqual({ slug: "alpha-case" });
+  });
+
+  it("forwards non-IRI input verbatim (the backend rejects it with a clear 400)", () => {
+    expect(buildSubmitPayload("080-CR-0111")).toEqual({ iri: "080-CR-0111" });
+  });
+});
+
+describe("looksLikeReviewIri", () => {
+  it("accepts case and court-case IRIs", () => {
+    expect(looksLikeReviewIri("https://jawafdehi.org/case/alpha-case")).toBe(true);
+    expect(
+      looksLikeReviewIri("https://jawafdehi.org/courtcase/special/080-cr-0111")
+    ).toBe(true);
+    expect(looksLikeReviewIri("  https://jawafdehi.org/case/alpha-case  ")).toBe(true);
+  });
+
+  it("rejects case numbers, names, and legacy court refs", () => {
+    expect(looksLikeReviewIri("080-CR-0111")).toBe(false);
+    expect(looksLikeReviewIri("Giribandhu")).toBe(false);
+    expect(looksLikeReviewIri("special:081-CR-0136")).toBe(false);
+    expect(looksLikeReviewIri("case-081-cr-0136-oxygen-plant")).toBe(false);
   });
 });

--- a/src/services/casework-api.test.ts
+++ b/src/services/casework-api.test.ts
@@ -40,4 +40,15 @@ describe("looksLikeReviewIri", () => {
     expect(looksLikeReviewIri("special:081-CR-0136")).toBe(false);
     expect(looksLikeReviewIri("case-081-cr-0136-oxygen-plant")).toBe(false);
   });
+
+  it("mirrors the backend: court-case numbers are lowercase-only (uppercase is not canonical)", () => {
+    // Court-case IRIs are strictly lowercase everywhere on the platform, so an
+    // uppercase number is not a valid court-case IRI — keep this in sync with
+    // the backend so the hint never says "ok" for something it will 400.
+    expect(
+      looksLikeReviewIri("https://jawafdehi.org/courtcase/special/080-CR-0111")
+    ).toBe(false);
+    // A case slug, by contrast, may contain uppercase.
+    expect(looksLikeReviewIri("https://jawafdehi.org/case/Case-Alpha")).toBe(true);
+  });
 });

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -19,21 +19,32 @@ const CASEWORK = "/api/casework";
 // ---- Reviews ----
 
 export interface SubmitReviewPayload {
+  // Caseworkers submit an `iri`: a Jawafdehi case IRI
+  // (https://jawafdehi.org/case/<slug>) or a court-case IRI
+  // (https://jawafdehi.org/courtcase/<court>/<case-number>). The backend
+  // resolves it to the case's canonical slug.
+  iri?: string;
+  // `slug` is used only by the internal re-run / regrade path, which already
+  // holds the resolved canonical slug.
   slug?: string;
-  court_case_number?: string;
 }
 
-// A court case ref is "<court>:<case_number>" (e.g. "special:081-CR-0079"):
-// lowercase-alnum court id, then a hyphen/alnum case number, no slashes/scheme.
-const COURT_REF_RE = /^[a-z0-9]+:[A-Za-z0-9-]+$/;
+// A submitted IRI is either a Jawafdehi case IRI or a court-case IRI. The
+// backend is the authority (it resolves + validates against the DB); this is a
+// lenient client-side shape check so the form can flag obviously-wrong input
+// (a bare case number, a name) before a round-trip.
+const REVIEW_IRI_RE =
+  /^https?:\/\/[^/]+\/(?:case\/[a-zA-Z][a-zA-Z0-9-]*|courtcase\/[a-z0-9][a-z0-9_-]*\/[a-z0-9][a-z0-9._-]*)$/;
 
-// Classify free-text input from the submit box into the right field. A court
-// case ref goes to `court_case_number`; everything else (a bare slug or a full
-// case URL like https://jawafdehi.org/case/<slug>) goes to `slug`, which the
-// backend normalizes (it extracts the slug from a URL).
+export function looksLikeReviewIri(raw: string): boolean {
+  return REVIEW_IRI_RE.test(raw.trim());
+}
+
+// The submit box demands an IRI (a Jawafdehi case IRI or a court-case IRI).
+// Send it verbatim as `iri`; the backend resolves it to the canonical case slug
+// and returns a clear 400 if it names no case.
 export function buildSubmitPayload(raw: string): SubmitReviewPayload {
-  const value = raw.trim();
-  return COURT_REF_RE.test(value) ? { court_case_number: value } : { slug: value };
+  return { iri: raw.trim() };
 }
 
 export async function listReviews(params?: {


### PR DESCRIPTION
## Why

The case-review submit box advertised "case slug, court case number, or case URL", but the backend only ever exact-matched a **canonical slug**. So a caseworker typing a case name (`giribandhu`), a court-case number (`080-CR-0111`), or a URL had it accepted and then fail ~5 min later at grade time with a misleading "seed it first" error. Only pasting the exact canonical slug worked.

## What

Match the new backend contract (Jawafdehi/JawafdehiAPI#292): **demand an IRI**.

- `buildSubmitPayload` sends the input verbatim as **`iri`** (a Jawafdehi case IRI `https://jawafdehi.org/case/<slug>` or a court-case IRI `…/courtcase/<court>/<case-number>`); the backend resolves it to the canonical case slug and returns a clear 400 if it names no case.
- Drop the `court_case_number` (`special:…`) path and `COURT_REF_RE`.
- Update the form description + placeholder to ask for an IRI.
- Add `looksLikeReviewIri` for an inline hint when the input clearly isn't an IRI (backend stays authoritative).
- The internal **re-run** path still submits the already-resolved `slug`.

## Tests

`casework-api.test.ts` rewritten for the IRI behavior (`buildSubmitPayload` + `looksLikeReviewIri`); vitest green, `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)