### PR TITLE
fix(admin): drop Courts & Blocklisted firms from Data Lake sidebar (BB-22)

### DIFF
--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/lib/roles";
 import { Button } from "@/components/ui/button";
 import {
-  Building2,
   ClipboardCheck,
   FileText,
   Gavel,
@@ -72,8 +71,6 @@ const NAV: NavGroup[] = [
     heading: "Data Lake",
     items: [
       { to: "/admin/datalake/courtcases", label: "Court cases", icon: Gavel, canAccess: hasNgmWriteAccess },
-      { to: "/admin/datalake/courts", label: "Courts", icon: Building2, canAccess: hasNgmWriteAccess },
-      { to: "/admin/datalake/firms", label: "Blocklisted firms", icon: Building2, canAccess: hasNgmWriteAccess },
       { to: "/admin/datalake/materials", label: "Materials", icon: ScrollText, canAccess: hasNgmWriteAccess },
     ],
   },


### PR DESCRIPTION
## BB-22 — Data Lake sidebar lists "Courts" & "Blocklisted firms"

Per the bug-bash decision, these two entries are removed from the admin **Data Lake** sidebar group (`src/components/admin/AdminLayout.tsx`). **Court cases** and **Materials** remain.

- Removed the `Courts` (`/admin/datalake/courts`) and `Blocklisted firms` (`/admin/datalake/firms`) nav items.
- Removed the now-orphaned `Building2` icon import.

Routes/pages (`Courts`, `Firms`, `FirmForm`) are left in place — reachable only by direct URL. Removing them entirely can be a follow-up.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)