### PR TITLE
fix(i18n): add missing caseCard.entitySummary.withOthersNepali key (BB-06)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -968,7 +968,8 @@
     "entitySummary": {
       "withOthers_one": "{{name}} with {{count}} other",
       "withOthers_other": "{{name}} with {{count}} others",
-      "withOthersNepali": "{{name}} with {{countLabel}} others"
+      "withOthersNepali_one": "{{name}} with {{countLabel}} other",
+      "withOthersNepali_other": "{{name}} with {{countLabel}} others"
     }
   },
   "entityCard": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -967,7 +967,8 @@
     },
     "entitySummary": {
       "withOthers_one": "{{name}} with {{count}} other",
-      "withOthers_other": "{{name}} with {{count}} others"
+      "withOthers_other": "{{name}} with {{count}} others",
+      "withOthersNepali": "{{name}} with {{countLabel}} others"
     }
   },
   "entityCard": {

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -967,7 +967,8 @@
     "entitySummary": {
       "withOthers_one": "{{name}} समेत {{count}} अन्य",
       "withOthers_other": "{{name}} समेत {{count}} अन्यहरू",
-      "withOthersNepali": "{{name}} समेत {{countLabel}} अन्यहरू"
+      "withOthersNepali_one": "{{name}} समेत {{countLabel}} अन्य",
+      "withOthersNepali_other": "{{name}} समेत {{countLabel}} अन्यहरू"
     }
   },
   "entityCard": {

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -966,7 +966,8 @@
     },
     "entitySummary": {
       "withOthers_one": "{{name}} समेत {{count}} अन्य",
-      "withOthers_other": "{{name}} समेत {{count}} अन्यहरू"
+      "withOthers_other": "{{name}} समेत {{count}} अन्यहरू",
+      "withOthersNepali": "{{name}} समेत {{countLabel}} अन्यहरू"
     }
   },
   "entityCard": {


### PR DESCRIPTION
## BB-06 — Raw i18n key leaks on case cards in Nepali mode

In NE mode, any case card whose entity list has more than one name rendered the literal string `caseCard.entitySummary.withOthersNepali` instead of "X समेत N अन्यहरू".

### Root cause
`src/components/CaseCard.tsx:52` (Nepali branch) calls `t("caseCard.entitySummary.withOthersNepali", …)`, but that key was **absent from both `en.json` and `ne.json`** and no `defaultValue` is passed. With `fallbackLng: 'ne'`, a key missing in `ne` has no fallback, so i18next returns the raw key. (The EN branch uses `withOthers` with working plural forms, which is why it only manifested in NE.)

### Fix
Add `withOthersNepali` to both locales, using the `{{countLabel}}` interpolation the call site already supplies (Nepali-digit-formatted count):
- `ne.json`: `"{{name}} समेत {{countLabel}} अन्यहरू"`
- `en.json`: `"{{name}} with {{countLabel}} others"` (safety fallback)

### Verification
- Both locale JSON files parse. `eslint`/lint-staged clean. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)