### PR TITLE
feat(admin): add search box to Jawafdehi cases list (BB-24)

### DIFF
--- a/src/pages/admin/jawafdehi/AdminCases.tsx
+++ b/src/pages/admin/jawafdehi/AdminCases.tsx
@@ -44,65 +44,71 @@ export default function AdminCases() {
   const [search, setSearch] = useState("");
 
   return (
-    <ResourceTable<Row>
-      // Re-mount the table (resetting pagination) whenever a filter changes,
-      // so the new fetchPage closure runs from page 1.
-      key={`${state}|${search}`}
-      title="Jawafdehi Cases"
-      description="Accountability / corruption cases. Full create / edit / delete."
-      columns={columns}
-      pageSize={PAGE_SIZE}
-      rowKey={(r) => str(r.slug ?? r.id)}
-      onRowClick={(r) => {
-        const slug = r.slug;
-        if (typeof slug === "string" && slug)
-          navigate(`/admin/jawafdehi/cases/${encodeURIComponent(slug)}/edit`);
-      }}
-      headerAction={
-        <div className="flex items-center gap-2">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              setSearch(query.trim());
-            }}
-            className="flex items-center gap-2"
-          >
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search cases…"
-              className="h-9 w-[14rem]"
-            />
-            <Button type="submit" size="sm" variant="secondary">
-              <Search className="mr-1 h-4 w-4" /> Search
+    // The search form lives ABOVE the table (not in headerAction): the table
+    // remounts on a new search term to reset pagination, and keeping the input
+    // outside that keyed subtree preserves its focus across the remount.
+    <div className="space-y-4">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSearch(query.trim());
+        }}
+        className="flex items-center gap-2"
+      >
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search cases…"
+          className="h-9 w-full max-w-sm"
+        />
+        <Button type="submit" size="sm" variant="secondary">
+          <Search className="mr-1 h-4 w-4" /> Search
+        </Button>
+      </form>
+
+      <ResourceTable<Row>
+        // Re-mount the table (resetting pagination) whenever a filter changes,
+        // so the new fetchPage closure runs from page 1.
+        key={`${state}|${search}`}
+        title="Jawafdehi Cases"
+        description="Accountability / corruption cases. Full create / edit / delete."
+        columns={columns}
+        pageSize={PAGE_SIZE}
+        rowKey={(r) => str(r.slug ?? r.id)}
+        onRowClick={(r) => {
+          const slug = r.slug;
+          if (typeof slug === "string" && slug)
+            navigate(`/admin/jawafdehi/cases/${encodeURIComponent(slug)}/edit`);
+        }}
+        headerAction={
+          <div className="flex items-center gap-2">
+            <Select value={state} onValueChange={setState}>
+              <SelectTrigger className="h-9 w-[9rem]">
+                <SelectValue placeholder="All states" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>All states</SelectItem>
+                {CASE_STATES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button size="sm" onClick={() => navigate("/admin/jawafdehi/cases/new")}>
+              <Plus className="mr-1 h-4 w-4" /> New case
             </Button>
-          </form>
-          <Select value={state} onValueChange={setState}>
-            <SelectTrigger className="h-9 w-[9rem]">
-              <SelectValue placeholder="All states" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL}>All states</SelectItem>
-              {CASE_STATES.map((s) => (
-                <SelectItem key={s} value={s}>
-                  {s}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button size="sm" onClick={() => navigate("/admin/jawafdehi/cases/new")}>
-            <Plus className="mr-1 h-4 w-4" /> New case
-          </Button>
-        </div>
-      }
-      fetchPage={(page) =>
-        listCases<Row>({
-          page,
-          page_size: PAGE_SIZE,
-          ...(state !== ALL ? { state } : {}),
-          ...(search ? { search } : {}),
-        })
-      }
-    />
+          </div>
+        }
+        fetchPage={(page) =>
+          listCases<Row>({
+            page,
+            page_size: PAGE_SIZE,
+            ...(state !== ALL ? { state } : {}),
+            ...(search ? { search } : {}),
+          })
+        }
+      />
+    </div>
   );
 }

--- a/src/pages/admin/jawafdehi/AdminCases.tsx
+++ b/src/pages/admin/jawafdehi/AdminCases.tsx
@@ -5,6 +5,7 @@ import { listCases } from "@/services/admin-api";
 import { CASE_STATES } from "@/lib/jawafdehi-forms";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -12,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 
 type Row = Record<string, unknown>;
 
@@ -36,12 +37,17 @@ export default function AdminCases() {
   const navigate = useNavigate();
   // F10 — state filter. "__all__" sends no ?state= param.
   const [state, setState] = useState<string>(ALL);
+  // BB-24 — text search over title/description/key_allegations. `query` is the
+  // input value; `search` is the applied term (only updated on submit) so the
+  // table refetches on Enter, not on every keystroke.
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState("");
 
   return (
     <ResourceTable<Row>
-      // Re-mount the table (resetting pagination) whenever the filter changes,
+      // Re-mount the table (resetting pagination) whenever a filter changes,
       // so the new fetchPage closure runs from page 1.
-      key={state}
+      key={`${state}|${search}`}
       title="Jawafdehi Cases"
       description="Accountability / corruption cases. Full create / edit / delete."
       columns={columns}
@@ -54,6 +60,23 @@ export default function AdminCases() {
       }}
       headerAction={
         <div className="flex items-center gap-2">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              setSearch(query.trim());
+            }}
+            className="flex items-center gap-2"
+          >
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search cases…"
+              className="h-9 w-[14rem]"
+            />
+            <Button type="submit" size="sm" variant="secondary">
+              <Search className="mr-1 h-4 w-4" /> Search
+            </Button>
+          </form>
           <Select value={state} onValueChange={setState}>
             <SelectTrigger className="h-9 w-[9rem]">
               <SelectValue placeholder="All states" />
@@ -77,6 +100,7 @@ export default function AdminCases() {
           page,
           page_size: PAGE_SIZE,
           ...(state !== ALL ? { state } : {}),
+          ...(search ? { search } : {}),
         })
       }
     />


### PR DESCRIPTION
## BB-24 — Admin Cases list has no search box

The admin Cases list (`src/pages/admin/jawafdehi/AdminCases.tsx`) offered only a state `<Select>` filter and a "New case" button — no way to search, unlike the admin Entities list.

### Fix
Add a text search `<Input>` (submitted on Enter) wired to the **existing** `/api/cases/?search=` backend filter (`SearchFilter` over `title`/`description`/`key_allegations`, already live — `listCases` passes params straight through). The `ResourceTable` re-mounts on a new search term (`key={`${state}|${search}`}`) so pagination resets to page 1, mirroring the existing state-filter behavior. Search is applied on submit (not per keystroke).

No backend change needed.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text search to the admin cases table.
  * Introduced a search field and form above the list so results can be filtered by keyword.
  * Search now works alongside the existing state filter for more precise case lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->