### PR TITLE
feat(admin): make case "Missing details" editable in the portal (BB-17)

### DIFF
--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -64,6 +64,7 @@ interface CaseFormState {
   case_type: string;
   description: string;
   notes: string;
+  missing_details: string;
   key_allegations: string[];
   entities: EntityRelationshipRow[];
   timeline: TimelineEventRow[];
@@ -86,6 +87,7 @@ const EMPTY: CaseFormState = {
   case_type: "CORRUPTION",
   description: "",
   notes: "",
+  missing_details: "",
   key_allegations: [],
   entities: [],
   timeline: [],
@@ -165,6 +167,7 @@ function fromCase(c: Record<string, unknown>): CaseFormState {
     case_type: str(c.case_type) || "CORRUPTION",
     description: str(c.description),
     notes: str(c.notes),
+    missing_details: str(c.missing_details),
     key_allegations: allegations,
     entities: parseEntities(c),
     timeline: parseTimeline(c),
@@ -290,6 +293,8 @@ export default function AdminCaseForm() {
     if (form.description !== original.description)
       ops.push(replaceOp("/description", form.description));
     if (form.notes !== original.notes) ops.push(replaceOp("/notes", form.notes));
+    if (form.missing_details !== original.missing_details)
+      ops.push(replaceOp("/missing_details", form.missing_details));
     if (changed(form.key_allegations, original.key_allegations))
       ops.push(buildStringListPatch("/key_allegations", form.key_allegations));
     if (changed(form.entities, original.entities))
@@ -347,6 +352,7 @@ export default function AdminCaseForm() {
           case_type: form.case_type,
           description: form.description || undefined,
           notes: form.notes || undefined,
+          missing_details: form.missing_details || undefined,
           key_allegations: form.key_allegations.length
             ? form.key_allegations
             : undefined,
@@ -488,6 +494,20 @@ export default function AdminCaseForm() {
           <MDEditor
             value={form.notes}
             onChange={(v) => set("notes", v ?? "")}
+            height={200}
+            preview="edit"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label>Missing details</Label>
+          <p className="text-xs text-muted-foreground">
+            Markdown. Shown publicly on the case page — note information that is
+            not yet available or still being gathered.
+          </p>
+          <MDEditor
+            value={form.missing_details}
+            onChange={(v) => set("missing_details", v ?? "")}
             height={200}
             preview="edit"
           />


### PR DESCRIPTION
## BB-17 — "Missing details" renders publicly but isn't editable in the portal

The public case page renders `missing_details` (`CaseDetail.tsx`), and the backend already supports writes (model `TextField` + patch serializer `validate_missing_details` + writable scalar), but `AdminCaseForm` had **no field for it** — so the section showed publicly yet could never be edited.

### Fix (pure frontend; backend already ready)
Mirror the existing internal-notes field in `src/pages/admin/jawafdehi/AdminCaseForm.tsx`:
- `missing_details` added to `CaseFormState`, `EMPTY`, and `fromCase` (load).
- `replace("/missing_details", …)` patch op on edit.
- Included in the create payload (`CreateCasePayload` has an index signature; DRF ignores it if the create serializer doesn't accept it).
- A Markdown `MDEditor` labelled "Missing details" with a note that it is shown publicly.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Missing details” markdown section to the admin case form.
  * The field is now included when creating and editing cases, and existing values load automatically for previously saved cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->