### PR TITLE
fix(admin): unwrap material name language-map in evidence picker (BB-19)

### DIFF
--- a/src/components/admin/case/EvidenceEditor.tsx
+++ b/src/components/admin/case/EvidenceEditor.tsx
@@ -17,8 +17,22 @@ function materialIri(m: Record<string, unknown>): string {
   return String(m["@id"] ?? m.iri ?? m.id ?? "");
 }
 
+// A stored material's `name`/`title` comes from JSON-LD as a language map
+// ({en, ne}); String()-ing that object yields "[object Object]" (BB-19). Unwrap
+// it to a readable string — prefer English, then Nepali, then any string value.
+function pickLangString(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v && typeof v === "object") {
+    const map = v as Record<string, unknown>;
+    const picked =
+      map.en ?? map.ne ?? Object.values(map).find((x) => typeof x === "string");
+    if (typeof picked === "string") return picked;
+  }
+  return "";
+}
+
 function materialTitle(m: Record<string, unknown>): string {
-  return String(m.name ?? m.title ?? materialIri(m));
+  return pickLangString(m.name) || pickLangString(m.title) || materialIri(m);
 }
 
 // F5 — evidence linker. Case evidence is a reference to a data-lake material (the

--- a/src/components/admin/case/EvidenceEditor.tsx
+++ b/src/components/admin/case/EvidenceEditor.tsx
@@ -24,9 +24,11 @@ function pickLangString(v: unknown): string {
   if (typeof v === "string") return v;
   if (v && typeof v === "object") {
     const map = v as Record<string, unknown>;
-    const picked =
-      map.en ?? map.ne ?? Object.values(map).find((x) => typeof x === "string");
-    if (typeof picked === "string") return picked;
+    // Check each candidate for a string value; a non-string `en` (e.g. a number
+    // or nested object) must not short-circuit past `ne`/other languages.
+    for (const candidate of [map.en, map.ne, ...Object.values(map)]) {
+      if (typeof candidate === "string") return candidate;
+    }
   }
   return "";
 }


### PR DESCRIPTION
## BB-19 — Evidence picker shows "[object Object]" rows

The evidence material-picker in the case editor rendered **"[object Object]"** for every result.

### Root cause
`src/components/admin/case/EvidenceEditor.tsx` — `materialTitle` did `String(m.name ?? m.title ?? materialIri(m))`, but a stored material's `name` (and `title`) come from JSON-LD as a **language map** `{en, ne}`. `m.name` is a truthy object, so `??` never falls through, and `String({...})` → `"[object Object]"`.

### Fix
Add `pickLangString` to unwrap the language map (prefer `en`, then `ne`, then any string value), falling back to `title` then the IRI.

### Scope note
BB-19 has a **second, backend half** — the `/api/materials/` list endpoint ignores the `search`/`limit` params and returns the 50 most-recent materials regardless of query ("confusing/duplicate matches"). That is a separate backend fix and will be handled in the backend batch, not here. This PR fixes the "[object Object]" title rendering only.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)