### PR TITLE
fix(admin): show material title on linked evidence rows (BB-20)

### DIFF
--- a/src/components/admin/case/EvidenceEditor.tsx
+++ b/src/components/admin/case/EvidenceEditor.tsx
@@ -38,11 +38,11 @@ export default function EvidenceEditor({ rows, onChange }: Props) {
 
   const remove = (i: number) => onChange(rows.filter((_, idx) => idx !== i));
 
-  const addRow = (iri: string) => {
+  const addRow = (iri: string, title?: string) => {
     const value = iri.trim();
     if (!isValidMaterialIri(value)) return;
     if (rows.some((r) => r.material_iri === value)) return; // no dupes
-    onChange([...rows, { material_iri: value, additional_details: "" }]);
+    onChange([...rows, { material_iri: value, additional_details: "", title }]);
   };
 
   const runSearch = async () => {
@@ -112,7 +112,7 @@ export default function EvidenceEditor({ rows, onChange }: Props) {
                     variant="ghost"
                     disabled={!isValidMaterialIri(iri)}
                     onClick={() => {
-                      addRow(iri);
+                      addRow(iri, materialTitle(m));
                       setResults([]);
                       setQuery("");
                     }}
@@ -163,7 +163,16 @@ export default function EvidenceEditor({ rows, onChange }: Props) {
               className="grid items-center gap-2 rounded border p-2 sm:grid-cols-[1fr_auto]"
             >
               <div className="min-w-0 space-y-1">
-                <span className="block truncate font-mono text-xs">{r.material_iri}</span>
+                {r.title ? (
+                  <>
+                    <span className="block truncate text-sm font-medium">{r.title}</span>
+                    <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                      {r.material_iri}
+                    </span>
+                  </>
+                ) : (
+                  <span className="block truncate font-mono text-xs">{r.material_iri}</span>
+                )}
                 <Input
                   value={r.additional_details}
                   onChange={(e) => update(i, { additional_details: e.target.value })}

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -116,6 +116,9 @@ export interface TimelineEventRow {
 export interface EvidenceRow {
   material_iri: string;
   additional_details: string;
+  // Display-only human title resolved from the material (BB-20). Not sent in the
+  // patch — buildEvidencePatch only emits material_iri + additional_details.
+  title?: string;
 }
 
 // --- Validators --------------------------------------------------------------

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -145,10 +145,21 @@ function parseTimeline(c: Record<string, unknown>): TimelineEventRow[] {
 function parseEvidence(c: Record<string, unknown>): EvidenceRow[] {
   const list = Array.isArray(c.evidence) ? (c.evidence as Record<string, unknown>[]) : [];
   return list
-    .map((e) => ({
-      material_iri: str(e.material_iri ?? e.material ?? e["@id"]),
-      additional_details: str(e.additional_details ?? e.notes),
-    }))
+    .map((e) => {
+      // CaseDetailSerializer enriches each evidence entry with a resolved
+      // `material` object ({display_name, material_type, urls}); capture the
+      // human title for display so linked rows aren't shown as a raw IRI (BB-20).
+      const mat = e.material;
+      const title =
+        mat && typeof mat === "object"
+          ? str((mat as Record<string, unknown>).display_name)
+          : "";
+      return {
+        material_iri: str(e.material_iri ?? e.material ?? e["@id"]),
+        additional_details: str(e.additional_details ?? e.notes),
+        title,
+      };
+    })
     .filter((e) => e.material_iri.trim());
 }
 

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -155,7 +155,12 @@ function parseEvidence(c: Record<string, unknown>): EvidenceRow[] {
           ? str((mat as Record<string, unknown>).display_name)
           : "";
       return {
-        material_iri: str(e.material_iri ?? e.material ?? e["@id"]),
+        // `e.material` is now the resolved object (used for `title`); only fall
+        // back to it for the IRI when it's still a bare string, else `String()`
+        // would yield "[object Object]".
+        material_iri: str(
+          e.material_iri ?? (typeof mat === "string" ? mat : undefined) ?? e["@id"],
+        ),
         additional_details: str(e.additional_details ?? e.notes),
         title,
       };


### PR DESCRIPTION
## BB-20 — Evidence items show a raw IRI/slug, no human title

Linked evidence rows in the case editor rendered only the raw `material_iri` (`EvidenceEditor.tsx`), so it was hard to tell which description maps to which evidence.

### Fix (frontend — editor half)
The case-detail payload **already** resolves a human title — `CaseDetailSerializer.get_evidence` enriches each entry with `material.display_name` — but `parseEvidence` dropped it.
- `EvidenceRow` gains an optional **display-only** `title`. `buildEvidencePatch` still emits only `material_iri` + `additional_details`, so the title is never sent in the PATCH.
- `parseEvidence` captures `material.display_name` from the loaded case.
- Linked rows render the title (IRI shown beneath) when known; rows added from the picker carry the title from the search result.

### Scope note — deferred backend half
The **public page** half of BB-20 (the `DocumentSourceCard` IRI fallback, and making `resolve_materials` fall back to the court-case derive path so `display_name` populates for court/derived materials) is a backend change and will be handled in the backend batch, not here.

### Interaction with #183 (BB-19)
Touches the same file but different regions (this: `addRow`/linked-row render/`parseEvidence`/`EvidenceRow`; #183: `materialTitle`), so they merge cleanly and are complementary.

### Verification
- `eslint` clean on the changed files. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)