### PR TITLE
fix(search): recover from out-of-range archive search page (BB-14)

### DIFF
--- a/src/pages/ArchiveSearch.tsx
+++ b/src/pages/ArchiveSearch.tsx
@@ -323,7 +323,7 @@ export default function ArchiveSearch({
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription className="flex items-center justify-between gap-4">
                   <span>
-                    {params.page > 1
+                    {(params.page ?? 1) > 1
                       ? "That results page is out of range. Return to the first page to keep searching."
                       : "Archive search could not be loaded."}
                   </span>
@@ -333,12 +333,12 @@ export default function ArchiveSearch({
                     // bad page and never recover (BB-14). Reset to page 1 to
                     // escape it; otherwise retry the current query.
                     onClick={() =>
-                      params.page > 1 ? updateParams({ page: 1 }) : refetch()
+                      (params.page ?? 1) > 1 ? updateParams({ page: 1 }) : refetch()
                     }
                     size="sm"
                     variant="outline"
                   >
-                    {params.page > 1 ? "Back to first page" : "Retry"}
+                    {(params.page ?? 1) > 1 ? "Back to first page" : "Retry"}
                   </Button>
                 </AlertDescription>
               </Alert>

--- a/src/pages/ArchiveSearch.tsx
+++ b/src/pages/ArchiveSearch.tsx
@@ -322,9 +322,23 @@ export default function ArchiveSearch({
               <Alert className="mb-5" variant="destructive">
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription className="flex items-center justify-between gap-4">
-                  <span>Archive search could not be loaded.</span>
-                  <Button onClick={() => refetch()} size="sm" variant="outline">
-                    Retry
+                  <span>
+                    {params.page > 1
+                      ? "That results page is out of range. Return to the first page to keep searching."
+                      : "Archive search could not be loaded."}
+                  </span>
+                  <Button
+                    // A common cause is an out-of-range page (e.g. a stale
+                    // ?page=9999 URL): plain refetch would re-request the same
+                    // bad page and never recover (BB-14). Reset to page 1 to
+                    // escape it; otherwise retry the current query.
+                    onClick={() =>
+                      params.page > 1 ? updateParams({ page: 1 }) : refetch()
+                    }
+                    size="sm"
+                    variant="outline"
+                  >
+                    {params.page > 1 ? "Back to first page" : "Retry"}
                   </Button>
                 </AlertDescription>
               </Alert>


### PR DESCRIPTION
## BB-14 — Search has no recovery for a bad page; Retry doesn't recover

Visiting a deep/out-of-range results page (e.g. a stale `/search?...&page=9999`) makes the unified search API return an error (a `SearchError` → HTTP 400 beyond the 10k offset window). The error alert's **Retry** button called `refetch()` with the **same** `page`, so it re-errored forever — the reported "Retry doesn't recover."

### Fix (frontend)
`src/pages/ArchiveSearch.tsx` — the recovery action now resets to **page 1** when `page > 1` (escaping the bad page), and keeps a plain `refetch()` for genuine errors on page 1. The message/label also adapts ("That results page is out of range… / Back to first page").

`readParams` already clamps the lower page bound; in-app pagination is already bounded by `PaginationControls`. The remaining trigger is a hand-typed/stale URL, which this recovery handles.

### Scope note — deferred backend half
Making the API return an **empty page (200)** instead of 400/404 for an over-range page — so the MCP client and all callers degrade gracefully (also relates to the `MCP-V` 404) — is a backend change and will be handled in the backend batch.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)