### PR TITLE
fix(admin): add language placeholders to material description fields (BB-18)

### DIFF
--- a/src/pages/admin/datalake/MaterialForm.tsx
+++ b/src/pages/admin/datalake/MaterialForm.tsx
@@ -333,6 +333,7 @@ export default function MaterialForm() {
                 })
               }
               rows={3}
+              placeholder="सामग्रीको विवरण (नेपालीमा)"
             />
           </div>
           <div className="space-y-1">
@@ -346,6 +347,7 @@ export default function MaterialForm() {
                 })
               }
               rows={3}
+              placeholder="Material description (in English)"
             />
           </div>
         </div>


### PR DESCRIPTION
## BB-18 — Bilingual material description entered in the wrong language field

The material edit form's two description fields (`MaterialForm.tsx`) had **no placeholder and no language guidance**, so editors sometimes typed English into the नेपाली box and left the English box blank. (Notably the sibling **Name** fields already carry script-appropriate placeholders — the description fields were the gap.)

### Fix
Add script-appropriate `placeholder`s to both description textareas, matching the Name-field pattern:
- `desc-ne`: `"सामग्रीको विवरण (नेपालीमा)"`
- `desc-en`: `"Material description (in English)"`

Pure UI hint — **no behavior change**. (A soft, non-blocking script-mismatch warning could be a later enhancement; this is the minimal guidance fix, and the issue is partly data-entry/training.)

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)