### PR TITLE
fix(i18n): localise the Archive nav dropdown (BB-05)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -16,7 +16,11 @@
     "skipToContent": "Skip to content",
     "searchCases": "Search cases",
     "homeAria": "Jawafdehi home",
-    "menu": "Menu"
+    "menu": "Menu",
+    "archive": "Archive",
+    "searchArchive": "Search archive",
+    "materials": "Governance materials",
+    "courtCases": "Court cases"
   },
   "weeklyMeetings": {
     "eyebrow": "Live every week",

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -16,7 +16,11 @@
     "skipToContent": "मुख्य सामग्रीमा जानुहोस्",
     "searchCases": "मुद्दाहरू खोज्नुहोस्",
     "homeAria": "जवाफदेही गृहपृष्ठ",
-    "menu": "मेनु"
+    "menu": "मेनु",
+    "archive": "अभिलेख",
+    "searchArchive": "अभिलेख खोज्नुहोस्",
+    "materials": "शासकीय सामग्रीहरू",
+    "courtCases": "अदालती मुद्दाहरू"
   },
   "weeklyMeetings": {
     "eyebrow": "हरेक हप्ता प्रत्यक्ष",


### PR DESCRIPTION
## BB-05 — Homepage & nav not localised in Nepali mode

This PR fixes the **nav** half of BB-05.

### Root cause (nav)
The Navbar Archive dropdown items call `t()` with keys that existed in **neither** locale — `nav.searchArchive` (`Navbar.tsx:93`), `nav.materials` (`:94`), `nav.courtCases` (`:95`), `nav.archive` (`:265`) — so they fell back to the inline English default (2nd arg) and stayed English even in NE mode.

### Fix
Add the four keys to `en.json` and `ne.json`:
| key | en | ne |
|-----|----|----|
| `nav.archive` | Archive | अभिलेख |
| `nav.searchArchive` | Search archive | अभिलेख खोज्नुहोस् |
| `nav.materials` | Governance materials | शासकीय सामग्रीहरू |
| `nav.courtCases` | Court cases | अदालती मुद्दाहरू |

### Scope note — deferred follow-up (homepage/hero)
The other half of BB-05 — the **fully hardcoded** homepage strings (`home/hero.tsx`, `home/report-case-cta.tsx`, `home/supportingpartner.tsx`, and the `Index.tsx` section headings) that use **no `t()` at all** — is a larger refactor that needs reviewed Nepali marketing copy. It's intentionally **not** in this PR and should be a separate change (ideally with a Nepali-speaking reviewer). Flagged in the investigation report.

### Verification
- Both locale JSON files parse; lint-staged clean. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)