### PR TITLE
fix(admin): clearer case-editor microcopy for slug & allegations (BB-21)

### DIFF
--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -460,7 +460,10 @@ export default function AdminCaseForm() {
               placeholder="auto-derived from title"
             />
             <FieldError
-              message={!slugValid && "Lowercase alphanumeric, hyphen-separated."}
+              message={
+                !slugValid &&
+                "Use lowercase letters, numbers, and hyphens (e.g. ncell-tax-case). Leave blank to auto-generate from the title."
+              }
             />
             {editing && (
               <p className="text-xs text-muted-foreground">
@@ -530,7 +533,10 @@ export default function AdminCaseForm() {
         </div>
 
         <div className="space-y-1">
-          <Label htmlFor="allegations">Key allegations (one per line)</Label>
+          <Label htmlFor="allegations">Key allegations</Label>
+          <p className="text-xs text-muted-foreground">
+            Enter one allegation per line.
+          </p>
           <textarea
             id="allegations"
             value={allegationsText}


### PR DESCRIPTION
## BB-21 — Unclear microcopy in the case editor

### Fix (frontend copy)
`src/pages/admin/jawafdehi/AdminCaseForm.tsx`:
- **Key allegations** — replaced the inline "(one per line)" label with a proper helper line: label "Key allegations" + muted text "Enter one allegation per line."
- **Slug** — replaced the terse "Lowercase alphanumeric, hyphen-separated." with a clearer message, an example (`ncell-tax-case`), and a note that leaving it blank auto-generates the slug from the title.

### Scope note — deferred
The other item in BB-21, the raw DRF **"This field may not be blank"** error, is not a frontend string — it's the backend serializer's default message surfaced verbatim via `extractErrorMessage` (`http.ts`). Making it friendlier is a backend/error-mapping change affecting all admin forms and is intentionally out of scope for this copy pass.

### Verification
- `eslint` clean on the changed file. (CI runs `bun run lint` + `bun run build`.)

Part of the Jawafdehi bug-bash FE quick-win batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)