### PR TITLE
feat(cases): gate verdict outcome UI to the accused role

### DIFF
--- a/src/components/CaseEntityChips.tsx
+++ b/src/components/CaseEntityChips.tsx
@@ -108,11 +108,12 @@ export function CaseEntityChips({
               <span className="text-base font-medium leading-snug text-primary">
                 {displayName}
               </span>
-              {shouldShowOutcome(jawafEntity.outcome) && (
-                <Badge variant="outline" className={outcomeBadgeClass(jawafEntity.outcome)}>
-                  {outcomeLabel(jawafEntity.outcome, language)}
-                </Badge>
-              )}
+              {jawafEntity.type === "accused" &&
+                shouldShowOutcome(jawafEntity.outcome) && (
+                  <Badge variant="outline" className={outcomeBadgeClass(jawafEntity.outcome)}>
+                    {outcomeLabel(jawafEntity.outcome, language)}
+                  </Badge>
+                )}
               {strippedNotes && (
                 <span className="text-sm leading-snug text-primary/75">
                   {strippedNotes}

--- a/src/components/admin/case/EntityRelationshipsEditor.tsx
+++ b/src/components/admin/case/EntityRelationshipsEditor.tsx
@@ -158,9 +158,15 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
                 </div>
                 <Select
                   value={r.relationship_type}
-                  onValueChange={(v) =>
-                    update(i, { relationship_type: v as EntityRelationshipRow["relationship_type"] })
-                  }
+                  onValueChange={(v) => {
+                    const rt = v as EntityRelationshipRow["relationship_type"];
+                    update(i, {
+                      relationship_type: rt,
+                      // A verdict applies only to ACCUSED: keep/seed it for
+                      // accused, clear it (null) for every other role.
+                      outcome: rt === "ACCUSED" ? (r.outcome ?? "CHARGED") : null,
+                    });
+                  }}
                 >
                   <SelectTrigger aria-label="Relationship type">
                     <SelectValue />
@@ -173,23 +179,32 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
                     ))}
                   </SelectContent>
                 </Select>
-                <Select
-                  value={r.outcome}
-                  onValueChange={(v) =>
-                    update(i, { outcome: v as EntityRelationshipRow["outcome"] })
-                  }
-                >
-                  <SelectTrigger aria-label="Verdict outcome">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {OUTCOME_TYPES.map((o) => (
-                      <SelectItem key={o} value={o}>
-                        {o}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {r.relationship_type === "ACCUSED" ? (
+                  <Select
+                    value={r.outcome ?? "CHARGED"}
+                    onValueChange={(v) =>
+                      update(i, { outcome: v as EntityRelationshipRow["outcome"] })
+                    }
+                  >
+                    <SelectTrigger aria-label="Verdict outcome">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OUTCOME_TYPES.map((o) => (
+                        <SelectItem key={o} value={o}>
+                          {o}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <div
+                    className="flex items-center px-2 text-xs text-muted-foreground"
+                    aria-hidden
+                  >
+                    — no verdict —
+                  </div>
+                )}
                 <Button
                   type="button"
                   size="icon"

--- a/src/lib/jawafdehi-forms.test.ts
+++ b/src/lib/jawafdehi-forms.test.ts
@@ -116,6 +116,23 @@ describe("buildEntitiesPatch", () => {
       value: [],
     });
   });
+  it("sends outcome null for non-accused roles (a verdict is accused-only)", () => {
+    const rows: EntityRelationshipRow[] = [
+      { nes_id: IRI, relationship_type: "RELATED", outcome: "CONVICTED", notes: "" },
+      { nes_id: IRI, relationship_type: "LOCATION", outcome: null, notes: "" },
+    ];
+    const value = (buildEntitiesPatch(rows).value as { outcome: unknown }[]).map(
+      (v) => v.outcome,
+    );
+    expect(value).toEqual([null, null]);
+  });
+  it("falls back to CHARGED for an accused row with no verdict", () => {
+    const rows: EntityRelationshipRow[] = [
+      { nes_id: IRI, relationship_type: "ACCUSED", outcome: null, notes: "" },
+    ];
+    const value = buildEntitiesPatch(rows).value as { outcome: unknown }[];
+    expect(value[0].outcome).toBe("CHARGED");
+  });
 });
 
 describe("buildTimelinePatch", () => {

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -99,7 +99,8 @@ export type OutcomeType = (typeof OUTCOME_TYPES)[number];
 export interface EntityRelationshipRow {
   nes_id: string;
   relationship_type: RelationshipType;
-  outcome: OutcomeType;
+  // A verdict is meaningful only for ACCUSED; every other role carries null.
+  outcome: OutcomeType | null;
   notes: string;
 }
 
@@ -179,7 +180,11 @@ export function buildEntitiesPatch(rows: EntityRelationshipRow[]): PatchOp {
     .map((r) => ({
       nes_id: r.nes_id.trim(),
       relationship_type: r.relationship_type,
-      outcome: r.outcome,
+      // A verdict is only accepted on ACCUSED (the API 400s it otherwise);
+      // every other role sends null. An accused row with no verdict falls
+      // back to CHARGED.
+      outcome:
+        r.relationship_type === "ACCUSED" ? (r.outcome ?? "CHARGED") : null,
       notes: r.notes ?? "",
     }));
   return replaceOp("/entities", value);

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -121,15 +121,19 @@ function asOutcome(v: unknown): OutcomeType {
 // read-plane shape (nes_id may live under different keys).
 function parseEntities(c: Record<string, unknown>): EntityRelationshipRow[] {
   const list = Array.isArray(c.entities) ? (c.entities as Record<string, unknown>[]) : [];
-  return list.map((e) => ({
-    nes_id: str(e.nes_id ?? e.entity ?? e["@id"]),
+  return list.map((e) => {
     // The case-read API emits the role under `type`; keep `relationship_type`/
     // `role` as fallbacks. Reading only the latter two coerced every loaded row
     // to ACCUSED, so a whole-list save silently rewrote all non-accused roles.
-    relationship_type: asRelType(e.type ?? e.relationship_type ?? e.role),
-    outcome: asOutcome(e.outcome),
-    notes: str(e.notes),
-  }));
+    const relationship_type = asRelType(e.type ?? e.relationship_type ?? e.role);
+    return {
+      nes_id: str(e.nes_id ?? e.entity ?? e["@id"]),
+      relationship_type,
+      // A verdict is meaningful only for ACCUSED; every other role is null.
+      outcome: relationship_type === "ACCUSED" ? asOutcome(e.outcome) : null,
+      notes: str(e.notes),
+    };
+  });
 }
 
 function parseTimeline(c: Record<string, unknown>): TimelineEventRow[] {

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -72,7 +72,7 @@ export interface JawafEntity {
   nes_id: string | null; // Entity ID from Nepal Entity Service
   display_name: string | null; // Display name for the entity
   type?: string; // Relationship type: 'accused', 'alleged', 'related', 'witness', 'location', 'respondent', 'petitioner', etc.
-  outcome?: EntityOutcome; // Verdict outcome; absent/'charged' = undecided
+  outcome?: EntityOutcome | null; // Verdict — only on 'accused'; null for every other role
   notes?: string; // Additional notes about the relationship
   related_cases?: EntityCaseRelationship[]; // Unified case links with relation metadata
 }
@@ -80,7 +80,7 @@ export interface JawafEntity {
 export interface EntityCaseRelationship {
   case_id: number;
   relation_type: string;
-  outcome?: EntityOutcome; // Verdict outcome for this entity in this case
+  outcome?: EntityOutcome | null; // Verdict — only on 'accused'; null otherwise
   notes: string;
 }
 


### PR DESCRIPTION
Pairs with **JawafdehiAPI#301** (verdict `outcome` allowed only on `accused`; every other role is `NULL`, enforced by a DB CHECK constraint + a serializer 400).

## Why the UI has to change
`buildEntitiesPatch` always sent `outcome: <value>` for every row — so on a case with non-accused entities it sent `outcome: "CHARGED"` on e.g. a `related` org. Against the new backend that's a **400**. So this isn't just cosmetic; the admin editor won't save without it.

## Changes
- **`buildEntitiesPatch`** — sends `outcome: null` for non-accused roles; an accused row with no verdict falls back to `CHARGED`.
- **`EntityRelationshipsEditor`** — the outcome selector renders **only on `ACCUSED` rows** (a muted `— no verdict —` placeholder keeps the grid aligned otherwise). Switching a row's role seeds `CHARGED` for accused / clears to `null` for anything else.
- **`AdminCaseForm.parseEntities`** — a loaded non-accused row now parses to `outcome: null` instead of defaulting to `CHARGED`.
- **`CaseEntityChips`** (public) — the badge is gated by role (`accused`) in addition to the existing value guard, so stale/bad data never renders a verdict on a location/org.
- **types** — `EntityRelationshipRow.outcome` and `JawafEntity.outcome` are nullable.

## Tests / checks
- `jawafdehi-forms.test.ts` — added: non-accused → `outcome: null`; accused-with-no-verdict → `CHARGED`. Existing cases unchanged.
- `tsc --noEmit` clean, `eslint` clean, `vitest` green (19).

Merge **after** JawafdehiAPI#301 (or together) — the UI expects the API to accept `outcome: null` and reject a verdict on non-accused.

**Do not merge on my behalf.** Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)