### PR TITLE
feat(admin): derive Bikram Sambat from AD in case authoring

### DIFF
--- a/src/components/admin/DatePairInput.tsx
+++ b/src/components/admin/DatePairInput.tsx
@@ -24,18 +24,34 @@ import { adStringToBSString } from "@/utils/bs-calendar";
 //    writes back ONLY to AD (using the Gregorian date the BS picker emits), and
 //    the shown BS re-derives from that AD. The caller owns only AD and passes
 //    `onAdChange`; `bsValue`/`onChange` are ignored.
-interface DatePairInputProps {
+interface DatePairInputBaseProps {
   label: string;
   idBase: string;
   adValue: string; // AD "YYYY-MM-DD" or ""
-  bsValue?: string; // BS "YYYY-MM-DD" or "" (ignored when deriveBs is set)
-  onChange?: (pair: { ad: string; bs: string }) => void; // default mode
-  // Derive-only mode: BS is computed from AD for display and never stored. The
-  // caller owns only the AD value and receives just the AD string back.
-  deriveBs?: boolean;
-  onAdChange?: (ad: string) => void; // required when deriveBs is set
   disabled?: boolean;
 }
+
+// A discriminated union on `deriveBs` so the two modes can't be mixed at the
+// type level: derive-only mode requires `onAdChange` and forbids the stored-BS
+// props, and default mode requires `bsValue`/`onChange` and forbids `onAdChange`.
+type DatePairInputProps = DatePairInputBaseProps &
+  (
+    | {
+        // Derive-only mode: BS is computed from AD for display and never stored.
+        // The caller owns only the AD value and receives just the AD string back.
+        deriveBs: true;
+        onAdChange: (ad: string) => void;
+        bsValue?: never;
+        onChange?: never;
+      }
+    | {
+        // Default mode: BS and AD are BOTH stored by the caller.
+        deriveBs?: false;
+        bsValue: string; // BS "YYYY-MM-DD" or ""
+        onChange: (pair: { ad: string; bs: string }) => void;
+        onAdChange?: never;
+      }
+  );
 
 export default function DatePairInput({
   label,

--- a/src/components/admin/DatePairInput.tsx
+++ b/src/components/admin/DatePairInput.tsx
@@ -12,12 +12,28 @@ import { adStringToBSString } from "@/utils/bs-calendar";
 // previous per-field callback API fired twice per pick; a consumer that
 // recomputed derived state from props on each call — the timeline editor — had
 // the second call overwrite the first, silently dropping half the pair.)
+//
+// Two modes:
+//  - Default (`deriveBs` unset): BS and AD are BOTH stored by the caller. Picking
+//    in either calendar fills the other; `onChange` carries the whole {ad, bs}
+//    pair. Used by the datalake forms and the timeline editor, which persist a
+//    separate BS column.
+//  - `deriveBs`: AD is the single source of truth (the backend stores no BS
+//    column). The BS field is DERIVED for display from the AD value via
+//    `adStringToBSString` — never stored. Picking a BS date still works: it
+//    writes back ONLY to AD (using the Gregorian date the BS picker emits), and
+//    the shown BS re-derives from that AD. The caller owns only AD and passes
+//    `onAdChange`; `bsValue`/`onChange` are ignored.
 interface DatePairInputProps {
   label: string;
   idBase: string;
   adValue: string; // AD "YYYY-MM-DD" or ""
-  bsValue: string; // BS "YYYY-MM-DD" or ""
-  onChange: (pair: { ad: string; bs: string }) => void;
+  bsValue?: string; // BS "YYYY-MM-DD" or "" (ignored when deriveBs is set)
+  onChange?: (pair: { ad: string; bs: string }) => void; // default mode
+  // Derive-only mode: BS is computed from AD for display and never stored. The
+  // caller owns only the AD value and receives just the AD string back.
+  deriveBs?: boolean;
+  onAdChange?: (ad: string) => void; // required when deriveBs is set
   disabled?: boolean;
 }
 
@@ -25,26 +41,41 @@ export default function DatePairInput({
   label,
   idBase,
   adValue,
-  bsValue,
+  bsValue = "",
   onChange,
+  deriveBs,
+  onAdChange,
   disabled,
 }: DatePairInputProps) {
-  // Pick AD → set AD, and derive BS (if the AD value is out of the BS table's
-  // range, keep whatever BS the user had). Clearing AD clears BS too.
+  // In derive-only mode the BS field is a read-through of the AD value (never a
+  // stored value). Falls back to "" when AD is empty or out of the BS table.
+  const shownBs = deriveBs ? (adStringToBSString(adValue) ?? "") : bsValue;
+
+  // Pick AD → set AD, and (default mode only) derive BS. In derive mode the BS
+  // field re-computes from AD on the next render, so we just push the AD string.
   const handleAd = (value: string) => {
+    if (deriveBs) {
+      onAdChange?.(value);
+      return;
+    }
     if (value === "") {
-      onChange({ ad: "", bs: "" });
+      onChange?.({ ad: "", bs: "" });
       return;
     }
     const bs = adStringToBSString(value);
-    onChange({ ad: value, bs: bs ?? bsValue });
+    onChange?.({ ad: value, bs: bs ?? bsValue });
   };
 
-  // Pick BS → set BS, and mirror the paired Gregorian date the picker already
-  // computed. Propagate an empty adDate too (clearing BS clears AD) so the pair
-  // can't be left mismatched.
+  // Pick BS → in default mode set BS and mirror the paired Gregorian date the
+  // picker already computed. In derive mode, the BS selection is used ONLY to
+  // set AD (the picker emits the paired adDate); the shown BS re-derives from it.
+  // Propagate an empty adDate too (clearing clears AD) so nothing is mismatched.
   const handleBs = ({ bsDate, adDate }: { bsDate: string; adDate: string }) => {
-    onChange({ ad: adDate || "", bs: bsDate });
+    if (deriveBs) {
+      onAdChange?.(adDate || "");
+      return;
+    }
+    onChange?.({ ad: adDate || "", bs: bsDate });
   };
 
   return (
@@ -55,7 +86,7 @@ export default function DatePairInput({
         </Label>
         <BSDatePicker
           id={`${idBase}-bs`}
-          value={bsValue}
+          value={shownBs}
           onChange={handleBs}
           disabled={disabled}
         />

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -75,10 +75,11 @@ interface CaseFormState {
   banner_url: string;
   tags: string[];
   court_cases: string[];
+  // AD (Gregorian) is the single source of truth. Bikram Sambat is DERIVED from
+  // the AD date at display time (public pages and the admin BS picker), never
+  // stored — the backend has no BS columns.
   case_start_date: string; // AD
-  case_start_date_bs: string; // BS
   case_end_date: string; // AD
-  case_end_date_bs: string; // BS
 }
 
 const EMPTY: CaseFormState = {
@@ -98,9 +99,7 @@ const EMPTY: CaseFormState = {
   tags: [],
   court_cases: [],
   case_start_date: "",
-  case_start_date_bs: "",
   case_end_date: "",
-  case_end_date_bs: "",
 };
 
 // Coerce a loaded relationship_type into the known enum (default ACCUSED).
@@ -195,9 +194,7 @@ function fromCase(c: Record<string, unknown>): CaseFormState {
     // Canonical @id IRIs — the only court-case reference format.
     court_cases: strList(c.court_cases),
     case_start_date: str(c.case_start_date),
-    case_start_date_bs: str(c.case_start_date_bs),
     case_end_date: str(c.case_end_date),
-    case_end_date_bs: str(c.case_end_date_bs),
   };
 }
 
@@ -264,9 +261,11 @@ export default function AdminCaseForm() {
 
   const slugValid = effectiveSlug === "" || isValidSlug(effectiveSlug);
   const bigoValid = form.bigo.trim() === "" || Number.isFinite(Number(form.bigo));
+  // AD is the stored source of truth (BS is derived for display only), so
+  // validate the AD fields.
   const datesValid =
-    isValidDateField(form.case_start_date_bs) &&
-    isValidDateField(form.case_end_date_bs);
+    isValidDateField(form.case_start_date) &&
+    isValidDateField(form.case_end_date);
   // A partially-filled timeline/entity row would serialize into the /timeline or
   // /entities replace and 422 the whole PATCH (title-less timeline row, IRI-less
   // entity row). Block save until every *populated* row is complete, so the user
@@ -332,14 +331,12 @@ export default function AdminCaseForm() {
       ops.push(buildStringListPatch("/tags", form.tags));
     if (changed(form.court_cases, original.court_cases))
       ops.push(buildStringListPatch("/court_cases", form.court_cases));
+    // Only AD dates are stored; BS is derived from them at display time, so no
+    // /case_*_date_bs ops are emitted (those columns don't exist on the backend).
     if (form.case_start_date !== original.case_start_date)
       ops.push(replaceOp("/case_start_date", form.case_start_date || null));
-    if (form.case_start_date_bs !== original.case_start_date_bs)
-      ops.push(replaceOp("/case_start_date_bs", form.case_start_date_bs || null));
     if (form.case_end_date !== original.case_end_date)
       ops.push(replaceOp("/case_end_date", form.case_end_date || null));
-    if (form.case_end_date_bs !== original.case_end_date_bs)
-      ops.push(replaceOp("/case_end_date_bs", form.case_end_date_bs || null));
     return ops;
   };
 
@@ -599,25 +596,24 @@ export default function AdminCaseForm() {
           invalidHint="Use the canonical court-case @id IRI."
         />
 
+        {/* BS is derived from AD for display and never stored (the backend has
+            no BS columns). Authors may still pick in the Nepali calendar — that
+            selection sets the AD date, and the shown BS re-derives from it. */}
         <DatePairInput
           label="Case start"
           idBase="case-start"
+          deriveBs
           adValue={form.case_start_date}
-          bsValue={form.case_start_date_bs}
-          onChange={({ ad, bs }) =>
-            setForm((f) => ({ ...f, case_start_date: ad, case_start_date_bs: bs }))
-          }
+          onAdChange={(ad) => set("case_start_date", ad)}
         />
         <DatePairInput
           label="Case end"
           idBase="case-end"
+          deriveBs
           adValue={form.case_end_date}
-          bsValue={form.case_end_date_bs}
-          onChange={({ ad, bs }) =>
-            setForm((f) => ({ ...f, case_end_date: ad, case_end_date_bs: bs }))
-          }
+          onAdChange={(ad) => set("case_end_date", ad)}
         />
-        <FieldError message={!datesValid && "BS dates must be YYYY-MM-DD."} />
+        <FieldError message={!datesValid && "Dates must be YYYY-MM-DD."} />
 
         {/* Sub-resource editors (F3/F4/F5). Shown only in edit mode: a case
             must exist (have a slug) before entities/evidence can be linked. On


### PR DESCRIPTION
## What & why

Makes Bikram Sambat (BS) dates **derive-only** in Jawafdehi case authoring: BS is computed from the stored AD (Gregorian) date at the frontend, and the backend stores **no** BS columns.

This implements the decision on **JawafdehiAPI#296** — quoting the ask there: *"Can we just not store nepali dates in the system altogether? Makes it simple, stupid."* This PR is the replacement for that backend PR (which should be closed): rather than adding `case_start_date_bs`/`case_end_date_bs` columns, AD is the single source of truth and BS is derived, so AD and BS can never drift.

## Changes (admin authoring only — 2 files)
- **`DatePairInput.tsx`** — opt-in `deriveBs` mode: the BS field is a read-through of the AD value (`adStringToBSString(adValue)`, never stored). Picking a BS date writes back only to AD via the `adDate` the `@sbmdkl` picker already emits, so authors keep the full Nepali-calendar picking UX. Default stored-BS behavior is preserved, so the datalake (CourtCaseForm/FirmForm) and TimelineEditor callers are untouched.
- **`AdminCaseForm.tsx`** — drops `case_start_date_bs`/`case_end_date_bs` from form state, parse, and validation; `buildPatch` no longer emits `/case_*_date_bs` ops (only the AD `/case_start_date` + `/case_end_date`).

## Not touched
Public pages already derive BS from AD (`formatDateWithBS`/`formatCaseDateRange` via `convertToBS`); `git diff --name-only main HEAD` is only the two admin files. The `Case` type has no `_bs` fields. CaseTimeline's per-row `date_bs` is a separate concern and left as-is.

## Checks
lint clean · build (tsc + vite + SSR pre-render + sitemap) exit 0 · vitest 130 passed.

🤖 Prepared with Claude Code