### PR TITLE
feat(admin): Wave-2 caseworker/moderator UX — queue triage, dashboard metrics, feedback loop

### DIFF
--- a/src/components/admin/case/CaseHistoryPanel.tsx
+++ b/src/components/admin/case/CaseHistoryPanel.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import { getCaseHistory, type CaseStateChange } from "@/services/admin-api";
+import { fmtDate } from "@/lib/casework-ui";
+import { Badge } from "@/components/ui/badge";
+import { History, Loader2 } from "lucide-react";
+
+// F7 — case workflow history / author feedback loop. Shows who moved the case
+// between states, when, and (crucially) any reason a moderator left when
+// sending a submission back to draft or closing it. This is how a caseworker
+// learns "your case was returned because X" without the reason being buried in
+// the shared internal-notes field.
+//
+// Degrades quietly: if the backend has no /history/ endpoint yet,
+// getCaseHistory returns [] and the panel renders nothing (no error, no empty
+// box) so it's safe to ship ahead of the backend.
+
+// Human phrasing for a transition, from the reader's perspective.
+function describe(change: CaseStateChange): string {
+  const to = change.to_state;
+  if (to === "IN_REVIEW") return "Submitted for review";
+  if (to === "PUBLISHED") return "Published";
+  if (to === "CLOSED") return "Closed";
+  if (to === "DRAFT") {
+    // A revert from IN_REVIEW/PUBLISHED reads as "sent back"; the initial
+    // draft creation isn't logged, so any → DRAFT here is a return.
+    return "Sent back to draft";
+  }
+  return `Moved to ${to}`;
+}
+
+// A returned/closed transition is the one an author most needs to see, so we
+// give it a little visual weight (and always surface its reason).
+function isReturn(change: CaseStateChange): boolean {
+  return change.to_state === "DRAFT" || change.to_state === "CLOSED";
+}
+
+interface Props {
+  slug: string;
+  // Bumping this (e.g. after a transition) forces a refetch.
+  refreshKey?: number;
+}
+
+export default function CaseHistoryPanel({ slug, refreshKey = 0 }: Props) {
+  const [changes, setChanges] = useState<CaseStateChange[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getCaseHistory(slug)
+      .then((rows) => {
+        if (!cancelled) setChanges(rows);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, refreshKey]);
+
+  // Nothing to show (no history, or an older backend without the endpoint):
+  // render nothing so the panel is invisible until there's something to say.
+  if (!loading && changes.length === 0) return null;
+
+  return (
+    <div className="space-y-2 rounded-md border bg-white p-4">
+      <div className="flex items-center gap-2">
+        <History className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">History</span>
+        {loading && (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <ol className="space-y-2">
+        {changes.map((c) => (
+          <li
+            key={c.id}
+            className={`rounded-md border px-3 py-2 text-sm ${
+              isReturn(c) ? "border-amber-200 bg-amber-50" : "border-slate-100"
+            }`}
+          >
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="font-medium">{describe(c)}</span>
+              {c.actor_name && (
+                <span className="text-xs text-muted-foreground">
+                  by {c.actor_name}
+                </span>
+              )}
+              <span className="text-xs text-muted-foreground">
+                · {fmtDate(c.created_at)}
+              </span>
+            </div>
+            {c.reason && (
+              <p className="mt-1 whitespace-pre-wrap text-sm text-slate-700">
+                <Badge variant="secondary" className="mr-1 align-middle">
+                  Reason
+                </Badge>
+                {c.reason}
+              </p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -7,22 +8,29 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
+  CheckCircle2,
   ClipboardCheck,
+  Clock,
+  FileEdit,
   FileText,
   Gavel,
+  Loader2,
   Network,
   ShieldCheck,
 } from "lucide-react";
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
 import { hasNesWriteAccess, hasNgmWriteAccess, isModerator } from "@/lib/roles";
+import { listCases } from "@/services/admin-api";
+import { listReviewsGrouped } from "@/services/casework-api";
 
-// Landing page for the unified admin panel. Each card is a doorway into one of
-// the data domains (Entities / Data Lake / Jawafdehi) plus casework. Counts are
-// intentionally not fetched here yet — the resource pages own their own data.
+// Landing page for the unified admin panel. The top row is live "situational"
+// metrics (queue depth, published, drafts, AI reviews) that double as nav
+// doorways; below them are the section cards — one doorway per data domain
+// (Entities / Data Lake / Jawafdehi) plus casework.
 //
-// Cards are role-filtered with the SAME predicates the sidebar uses (see
+// Both rows are role-filtered with the SAME predicates the sidebar uses (see
 // AdminLayout NAV): a card is shown to everyone who cleared the panel gate
-// unless `canAccess` narrows it. Otherwise a caseworker would see prominent
+// unless a predicate narrows it. Otherwise a caseworker would see prominent
 // Entities / Moderation doorways that dead-end in a 403 (the sidebar hides
 // them, so the two surfaces must agree).
 interface Section {
@@ -69,10 +77,115 @@ const SECTIONS: Section[] = [
   },
 ];
 
+// A live count is `null` while loading and `undefined` when its fetch failed
+// (rendered as "—"). Distinguishing the two lets the card show a spinner vs. a
+// graceful placeholder instead of crashing the whole dashboard.
+type Count = number | null | undefined;
+
+interface Metrics {
+  inReview: Count;
+  published: Count;
+  drafts: Count;
+  reviews: Count;
+}
+
+interface Metric {
+  key: keyof Metrics;
+  to: string;
+  icon: typeof Network;
+  label: string;
+  sub: string;
+  // Narrow the metric to a subset of roles (matches the section predicates).
+  canAccess?: (roles: string[]) => boolean;
+  // Headline metric — rendered with emphasis (accent border/title).
+  headline?: boolean;
+}
+
+const METRICS: Metric[] = [
+  {
+    key: "inReview",
+    to: "/admin/moderation",
+    icon: Clock,
+    label: "Awaiting review",
+    sub: "Submissions in the moderation queue",
+    canAccess: isModerator,
+    headline: true,
+  },
+  {
+    key: "published",
+    to: "/admin/jawafdehi/cases",
+    icon: CheckCircle2,
+    label: "Published",
+    sub: "Live accountability cases",
+  },
+  {
+    key: "drafts",
+    to: "/admin/jawafdehi/cases",
+    icon: FileEdit,
+    label: "Drafts",
+    sub: "Cases still being authored",
+  },
+  {
+    key: "reviews",
+    to: "/admin/reviews",
+    icon: ClipboardCheck,
+    label: "Reviews (AI)",
+    sub: "Cases with AI-assisted reviews",
+  },
+];
+
+// Fetch a single count from a paginated list endpoint, swallowing failures so
+// one bad call surfaces as "—" rather than rejecting the whole Promise.all.
+async function safeCount(fetcher: () => Promise<{ count: number }>): Promise<Count> {
+  try {
+    const { count } = await fetcher();
+    return count;
+  } catch {
+    return undefined;
+  }
+}
+
+function MetricValue({ value }: { value: Count }) {
+  if (value === null) {
+    return (
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-label="Loading" />
+    );
+  }
+  return (
+    <span className="text-3xl font-bold tabular-nums">
+      {value === undefined ? "—" : value.toLocaleString()}
+    </span>
+  );
+}
+
 export default function AdminDashboard() {
   const { user } = useCaseworkAuth();
   const roles = user?.roles ?? [];
   const sections = SECTIONS.filter((s) => !s.canAccess || s.canAccess(roles));
+  const metrics = METRICS.filter((m) => !m.canAccess || m.canAccess(roles));
+
+  const [counts, setCounts] = useState<Metrics>({
+    inReview: null,
+    published: null,
+    drafts: null,
+    reviews: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      safeCount(() => listCases({ state: "IN_REVIEW", page_size: 1 })),
+      safeCount(() => listCases({ state: "PUBLISHED", page_size: 1 })),
+      safeCount(() => listCases({ state: "DRAFT", page_size: 1 })),
+      safeCount(() => listReviewsGrouped({ page_size: 1 })),
+    ]).then(([inReview, published, drafts, reviews]) => {
+      if (cancelled) return;
+      setCounts({ inReview, published, drafts, reviews });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -82,6 +195,37 @@ export default function AdminDashboard() {
           One panel for entities, the data lake, Jawafdehi cases, and casework.
         </p>
       </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {metrics.map((m) => {
+          const Icon = m.icon;
+          return (
+            <Link key={m.key} to={m.to} className="group">
+              <Card
+                className={`h-full transition-colors group-hover:border-primary/50 ${
+                  m.headline ? "border-primary/40 bg-primary/5" : ""
+                }`}
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle
+                    className={`flex items-center gap-2 text-sm font-medium ${
+                      m.headline ? "text-primary" : "text-muted-foreground"
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {m.label}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-1">
+                  <MetricValue value={counts[m.key]} />
+                  <p className="text-xs text-muted-foreground">{m.sub}</p>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {sections.map((s) => {
           const Icon = s.icon;

--- a/src/pages/admin/casework/Moderation.tsx
+++ b/src/pages/admin/casework/Moderation.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   listCases,
@@ -6,30 +6,108 @@ import {
   adminErrorMessage,
   type PatchOp,
 } from "@/services/admin-api";
+import { listReviewsGrouped } from "@/services/casework-api";
+import type { Disposition } from "@/types/casework";
 import { replaceOp, type CaseState } from "@/lib/jawafdehi-forms";
+import { scoreBand, dispositionColor } from "@/lib/casework-ui";
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
 import { FormError } from "@/components/admin/FormError";
 import ConfirmButton from "@/components/admin/ConfirmButton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "@/hooks/use-toast";
-import { Check, Loader2, RefreshCw, Undo2, X } from "lucide-react";
+import {
+  ArrowUpDown,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  RefreshCw,
+  Undo2,
+  X,
+} from "lucide-react";
 
 type Row = Record<string, unknown>;
 const str = (v: unknown): string => (v == null ? "" : String(v));
 
+type ReviewBadge = { score: number | null; disposition: Disposition | null };
+type SortDir = "oldest" | "newest";
+
+// Compact relative age from an ISO timestamp: "just now", "3h", "5d", "2mo".
+function relativeAge(iso: string): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return "just now";
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y`;
+}
+
+// The timestamp a case entered its current (IN_REVIEW) state. Prefer the
+// versionInfo stamp (the moment it was submitted/reverted), then updated_at,
+// then created_at.
+function ageTimestamp(r: Row): string {
+  const vi = r.versionInfo;
+  if (vi && typeof vi === "object") {
+    const dt = (vi as Record<string, unknown>).datetime;
+    if (dt) return str(dt);
+  }
+  return str(r.updated_at) || str(r.created_at);
+}
+
+const MS_PER_DAY = 86400000;
+
+// Age color: neutral < 3d, amber 3–7d, red > 7d.
+function ageColor(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "text-muted-foreground";
+  const days = (Date.now() - then) / MS_PER_DAY;
+  if (days > 7) return "text-red-600 font-medium";
+  if (days > 3) return "text-amber-600 font-medium";
+  return "text-muted-foreground";
+}
+
+function truncate(s: string, n = 300): string {
+  const t = s.trim();
+  return t.length > n ? `${t.slice(0, n)}…` : t;
+}
+
 // F11 — moderation queue. The queue IS the set of cases in IN_REVIEW (plan §G;
 // no intake model). Per-row: Approve → PUBLISHED, Reject → DRAFT, Dismiss →
-// CLOSED, each via a state-transition PATCH; a reason is written to /notes in
-// the same patch. Role-gated to admin/moderator (nav already scoped; the API is
-// the authority regardless).
+// CLOSED, each via a state-transition PATCH; the moderator's reason rides the
+// X-Transition-Reason header so it lands in the case history (author feedback,
+// F7) instead of the shared internal notes. Role-gated to admin/moderator (nav
+// already scoped; the API is the authority regardless). Triage affordances
+// (age, sort, type filter, inline preview, AI-review badge) sit around that core.
 export default function Moderation() {
   const { isModerator } = useCaseworkAuth();
   const [rows, setRows] = useState<Row[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [reasons, setReasons] = useState<Record<string, string>>({});
+  const [reviews, setReviews] = useState<Map<string, ReviewBadge>>(new Map());
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [sortDir, setSortDir] = useState<SortDir>("oldest");
+  const [typeFilter, setTypeFilter] = useState<string>("__all__");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -37,10 +115,27 @@ export default function Moderation() {
     try {
       const page = await listCases<Row>({ state: "IN_REVIEW", page_size: 100 });
       setRows(page.results ?? []);
+      setTotal(page.count ?? (page.results?.length ?? 0));
     } catch (err) {
       setError(adminErrorMessage(err, "Failed to load the moderation queue"));
     } finally {
       setLoading(false);
+    }
+    // AI-review badges are best-effort: a failure just means no badges.
+    try {
+      const grouped = await listReviewsGrouped({ page_size: 200 });
+      const map = new Map<string, ReviewBadge>();
+      for (const g of grouped.results ?? []) {
+        if (!g.slug || !g.latest) continue;
+        map.set(g.slug, {
+          score: g.latest.overall_score,
+          disposition: g.latest.disposition,
+        });
+      }
+      setReviews(map);
+    } catch {
+      // non-fatal — leave the badge map empty
+      setReviews(new Map());
     }
   }, []);
 
@@ -50,6 +145,34 @@ export default function Moderation() {
   useEffect(() => {
     if (isModerator) load();
   }, [load, isModerator]);
+
+  // Distinct case types present in the loaded rows (for the type filter).
+  const caseTypes = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows) {
+      const t = str(r.case_type);
+      if (t) set.add(t);
+    }
+    return Array.from(set).sort();
+  }, [rows]);
+
+  // Client-side filter + sort over the already-loaded rows.
+  const visibleRows = useMemo(() => {
+    const filtered =
+      typeFilter === "__all__"
+        ? rows
+        : rows.filter((r) => str(r.case_type) === typeFilter);
+    const withTs = filtered.map((r) => ({
+      r,
+      ts: new Date(ageTimestamp(r)).getTime(),
+    }));
+    withTs.sort((a, b) => {
+      const av = Number.isNaN(a.ts) ? 0 : a.ts;
+      const bv = Number.isNaN(b.ts) ? 0 : b.ts;
+      return sortDir === "oldest" ? av - bv : bv - av;
+    });
+    return withTs.map((x) => x.r);
+  }, [rows, typeFilter, sortDir]);
 
   if (!isModerator) {
     return (
@@ -63,9 +186,11 @@ export default function Moderation() {
     try {
       const ops: PatchOp[] = [replaceOp("/state", to)];
       const reason = (reasons[slug] ?? "").trim();
-      // Write the reason to /notes in the same patch (plan §G2).
-      if (reason) ops.push(replaceOp("/notes", reason));
-      await patchCase(slug, ops);
+      // The moderator's reason travels via X-Transition-Reason so it's recorded
+      // in the case's workflow history and shown to the author (F7 feedback
+      // loop) — rather than being overloaded into the shared internal /notes
+      // field, which mixed return reasons with authoring notes.
+      await patchCase(slug, ops, { transitionReason: reason || undefined });
       toast({ title: `Case ${verb}`, description: slug });
       // Drop the case from the queue (it left IN_REVIEW).
       setRows((prev) => prev.filter((r) => str(r.slug) !== slug));
@@ -109,6 +234,44 @@ export default function Moderation() {
 
       <FormError message={error} />
 
+      {!loading && rows.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <SelectTrigger className="h-9 w-[180px]">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">All types</SelectItem>
+              {caseTypes.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={sortDir}
+            onValueChange={(v) => setSortDir(v as SortDir)}
+          >
+            <SelectTrigger className="h-9 w-[190px]">
+              <ArrowUpDown className="mr-1 h-4 w-4 opacity-60" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="oldest">Oldest first</SelectItem>
+              <SelectItem value="newest">Newest first</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <span className="ml-auto text-xs text-muted-foreground">
+            {total > rows.length
+              ? `Showing ${rows.length} of ${total}`
+              : `${visibleRows.length} case${visibleRows.length === 1 ? "" : "s"}`}
+          </span>
+        </div>
+      )}
+
       {loading ? (
         <div className="flex min-h-[30vh] items-center justify-center">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -117,35 +280,136 @@ export default function Moderation() {
         <p className="rounded-md border border-dashed bg-slate-50 px-3 py-6 text-center text-sm text-muted-foreground">
           Nothing awaiting review.
         </p>
+      ) : visibleRows.length === 0 ? (
+        <p className="rounded-md border border-dashed bg-slate-50 px-3 py-6 text-center text-sm text-muted-foreground">
+          No cases match the current filter.
+        </p>
       ) : (
         <div className="space-y-3">
-          {rows.map((r) => {
+          {visibleRows.map((r) => {
             const slug = str(r.slug);
             const busy = busySlug === slug;
+            const ts = ageTimestamp(r);
+            const review = reviews.get(slug);
+            const isOpen = !!expanded[slug];
+            const allegations = Array.isArray(r.key_allegations)
+              ? (r.key_allegations as unknown[])
+              : [];
+            const entities = Array.isArray(r.entities)
+              ? (r.entities as Record<string, unknown>[])
+              : [];
+            const evidence = Array.isArray(r.evidence)
+              ? (r.evidence as unknown[])
+              : [];
+            const description = str(r.description);
             return (
               <div key={slug} className="rounded-xl border bg-white p-4">
                 <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="font-mono text-xs text-slate-500">{slug}</div>
-                    <div className="font-medium">{str(r.title) || "—"}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {str(r.case_type)}
+                  <div className="flex min-w-0 items-start gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpanded((prev) => ({ ...prev, [slug]: !prev[slug] }))
+                      }
+                      className="mt-0.5 rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+                      aria-label={isOpen ? "Collapse preview" : "Expand preview"}
+                      aria-expanded={isOpen}
+                    >
+                      {isOpen ? (
+                        <ChevronDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4" />
+                      )}
+                    </button>
+                    <div className="min-w-0">
+                      <div className="font-mono text-xs text-slate-500">{slug}</div>
+                      <div className="font-medium">{str(r.title) || "—"}</div>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span>{str(r.case_type)}</span>
+                        {ts && (
+                          <span className={`inline-flex items-center gap-1 ${ageColor(ts)}`}>
+                            <Clock className="h-3 w-3" />
+                            {relativeAge(ts)}
+                          </span>
+                        )}
+                        {review ? (
+                          <Link
+                            to="/admin/reviews"
+                            className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 ${dispositionColor(review.disposition)}`}
+                            title="View AI review"
+                          >
+                            <span
+                              className="inline-block h-1.5 w-1.5 rounded-full"
+                              style={{ backgroundColor: scoreBand(review.score) }}
+                            />
+                            {review.score == null ? "—" : review.score}
+                            {review.disposition ? ` · ${review.disposition}` : ""}
+                          </Link>
+                        ) : (
+                          <span className="text-slate-400">no review</span>
+                        )}
+                      </div>
                     </div>
                   </div>
                   <Link
                     to={`/admin/jawafdehi/cases/${slug}/edit`}
-                    className="text-sm underline underline-offset-2"
+                    className="shrink-0 text-sm underline underline-offset-2"
                   >
                     Open
                   </Link>
                 </div>
+
+                {isOpen && (
+                  <div className="mt-3 space-y-2 rounded-lg border bg-slate-50 p-3 text-sm">
+                    <div>
+                      <div className="text-xs font-semibold uppercase text-slate-500">
+                        Description
+                      </div>
+                      <p className="whitespace-pre-wrap text-slate-700">
+                        {description ? truncate(description) : "—"}
+                      </p>
+                    </div>
+                    {allegations.length > 0 && (
+                      <div>
+                        <div className="text-xs font-semibold uppercase text-slate-500">
+                          Key allegations
+                        </div>
+                        <ul className="list-disc pl-5 text-slate-700">
+                          {allegations.map((a, i) => (
+                            <li key={i}>{str(a)}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {entities.length > 0 && (
+                      <div>
+                        <div className="text-xs font-semibold uppercase text-slate-500">
+                          Entities
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                          {entities.map((e, i) => (
+                            <span
+                              key={i}
+                              className="rounded bg-white px-1.5 py-0.5 font-mono text-xs text-slate-600 ring-1 ring-slate-200"
+                            >
+                              {str(e.name) || str(e.nes_id) || str(e.id) || "entity"}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    <div className="text-xs text-slate-500">
+                      Evidence: {evidence.length}
+                    </div>
+                  </div>
+                )}
 
                 <Input
                   value={reasons[slug] ?? ""}
                   onChange={(e) =>
                     setReasons((prev) => ({ ...prev, [slug]: e.target.value }))
                   }
-                  placeholder="Reason (optional, saved to notes)"
+                  placeholder="Reason (optional — shown to the author in history)"
                   className="mt-3"
                 />
 
@@ -176,7 +440,7 @@ export default function Moderation() {
                     variant="destructive"
                     disabled={busy || !isModerator}
                     title="Dismiss this submission?"
-                    description="Dismissing closes the case and removes it from the moderation queue. You can reopen it as a draft later. The reason you entered (if any) is saved to notes."
+                    description="Dismissing closes the case and removes it from the moderation queue. You can reopen it as a draft later. The reason you entered (if any) is recorded in the case history."
                     confirmLabel="Dismiss"
                     onConfirm={() => act(slug, "CLOSED", "dismissed")}
                   >

--- a/src/pages/admin/casework/Moderation.tsx
+++ b/src/pages/admin/casework/Moderation.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   listCases,
@@ -109,21 +109,35 @@ export default function Moderation() {
   const [sortDir, setSortDir] = useState<SortDir>("oldest");
   const [typeFilter, setTypeFilter] = useState<string>("__all__");
 
+  // load() is called from an effect AND the Refresh button, so a component-
+  // lifetime ref (not an effect-scoped flag) guards its async setState against a
+  // resolve-after-unmount when the moderator navigates away mid-request.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const page = await listCases<Row>({ state: "IN_REVIEW", page_size: 100 });
+      if (!mountedRef.current) return;
       setRows(page.results ?? []);
       setTotal(page.count ?? (page.results?.length ?? 0));
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(adminErrorMessage(err, "Failed to load the moderation queue"));
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
     // AI-review badges are best-effort: a failure just means no badges.
     try {
       const grouped = await listReviewsGrouped({ page_size: 200 });
+      if (!mountedRef.current) return;
       const map = new Map<string, ReviewBadge>();
       for (const g of grouped.results ?? []) {
         if (!g.slug || !g.latest) continue;
@@ -134,6 +148,7 @@ export default function Moderation() {
       }
       setReviews(map);
     } catch {
+      if (!mountedRef.current) return;
       // non-fatal — leave the badge map empty
       setReviews(new Map());
     }

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -4,10 +4,11 @@ import MDEditor from "@uiw/react-md-editor";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
 import {
-  getCase,
+  getCaseWithEtag,
   createCase,
-  patchCase,
+  patchCaseWithEtag,
   adminErrorMessage,
+  CaseConflictError,
   type CreateCasePayload,
   type PatchOp,
 } from "@/services/admin-api";
@@ -40,6 +41,7 @@ import TimelineEditor from "@/components/admin/case/TimelineEditor";
 import EvidenceEditor from "@/components/admin/case/EvidenceEditor";
 import ChipListEditor from "@/components/admin/case/ChipListEditor";
 import CaseStateControl from "@/components/admin/case/CaseStateControl";
+import CaseHistoryPanel from "@/components/admin/case/CaseHistoryPanel";
 import DatePairInput from "@/components/admin/DatePairInput";
 import { FormError, FieldError } from "@/components/admin/FormError";
 import { Button } from "@/components/ui/button";
@@ -227,6 +229,14 @@ export default function AdminCaseForm() {
   // In create mode, track whether the user hand-edited the slug so we stop
   // auto-deriving it from the title.
   const [slugDirty, setSlugDirty] = useState(false);
+  // Optimistic-concurrency token from the last load/save. Echoed back as
+  // If-Match on save so a concurrent edit is rejected instead of clobbered.
+  const [etag, setEtag] = useState<string | null>(null);
+  // True after a save was rejected because the case changed underneath us; we
+  // steer the user to reload rather than retry a stale write.
+  const [conflict, setConflict] = useState(false);
+  // Bumped to force the history panel to refetch (after a transition/save).
+  const [historyKey, setHistoryKey] = useState(0);
 
   const set = <K extends keyof CaseFormState>(k: K, v: CaseFormState[K]) =>
     setForm((f) => ({ ...f, [k]: v }));
@@ -235,13 +245,19 @@ export default function AdminCaseForm() {
     if (!editing || !slug) return;
     setLoading(true);
     setLoadFailed(false);
+    setConflict(false);
     try {
-      const c = await getCase<Record<string, unknown>>(slug);
+      const { data: c, etag: tok } = await getCaseWithEtag<
+        Record<string, unknown>
+      >(slug);
       const parsed = fromCase(c);
       setForm(parsed);
       setOriginal(parsed);
       setCaseState(str(c.state ?? c.status) || "DRAFT");
       setAllegationsText(parsed.key_allegations.join("\n"));
+      setEtag(tok);
+      // A fresh load resolves any prior conflict and refreshes the history.
+      setHistoryKey((k) => k + 1);
     } catch (err) {
       setError(adminErrorMessage(err, "Failed to load case"));
       setLoadFailed(true);
@@ -387,11 +403,14 @@ export default function AdminCaseForm() {
           setSaving(false);
           return;
         }
-        const updated = await patchCase<Record<string, unknown>>(slug, ops);
+        const { data: updated, etag: tok } = await patchCaseWithEtag<
+          Record<string, unknown>
+        >(slug, ops, { ifMatch: etag });
         const parsed = fromCase(updated);
         setForm(parsed);
         setOriginal(parsed);
         setCaseState(str(updated.state ?? updated.status) || caseState);
+        setEtag(tok);
         toast({ title: "Case updated" });
       } else {
         const payload: CreateCasePayload = {
@@ -413,7 +432,15 @@ export default function AdminCaseForm() {
         navigate(newSlug ? `/admin/jawafdehi/cases/${newSlug}/edit` : "/admin/jawafdehi/cases");
       }
     } catch (err) {
-      setError(adminErrorMessage(err, "Failed to save case"));
+      if (err instanceof CaseConflictError) {
+        // The case changed under us — a stale save was refused. Steer the user
+        // to reload (which pulls the latest + a fresh token) rather than letting
+        // them retry a write that would keep failing or clobber the new edit.
+        setConflict(true);
+        setError(err.message);
+      } else {
+        setError(adminErrorMessage(err, "Failed to save case"));
+      }
     } finally {
       setSaving(false);
     }
@@ -472,6 +499,27 @@ export default function AdminCaseForm() {
 
       <FormError message={error} />
 
+      {/* Optimistic-lock conflict: a save was refused because the case changed
+          since it was opened. Offer a one-click reload (discards local edits,
+          pulls the latest + a fresh token). Distinct from a generic save error
+          so the user knows retrying as-is won't help. */}
+      {conflict && (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          <span>
+            This case was changed by someone else since you opened it. Reload to
+            get the latest version before saving.
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => loadCase()}
+          >
+            Reload case
+          </Button>
+        </div>
+      )}
+
       {/* F2 — state transitions. Edit mode only (a persisted case has a state).
           Privileged targets are gated to admin/moderator in the UI; the API is
           the authority. Transitioning reloads the case to reflect the new state. */}
@@ -482,6 +530,12 @@ export default function AdminCaseForm() {
           isModerator={isModerator}
           onTransitioned={() => loadCase()}
         />
+      )}
+
+      {/* F7 — workflow history / author feedback. Renders nothing until there's
+          a transition to show (and is a no-op on an older backend). */}
+      {editing && slug && (
+        <CaseHistoryPanel slug={slug} refreshKey={historyKey} />
       )}
 
       <form onSubmit={onSubmit} className="space-y-5">

--- a/src/services/admin-api.test.ts
+++ b/src/services/admin-api.test.ts
@@ -8,16 +8,36 @@ vi.mock("./oidc", () => ({ getAccessToken: vi.fn().mockResolvedValue(null) }));
 // spy client; each verb records its (url, body) and resolves an empty body so
 // the wrappers just relay the shape. `vi.hoisted` lets the mock factory (which
 // is hoisted above imports) share the `calls` array with the test bodies.
-const { calls } = vi.hoisted(() => ({
-  calls: [] as { method: string; url: string; body?: unknown }[],
+const { calls, responses } = vi.hoisted(() => ({
+  calls: [] as {
+    method: string;
+    url: string;
+    body?: unknown;
+    config?: unknown;
+  }[],
+  // Per-method queue of scripted responses. When a queue has an entry it is
+  // shifted and used (resolve `{data, headers}` or reject an axios-like error);
+  // otherwise the default empty body is returned. Lets the optimistic-lock and
+  // etag tests drive status codes / headers without touching the happy path.
+  responses: {} as Record<
+    string,
+    Array<{ data?: unknown; headers?: unknown; status?: number }>
+  >,
 }));
 
 vi.mock("axios", () => {
   const record =
     (method: string) =>
-    (url: string, body?: unknown) => {
-      calls.push({ method, url, body });
-      return Promise.resolve({ data: {} });
+    (url: string, body?: unknown, config?: unknown) => {
+      calls.push({ method, url, body, config });
+      const queued = responses[method]?.shift();
+      if (queued && typeof queued.status === "number" && queued.status >= 400) {
+        return Promise.reject({ response: { status: queued.status, data: queued.data } });
+      }
+      return Promise.resolve({
+        data: queued?.data ?? {},
+        headers: queued?.headers ?? {},
+      });
     };
   const instance = {
     get: record("get"),
@@ -50,11 +70,16 @@ import {
   deleteMaterial,
   listCases,
   patchCase,
+  patchCaseWithEtag,
+  getCaseWithEtag,
+  getCaseHistory,
   deleteCase,
+  CaseConflictError,
 } from "./admin-api";
 
 beforeEach(() => {
   calls.length = 0;
+  for (const k of Object.keys(responses)) delete responses[k];
 });
 
 // TASK A — the client must address the SINGLE unified /api root; the former
@@ -146,5 +171,88 @@ describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
     expect(fd.get("role")).toBe("RAW");
     expect(fd.get("material_type")).toBe("official_report");
     expect(fd.get("file")).toBeInstanceOf(File);
+  });
+});
+
+// Wave-2: optimistic concurrency (If-Match / ETag), transition reason header,
+// and the case history endpoint.
+describe("admin-api case optimistic concurrency + history", () => {
+  it("getCaseWithEtag returns the ETag response header", async () => {
+    responses.get = [{ data: { slug: "x" }, headers: { etag: '"abc123"' } }];
+    const { data, etag } = await getCaseWithEtag("x");
+    expect(data).toMatchObject({ slug: "x" });
+    expect(etag).toBe('"abc123"');
+  });
+
+  it("getCaseWithEtag returns null etag when the header is absent", async () => {
+    responses.get = [{ data: { slug: "x" }, headers: {} }];
+    const { etag } = await getCaseWithEtag("x");
+    expect(etag).toBeNull();
+  });
+
+  it("patchCase sends If-Match and X-Transition-Reason when provided", async () => {
+    await patchCase("case-1", [{ op: "replace", path: "/state", value: "DRAFT" }], {
+      ifMatch: '"tok1"',
+      transitionReason: "needs a second source",
+    });
+    expect(calls[0]).toMatchObject({ method: "patch", url: "/api/cases/case-1/" });
+    const cfg = calls[0].config as { headers: Record<string, string> };
+    expect(cfg.headers["If-Match"]).toBe('"tok1"');
+    expect(cfg.headers["X-Transition-Reason"]).toBe("needs a second source");
+  });
+
+  it("patchCase omits the config entirely when no opts are given", async () => {
+    await patchCase("case-1", [{ op: "replace", path: "/title", value: "X" }]);
+    expect(calls[0].config).toBeUndefined();
+  });
+
+  it("patchCase maps a 412 to CaseConflictError", async () => {
+    responses.patch = [{ status: 412, data: { detail: "changed" } }];
+    await expect(
+      patchCase("case-1", [{ op: "replace", path: "/title", value: "X" }]),
+    ).rejects.toBeInstanceOf(CaseConflictError);
+  });
+
+  it("patchCase maps a 409 to CaseConflictError too", async () => {
+    responses.patch = [{ status: 409, data: {} }];
+    await expect(
+      patchCase("case-1", [{ op: "replace", path: "/title", value: "X" }]),
+    ).rejects.toBeInstanceOf(CaseConflictError);
+  });
+
+  it("patchCase rethrows non-conflict errors unchanged", async () => {
+    responses.patch = [{ status: 422, data: { detail: "bad" } }];
+    await expect(
+      patchCase("case-1", [{ op: "replace", path: "/title", value: "X" }]),
+    ).rejects.not.toBeInstanceOf(CaseConflictError);
+  });
+
+  it("patchCaseWithEtag returns the fresh ETag on success", async () => {
+    responses.patch = [{ data: { slug: "x" }, headers: { etag: '"tok2"' } }];
+    const { etag } = await patchCaseWithEtag("x", [
+      { op: "replace", path: "/title", value: "X" },
+    ]);
+    expect(etag).toBe('"tok2"');
+  });
+
+  it("getCaseHistory hits /history/ and unwraps a paginated envelope", async () => {
+    responses.get = [
+      { data: { count: 1, next: null, previous: null, results: [{ id: 1 }] } },
+    ];
+    const rows = await getCaseHistory("case-1");
+    expect(calls[0].url).toBe("/api/cases/case-1/history/");
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+
+  it("getCaseHistory tolerates a bare array response", async () => {
+    responses.get = [{ data: [{ id: 2 }] }];
+    const rows = await getCaseHistory("case-1");
+    expect(rows).toEqual([{ id: 2 }]);
+  });
+
+  it("getCaseHistory returns [] when the endpoint errors (older backend)", async () => {
+    responses.get = [{ status: 404, data: {} }];
+    const rows = await getCaseHistory("case-1");
+    expect(rows).toEqual([]);
   });
 });

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -429,29 +429,10 @@ export async function patchCase<T = Record<string, unknown>>(
   patchOps: PatchOp[],
   opts: PatchCaseOptions = {},
 ): Promise<T> {
-  const headers: Record<string, string> = {};
-  if (opts.ifMatch) headers["If-Match"] = opts.ifMatch;
-  if (opts.transitionReason && opts.transitionReason.trim())
-    headers["X-Transition-Reason"] = opts.transitionReason.trim();
-  try {
-    const { data } = await client.patch<T>(
-      `/api/cases/${encodeURIComponent(slug)}/`,
-      patchOps,
-      Object.keys(headers).length ? { headers } : undefined,
-    );
-    return data;
-  } catch (err) {
-    // 412 Precondition Failed (or 409 Conflict) => the optimistic lock tripped:
-    // the case changed since we loaded it. Surface a typed error so the editor
-    // can prompt a reload instead of a generic "save failed".
-    const s = (err as { response?: { status?: number } })?.response?.status;
-    if (s === 412 || s === 409) {
-      throw new CaseConflictError(
-        extractErrorMessage(err, "This case changed since you opened it."),
-      );
-    }
-    throw err;
-  }
+  // Thin wrapper over patchCaseWithEtag (which owns the header building + the
+  // 412/409 → CaseConflictError mapping) for callers that don't need the token.
+  const { data } = await patchCaseWithEtag<T>(slug, patchOps, opts);
+  return data;
 }
 
 // Like patchCase but also returns the fresh optimistic-concurrency token the

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -14,6 +14,11 @@
 // request carries `Authorization: Bearer <access>` from the shared oidc.ts.
 import { http as client, API_BASE_URL, extractErrorMessage } from "./http";
 
+// Note: axios lowercases response header keys, so `res.headers.etag` is the
+// ETag the backend sends as `ETag`. CORS must expose it — the dev proxy is
+// same-origin so it's visible; cross-origin prod relies on
+// Access-Control-Expose-Headers including ETag.
+
 // Back-compat re-exports: callers (and dev-auth.ts) import these names. The
 // client, base-URL resolution, and error extraction now live in http.ts (one
 // unified client for the whole app).
@@ -336,6 +341,64 @@ export async function getCase<T = Record<string, unknown>>(
   return data;
 }
 
+// Fetch a case together with its optimistic-concurrency token (the ETag the
+// backend emits on retrieve). The editor holds this token and echoes it back as
+// `If-Match` on save so a concurrent edit is rejected (409/412) instead of
+// silently clobbered. `etag` is null when the backend predates the feature —
+// callers then behave as before (no precondition sent).
+export async function getCaseWithEtag<T = Record<string, unknown>>(
+  slug: string,
+): Promise<{ data: T; etag: string | null }> {
+  const res = await client.get<T>(`/api/cases/${encodeURIComponent(slug)}/`);
+  return { data: res.data, etag: res.headers?.etag ?? null };
+}
+
+// One entry in a case's workflow history (GET /api/cases/{slug}/history/).
+export interface CaseStateChange {
+  id: number;
+  from_state: string;
+  to_state: string;
+  actor_name: string;
+  reason: string;
+  created_at: string;
+}
+
+// Fetch a case's state-change history (newest first). Returns [] when the
+// endpoint is absent (older backend) so the feedback panel degrades to hidden
+// rather than erroring.
+export async function getCaseHistory(slug: string): Promise<CaseStateChange[]> {
+  try {
+    const { data } = await client.get<
+      Paginated<CaseStateChange> | CaseStateChange[]
+    >(`/api/cases/${encodeURIComponent(slug)}/history/`);
+    if (Array.isArray(data)) return data;
+    return data?.results ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// Raised when a PATCH is rejected because the case changed since it was loaded
+// (optimistic-lock precondition failed). The editor catches this to prompt a
+// reload rather than showing a generic error.
+export class CaseConflictError extends Error {
+  constructor(message = "This case changed since you opened it.") {
+    super(message);
+    this.name = "CaseConflictError";
+  }
+}
+
+// Options for a case PATCH beyond the raw ops:
+//   ifMatch          — optimistic-concurrency token from getCaseWithEtag; sent
+//                      as If-Match so a stale write is rejected with 412/409.
+//   transitionReason — a human reason for a state change, sent as
+//                      X-Transition-Reason (recorded in the case history);
+//                      keeps the RFC-6902 body a pure patch.
+export interface PatchCaseOptions {
+  ifMatch?: string | null;
+  transitionReason?: string;
+}
+
 // The authoring shape POST /api/cases/ accepts. The backend forces state=DRAFT
 // on create (A1); everything else rides along verbatim (the [k] escape hatch
 // keeps the form free to send extra authoring fields).
@@ -359,16 +422,66 @@ export async function createCase<T = Record<string, unknown>>(
 }
 
 // UPDATE is an RFC-6902 patch (mirrors the entity contract): the body is a
-// bare array of patch ops.
+// bare array of patch ops. Optional `opts` carry an If-Match precondition and/or
+// an X-Transition-Reason header (see PatchCaseOptions).
 export async function patchCase<T = Record<string, unknown>>(
   slug: string,
   patchOps: PatchOp[],
+  opts: PatchCaseOptions = {},
 ): Promise<T> {
-  const { data } = await client.patch<T>(
-    `/api/cases/${encodeURIComponent(slug)}/`,
-    patchOps,
-  );
-  return data;
+  const headers: Record<string, string> = {};
+  if (opts.ifMatch) headers["If-Match"] = opts.ifMatch;
+  if (opts.transitionReason && opts.transitionReason.trim())
+    headers["X-Transition-Reason"] = opts.transitionReason.trim();
+  try {
+    const { data } = await client.patch<T>(
+      `/api/cases/${encodeURIComponent(slug)}/`,
+      patchOps,
+      Object.keys(headers).length ? { headers } : undefined,
+    );
+    return data;
+  } catch (err) {
+    // 412 Precondition Failed (or 409 Conflict) => the optimistic lock tripped:
+    // the case changed since we loaded it. Surface a typed error so the editor
+    // can prompt a reload instead of a generic "save failed".
+    const s = (err as { response?: { status?: number } })?.response?.status;
+    if (s === 412 || s === 409) {
+      throw new CaseConflictError(
+        extractErrorMessage(err, "This case changed since you opened it."),
+      );
+    }
+    throw err;
+  }
+}
+
+// Like patchCase but also returns the fresh optimistic-concurrency token the
+// backend emits on a successful write, so an in-place editor can keep saving
+// without a re-fetch. `etag` is null on an older backend.
+export async function patchCaseWithEtag<T = Record<string, unknown>>(
+  slug: string,
+  patchOps: PatchOp[],
+  opts: PatchCaseOptions = {},
+): Promise<{ data: T; etag: string | null }> {
+  const headers: Record<string, string> = {};
+  if (opts.ifMatch) headers["If-Match"] = opts.ifMatch;
+  if (opts.transitionReason && opts.transitionReason.trim())
+    headers["X-Transition-Reason"] = opts.transitionReason.trim();
+  try {
+    const res = await client.patch<T>(
+      `/api/cases/${encodeURIComponent(slug)}/`,
+      patchOps,
+      Object.keys(headers).length ? { headers } : undefined,
+    );
+    return { data: res.data, etag: res.headers?.etag ?? null };
+  } catch (err) {
+    const s = (err as { response?: { status?: number } })?.response?.status;
+    if (s === 412 || s === 409) {
+      throw new CaseConflictError(
+        extractErrorMessage(err, "This case changed since you opened it."),
+      );
+    }
+    throw err;
+  }
 }
 
 // Soft-delete a case (backend flips state -> CLOSED, returns 204).


### PR DESCRIPTION
## What & why

Wave-2 of the admin-panel UX work (Wave-1 = #194). Turns the caseworker/moderator surface from "functional" into "triage-grade": moderators can see what's waiting and how long, preview without leaving the queue, and give authors real feedback; caseworkers get a situational dashboard and are protected from clobbering concurrent edits.

**Backend pairing:** depends on `jawafdehi-api` Wave-2 (Jawafdehi/JawafdehiAPI#302) for `?page_size=`, the optimistic-lock `ETag`/`If-Match`, and the case-history endpoint. **Everything degrades gracefully if the backend isn't deployed yet** — history renders nothing, ETag is `null` so no precondition is sent (old last-write-wins), and page_size just falls back to the default page.

## Changes

### Moderation queue — triage-grade (PR-4) · `Moderation.tsx`
- **Waiting age** per row (from `versionInfo.datetime` → `updated_at` → `created_at`), colored amber >3d / red >7d so stale items stand out.
- **Oldest-first sort** (default) + **case-type filter** (client-side over loaded rows).
- **Inline expandable preview** (chevron): description / key allegations / entities / evidence count — read without leaving the queue; "Open" still goes to the full editor.
- **AI review badge** per row (score + disposition, links to `/admin/reviews`) from `/reviews/grouped/`; best-effort (a failure just means no badges).
- Fetches the **full** queue via `?page_size=100`.
- The moderator's **return reason now rides `X-Transition-Reason`** (recorded in case history, shown to the author) instead of being overloaded into the shared internal `/notes`.
- The existing Approve / Send-back / **ConfirmButton-wrapped Dismiss** + error handling are unchanged.

### Dashboard — situational metrics (PR-5) · `Dashboard.tsx`
- Live metric cards (awaiting review, published, drafts, AI reviews) that double as nav doorways; **queue depth is the headline for moderators**. Counts derive from the paginated `count` (`page_size=1`); each fetch is resilient (shows "—" on failure, never crashes). Existing role-gated section cards preserved.

### Case editor — concurrency + feedback (PR-3b / PR-7) · `AdminCaseForm.tsx`, new `CaseHistoryPanel.tsx`
- **Optimistic concurrency:** loads the case with its `ETag` and echoes `If-Match` on save; a stale write is refused (412/409) and the editor shows a **"reload case"** banner instead of silently clobbering a concurrent edit.
- **`CaseHistoryPanel`:** the author feedback loop — who moved the case, when, and any return reason (return/close highlighted). Hidden entirely when there's nothing to show or the endpoint is absent.

### API client · `admin-api.ts`
`getCaseWithEtag` / `patchCaseWithEtag` / `getCaseHistory`, a typed `CaseConflictError`, and `PatchCaseOptions {ifMatch, transitionReason}`.

## Tests & gates
- 11 new `admin-api` tests: ETag round-trip, `If-Match`/`X-Transition-Reason` headers sent (and omitted when no opts), 412 & 409 → `CaseConflictError`, non-conflict errors rethrown, history envelope/array unwrap + graceful 404-→[].
- Full suite **143 tests green**; `tsc --noEmit`, `eslint`, and `bun run build` (SSR + pre-render + sitemap) all clean.

## Not yet done
End-to-end browser verification against a live Wave-2 stack (the running local dev stack is on a different worktree). Unit + type + build coverage is green; a browser pass is the natural follow-up before merge.