### PR TITLE
fix(admin): repair data-lake list pagination + stale search JSON-LD (bug bash)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -570,8 +570,8 @@
       "primary": "Primary Evidence",
       "legal": "Legal Documents",
       "secondary": "Secondary Sources",
-      "documentCount": "{{count}} document",
-      "documentCount_plural": "{{count}} documents"
+      "documentCount_one": "{{count}} document",
+      "documentCount_other": "{{count}} documents"
     },
     "breadcrumbFallback": "Case"
   },

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -570,8 +570,8 @@
       "primary": "प्राथमिक स्रोत",
       "legal": "कानूनी प्रमाण",
       "secondary": "द्वितीयक स्रोतहरू",
-      "documentCount": "{{count}} प्रमाण",
-      "documentCount_plural": "{{count}} प्रमाणहरू"
+      "documentCount_one": "{{count}} प्रमाण",
+      "documentCount_other": "{{count}} प्रमाणहरू"
     },
     "breadcrumbFallback": "मुद्दा"
   },

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -160,7 +160,7 @@ const Index = () => {
               "@type": "SearchAction",
               "target": {
                 "@type": "EntryPoint",
-                "urlTemplate": "https://jawafdehi.org/cases?search={search_term_string}"
+                "urlTemplate": "https://jawafdehi.org/search?type=case&q={search_term_string}"
               },
               "query-input": "required name=search_term_string"
             },
@@ -168,7 +168,7 @@ const Index = () => {
               "@type": "SearchAction",
               "target": {
                 "@type": "EntryPoint",
-                "urlTemplate": "https://jawafdehi.org/entities?search={search_term_string}"
+                "urlTemplate": "https://jawafdehi.org/search?type=entity&q={search_term_string}"
               },
               "query-input": "required name=search_term_string"
             }

--- a/src/pages/admin/datalake/CourtCases.tsx
+++ b/src/pages/admin/datalake/CourtCases.tsx
@@ -18,7 +18,10 @@ const columns: Column<Row>[] = [
   { header: "Status", cell: (r) => <Badge variant="secondary">{str(r.case_status)}</Badge> },
 ];
 
-const PAGE_SIZE = 25;
+// Must match the backend's fixed page size: /api/courtcases/ uses the default
+// DRF PageNumberPagination (PAGE_SIZE=20, no honored page_size param). Sending a
+// different size here would desync the "N–M of total" footer from the rows.
+const PAGE_SIZE = 20;
 
 export default function CourtCases() {
   const navigate = useNavigate();
@@ -44,10 +47,10 @@ export default function CourtCases() {
         )
       }
       fetchPage={(page) =>
-        listCourtCases<Row>({
-          limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE,
-        })
+        // PageNumberPagination is 1-based on `page`; the previous limit/offset
+        // params were ignored by the backend, so paging past 1 refetched page 1
+        // (ADMIN-5). `page` moves the window and drives .next/.count correctly.
+        listCourtCases<Row>({ page })
       }
     />
   );

--- a/src/pages/admin/datalake/Courts.tsx
+++ b/src/pages/admin/datalake/Courts.tsx
@@ -20,7 +20,12 @@ const columns: Column<Row>[] = [
   { header: "Type", cell: (r) => str(r.court_type) },
 ];
 
-const PAGE_SIZE = 25;
+// /api/courts/ is unpaginated (bare array, ~97 rows) — listCourts normalizes it
+// to a single page with next=null, so every row arrives at once. Size the window
+// larger than the whole set so the "N–M of total" footer reads accurately (and
+// the Next button stays disabled) rather than claiming a page split that the
+// single-shot response never produces.
+const PAGE_SIZE = 500;
 
 export default function Courts() {
   const navigate = useNavigate();
@@ -40,9 +45,9 @@ export default function Courts() {
           <Plus className="mr-1 h-4 w-4" /> New Court
         </Button>
       }
-      fetchPage={(page) =>
-        listCourts<Row>({ limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
-      }
+      // Unpaginated endpoint: fetch the whole (normalized) set once; the page
+      // arg is unused because the backend returns every court in one array.
+      fetchPage={() => listCourts<Row>()}
     />
   );
 }

--- a/src/pages/admin/datalake/Firms.tsx
+++ b/src/pages/admin/datalake/Firms.tsx
@@ -16,7 +16,10 @@ const columns: Column<Row>[] = [
   { header: "Blocklisted", cell: (r) => str(r.blacklist_date_ad ?? r.blacklist_date_bs) },
 ];
 
-const PAGE_SIZE = 25;
+// Must match the backend's fixed page size: /api/firms/ uses the default DRF
+// PageNumberPagination (PAGE_SIZE=20, no honored page_size param), so the table
+// window has to be 20 to keep the "N–M of total" footer aligned with the rows.
+const PAGE_SIZE = 20;
 
 // F7 — blocklisted firms list. Firms are keyed by their numeric `id` (the model
 // PK); firm names are not unique, so the row/route key is the id.
@@ -39,7 +42,9 @@ export default function Firms() {
         </Button>
       }
       fetchPage={(page) =>
-        listBlacklistedFirms<Row>({ limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
+        // PageNumberPagination is 1-based on `page`; the old limit/offset params
+        // were ignored, so paging past 1 refetched page 1 (same class as ADMIN-5).
+        listBlacklistedFirms<Row>({ page })
       }
     />
   );

--- a/src/services/admin-api.test.ts
+++ b/src/services/admin-api.test.ts
@@ -109,6 +109,33 @@ describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
     ]);
   });
 
+  it("normalizes the bare-array /api/courts/ response into a paginated envelope (ADMIN-8)", async () => {
+    // /api/courts/ is unpaginated on the backend (pagination_class = None) and
+    // returns a plain array. listCourts must wrap it as { count, next, results }
+    // so the generic ResourceTable (which reads .results/.count) renders rows
+    // instead of an empty table.
+    responses.get = [
+      { data: [{ identifier: "kathmandudc" }, { identifier: "supremecourt" }] },
+    ];
+    const page = await listCourts();
+    expect(page.results.map((c) => (c as { identifier: string }).identifier)).toEqual([
+      "kathmandudc",
+      "supremecourt",
+    ]);
+    expect(page.count).toBe(2);
+    expect(page.next).toBeNull();
+  });
+
+  it("passes an already-paginated /api/courts/ envelope through unchanged", async () => {
+    // Defensive: if the backend ever starts paginating courts, don't double-wrap.
+    responses.get = [
+      { data: { count: 1, next: null, previous: null, results: [{ identifier: "x" }] } },
+    ];
+    const page = await listCourts();
+    expect(page.count).toBe(1);
+    expect(page.results).toHaveLength(1);
+  });
+
   it("routes materials to /api/materials", async () => {
     await listMaterials();
     await deleteMaterial("ciaa", "press-2081-042");

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -189,6 +189,11 @@ export async function listCourts<T = Record<string, unknown>>(
   // .results/.count/.next). Without this, res.results is undefined → the courts
   // table renders zero rows even though courts exist (ADMIN-8).
   const { data } = await client.get<T[] | Paginated<T>>("/api/courts/", { params });
+  // Defensive: an empty/absent body (network anomaly, 204-ish) would otherwise
+  // propagate as a null envelope and crash ResourceTable on `res.results`.
+  if (!data) {
+    return { count: 0, next: null, previous: null, results: [] };
+  }
   if (Array.isArray(data)) {
     return { count: data.length, next: null, previous: null, results: data };
   }

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -183,7 +183,15 @@ export async function listCourtCases<T = Record<string, unknown>>(
 export async function listCourts<T = Record<string, unknown>>(
   params: Record<string, unknown> = {},
 ): Promise<Paginated<T>> {
-  const { data } = await client.get<Paginated<T>>("/api/courts/", { params });
+  // /api/courts/ has `pagination_class = None` (small fixed set, ~97 rows), so it
+  // returns a BARE ARRAY — not a { count, next, results } envelope. Normalize it
+  // to the paginated shape the generic admin ResourceTable expects (it reads
+  // .results/.count/.next). Without this, res.results is undefined → the courts
+  // table renders zero rows even though courts exist (ADMIN-8).
+  const { data } = await client.get<T[] | Paginated<T>>("/api/courts/", { params });
+  if (Array.isArray(data)) {
+    return { count: data.length, next: null, previous: null, results: data };
+  }
   return data;
 }
 


### PR DESCRIPTION
## What & why

Bug-bash follow-ups verified against the **current** trunk. Most of the original S0/S1 findings turned out to be already fixed or the feature removed by recent merges (#188–#197); this PR closes the small set that is **genuinely still open**, all in the admin data-lake area plus two cosmetic cleanups.

### ADMIN-8 · Courts admin table renders empty
`/api/courts/` uses `pagination_class = None` and returns a **bare array**, but `listCourts` typed it as a `{count,next,results}` envelope. `ResourceTable` reads `res.results` → `undefined` → zero rows even though ~97 courts exist. Fix: `listCourts` normalizes a bare array into the paginated shape; the Courts page fetches the whole set once (`next=null`) and sizes its window past the full set so the "N–M of total" footer stays accurate and Next stays disabled.

### ADMIN-5 · Court-case & firm admin lists stuck on page 1
Both `/api/courtcases/` and `/api/firms/` use DRF's default `PageNumberPagination` (`?page`, `PAGE_SIZE=20`), but the pages sent `limit`/`offset`, which that paginator ignores — so "Next" just refetched page 1. Fix: send `page` and align the table window to the backend's 20.

### Cleanup
- **`documentCount` plural key** used the i18next-v3 `_plural` suffix, which never resolves under the v4 plural rules the rest of the bundle uses. Renamed to `_one`/`_other` in both locales to match convention. (Key is currently unreferenced, so no user-visible change today — this just makes it correct if wired up.)
- **Homepage JSON-LD `SearchAction`** `urlTemplate`s pointed at `/cases?search=` and `/entities?search=`; neither route consumes `?search=`, and `/entities` now redirects to unified search. Repointed both at the real `/search?type=…&q=…`.

## Tests
- Adds two `admin-api` tests locking in the bare-array normalization (and the pass-through when already paginated).
- Full suite green: **146 tests**, `lint`, and `build` (incl. SSR + pre-render) all pass locally.

## Scope notes
- Public court-case/firm browse pages use unified search, **not** these list endpoints, so the public API contract and its tests are untouched — this is FE-only.
- `/api/materials/` (cursor pagination) was intentionally left alone; it's not part of the flagged findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search behavior so entity searches now open the correct results page.
  * Updated language strings for document counts to display correctly in singular and plural forms.

* **Bug Fixes**
  * Fixed pagination in admin lists so courts, court cases, and blocklisted firms load the expected pages.
  * Ensured the courts list displays all available entries in one view when appropriate.
  * Normalized court data responses to prevent table display issues.

* **Tests**
  * Added coverage for court list response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->