### PR TITLE
perf(home): speed up "Recently Documented Cases" load

### DIFF
--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -29,7 +29,7 @@ async function prefetch(url: string, queryClient: QueryClient): Promise<void> {
   if (url === '/') {
     await Promise.allSettled([
       queryClient.prefetchQuery({ queryKey: ['statistics'], queryFn: getStatistics }),
-      queryClient.prefetchQuery({ queryKey: ['cases', { page: 1 }], queryFn: () => getCases({ page: 1 }) }),
+      queryClient.prefetchQuery({ queryKey: ['cases', { page: 1, page_size: 3 }], queryFn: () => getCases({ page: 1, page_size: 3 }) }),
     ]);
     return;
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -66,10 +66,10 @@ const Index = () => {
     })),
   });
 
-  // Build the resolved-name map from the cached query results. Keyed by a stable
-  // primitive signature (which ids have loaded) so the map identity only changes
-  // when a query actually resolves — keeps the featuredCases memo below stable.
-  const resolvedKey = entityQueries.map(q => (q.data ? 'y' : 'n')).join('');
+  // Build the resolved-name map from the cached query results. useQueries applies
+  // structural sharing, so entityQueries keeps a stable reference until a result
+  // actually changes (including a background refetch) — depending on it directly
+  // recomputes the map exactly when data changes and no more often.
   const resolvedEntities = useMemo(() => {
     const map: Record<string, Entity> = {};
     locationNesIds.forEach((nesId, i) => {
@@ -77,9 +77,7 @@ const Index = () => {
       if (entity) map[nesId] = entity;
     });
     return map;
-    // entityQueries omitted intentionally; resolvedKey captures when results load.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locationNesIds, resolvedKey]);
+  }, [locationNesIds, entityQueries]);
 
   // Transform API cases to CaseCard format
   const featuredCases = useMemo(() => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,10 +7,10 @@ import { SupportingPartner } from "@/components/home/supportingpartner";
 import { ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueries } from "@tanstack/react-query";
 import { getCases, getStatistics } from "@/services/jds-api";
 import { getEntityById } from "@/services/api";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import type { Entity } from "@/types/entity";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
@@ -20,7 +20,6 @@ import { useTranslation } from "react-i18next";
 const Index = () => {
   const { t, i18n } = useTranslation();
   const currentLang = i18n.language;
-  const [resolvedEntities, setResolvedEntities] = useState<Record<string, Entity>>({});
 
   const { data: stats, isError: statsError, isLoading: statsLoading } = useQuery({
     queryKey: ['statistics'],
@@ -35,51 +34,52 @@ const Index = () => {
     return value?.toLocaleString() || "0";
   };
 
+  // The "Recently Documented Cases" section renders only the top 3 cards, so
+  // fetch exactly 3 rather than the default page of 20 — this shrinks the
+  // payload and the backend per-card resolution work. Keep the query key in
+  // sync with the SSR prefetch in entry-server.tsx.
   const { data: casesData } = useQuery({
-    queryKey: ['cases', { page: 1 }],
-    queryFn: () => getCases({ page: 1 }),
+    queryKey: ['cases', { page: 1, page_size: 3 }],
+    queryFn: () => getCases({ page: 1, page_size: 3 }),
     staleTime: 5 * 60 * 1000,
   });
 
-  // Resolve location entities from the registry
-  useEffect(() => {
-    if (!casesData?.results) return;
-
-    let isMounted = true;
-
-    const resolveEntities = async () => {
-      const allEntities = casesData.results.flatMap(c => c.entities || []);
-      const locationEntities = allEntities.filter(e => e.type === 'location');
-      const uniqueNesIds = [...new Set(locationEntities.map(e => e.nes_id!).filter(Boolean))];
-
-      const entityPromises = uniqueNesIds.map(async (nesId) => {
-        try {
-          const entity = await getEntityById(nesId);
-          return { id: nesId, entity };
-        } catch {
-          return null;
-        }
-      });
-
-      const entities = await Promise.all(entityPromises);
-
-      // Only update state if component is still mounted
-      if (isMounted) {
-        const entitiesMap = entities.reduce((acc, item) => {
-          if (item) acc[item.id] = item.entity;
-          return acc;
-        }, {} as Record<string, Entity>);
-        setResolvedEntities(entitiesMap);
-      }
-    };
-
-    resolveEntities();
-
-    // Cleanup function to prevent state updates on unmounted component
-    return () => {
-      isMounted = false;
-    };
+  // Resolve location entity display names via react-query so they are cached
+  // and deduped across mounts (and shared with the case-detail page's
+  // ["entity-record", id] queries) instead of an uncached imperative fetch that
+  // re-fires on every mount. Only the top 3 rendered cases' locations are read.
+  const locationNesIds = useMemo(() => {
+    const top = casesData?.results?.slice(0, 3) ?? [];
+    const ids = top
+      .flatMap(c => c.entities ?? [])
+      .filter(e => e.type === 'location' && e.nes_id)
+      .map(e => e.nes_id!);
+    return [...new Set(ids)];
   }, [casesData]);
+
+  const entityQueries = useQueries({
+    queries: locationNesIds.map(nesId => ({
+      queryKey: ["entity-record", nesId],
+      queryFn: () => getEntityById(nesId),
+      staleTime: 10 * 60 * 1000,
+      retry: false,
+    })),
+  });
+
+  // Build the resolved-name map from the cached query results. Keyed by a stable
+  // primitive signature (which ids have loaded) so the map identity only changes
+  // when a query actually resolves — keeps the featuredCases memo below stable.
+  const resolvedKey = entityQueries.map(q => (q.data ? 'y' : 'n')).join('');
+  const resolvedEntities = useMemo(() => {
+    const map: Record<string, Entity> = {};
+    locationNesIds.forEach((nesId, i) => {
+      const entity = entityQueries[i]?.data;
+      if (entity) map[nesId] = entity;
+    });
+    return map;
+    // entityQueries omitted intentionally; resolvedKey captures when results load.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [locationNesIds, resolvedKey]);
 
   // Transform API cases to CaseCard format
   const featuredCases = useMemo(() => {

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -247,6 +247,8 @@ export interface CaseSearchParams {
   tags?: string;
   search?: string;
   page?: number;
+  /** Server honours ?page_size= up to 200 (CasePagination). */
+  page_size?: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem
The home page's "Recently Documented Cases" section loaded slowly and
never got faster on reload. It fetched a full page of 20 cases just to
render 3, and it ran an **uncached, imperative** `getEntityById` loop in
a `useEffect` that re-fired on every mount (no dedup, no cache).

## What changed
- **Fetch only what renders** — the home cases query now requests
  `page_size=3` instead of the default 20, shrinking the payload and the
  backend per-card work. The SSR prefetch key in `entry-server.tsx` is
  updated to match so hydration lines up. (`page_size?` added to
  `CaseSearchParams`.)
- **Cache entity-name resolution** — replaced the imperative
  `getEntityById` loop with react-query `useQueries` keyed by
  `["entity-record", nesId]`, so lookups are cached/deduped and shared
  with the case-detail page's identical queries instead of re-fetching on
  every mount.

## Why
Pairs with the backend change (`perf/cases-list-caching`): the backend
makes `/api/cases/` fast and cacheable; this makes the client request
only the 3 cards it renders and stop re-resolving entity names on every
mount.

## Verification
- Confirmed in the browser: the section issues a single
  `/api/cases/?page=1&page_size=3` request (not a 20-item fetch),
  initiated by `getCases`.
- No new type errors in the changed files; eslint clean on `Index.tsx`.

## Notes
- The full production speedup (cached `/api/cases`, warm-reload cache
  hits) is visible once the backend PR is deployed — production doesn't
  have those changes yet.
- Pre-existing repo issue, unrelated to this PR: `react-pdf` / `hast`
  are not installed, so `vite build` / `tsc` fail repo-wide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the number of cases displayed in paginated results.
  * The “Recently Documented Cases” section now displays the three most recent cases with location details resolved automatically.

* **Bug Fixes**
  * Improved consistency between server-rendered and client-rendered case data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->