### PR TITLE
fix(telemetry): gate Sentry + GA on runtime host (block *.workers.dev previews)

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { getConsent, setConsent } from "@/lib/consent";
 import { loadGoogleAnalytics } from "@/lib/ga";
+import { telemetryAllowedHere } from "@/lib/telemetry";
 
 /**
  * Opt-in cookie consent banner. Analytics (Google Analytics) load only after
@@ -15,6 +16,9 @@ export function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    // On dev builds, localhost, and *.workers.dev previews, GA never loads, so
+    // there's nothing to consent to — don't prompt.
+    if (!telemetryAllowedHere()) return;
     const decision = getConsent();
     if (decision === null) {
       setVisible(true);

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -4,14 +4,16 @@
  * gtag.js is never fetched and no GA cookies are set.
  */
 import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
+import { telemetryAllowedHere } from "./telemetry";
 
 let loaded = false;
 
 export function loadGoogleAnalytics(): void {
   if (typeof window === "undefined" || loaded || window.gtag) return;
-  // Never load the production GA property from a local dev build — otherwise
-  // localhost page views pollute prod analytics.
-  if (import.meta.env.DEV) return;
+  // Never load the production GA property from a dev build, localhost, or a
+  // Cloudflare `*.workers.dev` preview — otherwise their page views pollute
+  // prod analytics.
+  if (!telemetryAllowedHere()) return;
   loaded = true;
 
   const script = document.createElement("script");

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,16 +1,21 @@
 import * as Sentry from "@sentry/react";
+import { isCloudflarePreviewHost, telemetryAllowedHere } from "./telemetry";
 
 const HARDCODED_DSN = "https://f5fafd04ccca67355a3b404d1b209e94@o4511364048027648.ingest.de.sentry.io/4511366946226256";
 
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN as string | undefined;
 
 export function initSentry(): void {
-  // Only fall back to the hardcoded PRODUCTION DSN in non-dev builds. In dev,
-  // the prod DSN is omitted so localhost errors don't pollute the prod project
-  // (which also tripped 429s) — but a developer can still test Sentry locally by
-  // setting an explicit VITE_SENTRY_DSN. No DSN → nothing to init.
-  const dsn = SENTRY_DSN || (import.meta.env.DEV ? undefined : HARDCODED_DSN);
-  if (!dsn) return;
+  // Cloudflare `*.workers.dev` previews NEVER report — even though CI bakes
+  // VITE_SENTRY_DSN into every build — so preview errors can't reach the prod
+  // Sentry project (which also tripped 429s). This block cannot be overridden.
+  if (isCloudflarePreviewHost()) return;
+
+  // Dev builds and localhost stay silent too, UNLESS a developer opts into local
+  // Sentry testing by setting an explicit VITE_SENTRY_DSN.
+  if (!SENTRY_DSN && !telemetryAllowedHere()) return;
+
+  const dsn = SENTRY_DSN || HARDCODED_DSN;
 
   Sentry.init({
     dsn,

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,53 @@
+/**
+ * Telemetry host gate.
+ *
+ * Sentry error monitoring and Google Analytics must never run on developer
+ * machines or Cloudflare preview deploys, so that local noise and test-
+ * playground traffic don't pollute the production Sentry project / GA property.
+ *
+ * Two independent signals are needed because neither alone is sufficient:
+ *   - `import.meta.env.DEV` catches `vite dev` regardless of the host it is
+ *     served on (e.g. a LAN IP), but it is baked in at build time.
+ *   - the runtime hostname catches Cloudflare `*.workers.dev` previews, which
+ *     are PRODUCTION builds (`import.meta.env.DEV === false`) served from a
+ *     throwaway host — build mode can't tell them apart from the real site.
+ */
+
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "[::1]",
+]);
+
+/**
+ * Cloudflare Workers preview deploy (`<name>.<subdomain>.workers.dev`, and
+ * versioned previews `<version>-<name>.<subdomain>.workers.dev`) — a throwaway
+ * test playground.
+ *
+ * This is an ABSOLUTE block that callers must honour even when they would
+ * otherwise allow an explicit-DSN opt-in: CI bakes `VITE_SENTRY_DSN` into
+ * builds, so a preview build always carries a DSN and could re-enable Sentry
+ * here if suppression keyed off the DSN's presence.
+ */
+export function isCloudflarePreviewHost(): boolean {
+  if (typeof window === "undefined") return false;
+  const host = window.location.hostname;
+  return host === "workers.dev" || host.endsWith(".workers.dev");
+}
+
+export function telemetryAllowedHere(): boolean {
+  // No window (SSR / worker render): never load client telemetry.
+  if (typeof window === "undefined") return false;
+
+  // Dev builds never report, whatever host they are served from.
+  if (import.meta.env.DEV) return false;
+
+  const host = window.location.hostname;
+  if (BLOCKED_HOSTS.has(host)) return false;
+
+  if (isCloudflarePreviewHost()) return false;
+
+  return true;
+}


### PR DESCRIPTION
## What
Gate Sentry error monitoring and Google Analytics on the **runtime hostname**, not just the Vite build mode, so neither fires from developer machines or Cloudflare preview deploys.

## Why
`main` already suppresses telemetry on local dev via `import.meta.env.DEV`. But Cloudflare `*.workers.dev` preview deploys are **production builds** — `import.meta.env.DEV` is `false` there — so both Sentry and GA still reported from test playgrounds into the prod Sentry project / GA property.

## How
- New `src/lib/telemetry.ts`:
  - `telemetryAllowedHere()` → `false` for SSR, dev builds (`import.meta.env.DEV`), localhost / loopback / `0.0.0.0`, and any `*.workers.dev` host.
  - `isCloudflarePreviewHost()` → the **absolute** `*.workers.dev` block.
- `loadGoogleAnalytics()` gates on `telemetryAllowedHere()`.
- `initSentry()` blocks `*.workers.dev` unconditionally, then suppresses dev/localhost **unless** a developer sets an explicit `VITE_SENTRY_DSN` (local Sentry testing). The preview block is separate because `ci.yml` bakes `VITE_SENTRY_DSN` into every build, so keying suppression off the DSN would let a preview build re-enable Sentry.
- `CookieConsentBanner` no longer prompts on blocked hosts (GA can't load there, so there's nothing to consent to).

## Behaviour
| Context | Sentry | GA |
| --- | --- | --- |
| prod (jawafdehi.org) | on | on (with consent) |
| localhost, default | off | off |
| localhost + explicit `VITE_SENTRY_DSN` | on (opt-in) | off |
| `*.workers.dev` preview (even with CI-baked DSN) | **off** | **off** |
| dev build on a LAN IP | off | off |

Verified with a decision-table simulation across all eight cases above. `tsc --noEmit` + `eslint` clean; GA stays consent-gated; no test asserts telemetry loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
