### PR TITLE
fix(admin): make blank entity "Add row" unambiguous and non-lossy (BB-27)

### DIFF
--- a/src/components/admin/case/EntityRelationshipsEditor.tsx
+++ b/src/components/admin/case/EntityRelationshipsEditor.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { cn } from "@/lib/utils";
 import { searchEntities, adminErrorMessage } from "@/services/admin-api";
 import {
   RELATIONSHIP_TYPES,
@@ -43,17 +44,22 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
   const [results, setResults] = useState<Record<string, unknown>[]>([]);
   const [searching, setSearching] = useState(false);
   const [searchErr, setSearchErr] = useState<string | null>(null);
+  // Index of a row just appended by "Add row" / the link button, so its IRI input can grab focus and scroll into view once it mounts — otherwise the new row lands below the fold and the click reads as a no-op (BB-27).
+  const pendingFocus = useRef<number | null>(null);
 
   const update = (i: number, patch: Partial<EntityRelationshipRow>) =>
     onChange(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
 
   const remove = (i: number) => onChange(rows.filter((_, idx) => idx !== i));
 
-  const addRow = (nes_id = "") =>
+  const addRow = (nes_id = "") => {
+    // The appended row lands at the current end of the list; queue that index for focus.
+    pendingFocus.current = rows.length;
     onChange([
       ...rows,
       { nes_id, relationship_type: "ACCUSED", outcome: "CHARGED", notes: "" },
     ]);
+  };
 
   const runSearch = async () => {
     if (!query.trim()) return;
@@ -146,17 +152,37 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
       ) : (
         <div className="space-y-3">
           {rows.map((r, i) => {
-            const iriBad = r.nes_id.trim() !== "" && !isValidEntityIri(r.nes_id);
+            // A blank IRI means "required, not filled yet"; a non-blank IRI that fails the pattern is malformed. Both are invalid and block save (AdminCaseForm.entityRowsValid), so a blank add-row can no longer be silently dropped from the /entities patch and vanish on save (BB-27).
+            const iriMissing = r.nes_id.trim() === "";
+            const iriBad = !iriMissing && !isValidEntityIri(r.nes_id);
             return (
               <div key={i} className="grid gap-2 rounded border p-2 sm:grid-cols-[1fr_10rem_10rem_auto]">
                 <div className="space-y-1">
                   <Input
+                    ref={(el) => {
+                      if (el && pendingFocus.current === i) {
+                        pendingFocus.current = null;
+                        el.focus();
+                        el.scrollIntoView?.({ block: "nearest" });
+                      }
+                    }}
                     value={r.nes_id}
                     onChange={(e) => update(i, { nes_id: e.target.value })}
-                    className="font-mono text-xs"
+                    aria-invalid={iriMissing || iriBad}
+                    className={cn(
+                      "font-mono text-xs",
+                      (iriMissing || iriBad) &&
+                        "border-red-400 focus-visible:ring-red-400",
+                    )}
                     placeholder="https://jawafdehi.org/entity/person/…"
                   />
-                  <FieldError message={iriBad && "Not a canonical entity @id IRI."} />
+                  <FieldError
+                    message={
+                      (iriMissing &&
+                        "Entity IRI required — search above or paste a canonical @id.") ||
+                      (iriBad && "Not a canonical entity @id IRI.")
+                    }
+                  />
                   <Input
                     value={r.notes}
                     onChange={(e) => update(i, { notes: e.target.value })}

--- a/src/lib/jawafdehi-forms.test.ts
+++ b/src/lib/jawafdehi-forms.test.ts
@@ -65,6 +65,13 @@ describe("isValidEntityRow", () => {
     expect(
       isValidEntityRow({ nes_id: "not-an-iri", relationship_type: "ACCUSED", outcome: "CHARGED", notes: "" }),
     ).toBe(false);
+    // A blank / whitespace-only IRI row is invalid: the form blocks save on it (BB-27) rather than letting the patch builder silently drop the row and vanish on reload.
+    expect(
+      isValidEntityRow({ nes_id: "", relationship_type: "ACCUSED", outcome: "CHARGED", notes: "" }),
+    ).toBe(false);
+    expect(
+      isValidEntityRow({ nes_id: "   ", relationship_type: "WITNESS", outcome: null, notes: "" }),
+    ).toBe(false);
     expect(
       isValidEntityRow({
         nes_id: IRI,

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -294,18 +294,13 @@ export default function AdminCaseForm() {
   const datesValid =
     isValidDateField(form.case_start_date) &&
     isValidDateField(form.case_end_date);
-  // A partially-filled timeline/entity row would serialize into the /timeline or
-  // /entities replace and 422 the whole PATCH (title-less timeline row, IRI-less
-  // entity row). Block save until every *populated* row is complete, so the user
-  // fixes it here instead of losing the whole batch to a server rejection. A
-  // fully-blank trailing add-row is fine — it's dropped by the patch builder.
+  // A partially-filled timeline row (title without a date, etc.) would serialize into the /timeline replace and 422 the whole PATCH, so block save until every *populated* timeline row is complete — a fully-blank trailing timeline add-row is fine, the patch builder drops it.
   const timelineRowsValid = form.timeline.every(
     (r) =>
       (r.title.trim() === "" && r.date.trim() === "") || isValidTimelineRow(r),
   );
-  const entityRowsValid = form.entities.every(
-    (r) => r.nes_id.trim() === "" || isValidEntityRow(r),
-  );
+  // Entities are stricter than timeline: an "Add row" starts blank and buildEntitiesPatch silently drops blank-IRI rows, so a blank row would vanish on save with no feedback ("Add row appears to do nothing", BB-27). Require every entity row to carry a valid IRI so save is blocked with an inline hint instead — the author fills the IRI (search or paste) or removes the row, never loses it silently.
+  const entityRowsValid = form.entities.every((r) => isValidEntityRow(r));
   // An invalid court-case chip would 422 the whole PATCH (they are sent
   // verbatim rather than silently dropped) — block save until fixed.
   const courtCaseRowsValid = form.court_cases.every(


### PR DESCRIPTION
## Summary

Fixes **BB-27** (bug bash, 2026-07-07): the case editor's entity "Add row" appeared to do nothing.

"Add row" was never a literal no-op — it appended a blank relationship row — but a blank-IRI row was **silently discarded on save with no feedback anywhere in the flow**, so the row vanished on the next save/reload and the click read as "did nothing." Three cooperating gaps caused it:

- `buildEntitiesPatch()` (`src/lib/jawafdehi-forms.ts`) drops any row whose `nes_id` is blank from the `/entities` replace op.
- `entityRowsValid` in `AdminCaseForm.tsx` explicitly treated a blank-IRI row as valid, so save was never blocked.
- The per-row `FieldError` in `EntityRelationshipsEditor.tsx` only rendered for a non-blank-but-malformed IRI, so a blank IRI got zero inline signal.

## Changes

- **Inline feedback:** a blank IRI now shows an "Entity IRI required — search above or paste a canonical @id." hint plus an invalid input state (`aria-invalid` + red border).
- **No silent loss:** `entityRowsValid` now requires every entity row to carry a valid IRI, so save is blocked (with the existing aggregate message) until the author fills the IRI or removes the row — the row can no longer silently vanish.
- **Discoverability:** a freshly appended row (from "Add row" or the search-link button) focuses its IRI input and scrolls into view, so it's obviously there even when the editor sits below the fold.
- Timeline keeps its trailing-blank-row courtesy unchanged (only entities were lossy).
- Extends the `isValidEntityRow` unit test to pin the blank/whitespace-IRI-row-is-invalid contract the save gate now relies on.

## Behavior change to note

A blank trailing entity row now **blocks save** (author must fill the IRI or remove the row) instead of being silently dropped. This is the intended fix — it trades a silent no-op for explicit, correctable feedback.

## Testing

- `bun run lint` (eslint) — clean.
- `bunx vitest run` — 147/147 across 25 files (incl. the extended `isValidEntityRow` cases).
- `bun run build:dev` — builds clean.
- Rebased on latest `main`; no conflicts. Pre-existing `tsc` errors are unrelated (identical count vs `main`) and live in files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
