### PR TITLE
test: lock in case-overview markdown rendering for well-formed input (BB-08)

### DIFF
--- a/src/components/case-detail/case-overview-section.test.tsx
+++ b/src/components/case-detail/case-overview-section.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CaseOverviewSection } from "@/components/case-detail/case-overview-section";
+import { padColspanTableHeaders } from "@/utils/rehype-colspan";
+
+// Passthrough translations so assertions don't depend on i18n resources (mirrors ArticleView.test.tsx).
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+// CollapsibleCaseContent measures its content with a ResizeObserver, which jsdom does not implement.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+// These lock in that the case-description markdown pipeline (padColspanTableHeaders + react-markdown + remark-gfm + rehype-raw + rehypeColspan) renders well-formed input correctly, so the recurring "** shows as literal asterisks" report can only be authoring-side (malformed markdown), not a renderer defect.
+describe("padColspanTableHeaders", () => {
+  it("leaves well-formed emphasis and headings untouched", () => {
+    const source = "# Heading text\n\nThis has **bold text** and _italic text_.";
+    expect(padColspanTableHeaders(source)).toBe(source);
+  });
+
+  it("only pads the header of a colspan table and preserves inline markup inside it", () => {
+    const source = "| **A** |\n| --- | --- |\n| x | y |";
+    const padded = padColspanTableHeaders(source);
+    // The **A** header cell is preserved verbatim; only an empty trailing cell is appended so the header width matches the delimiter row.
+    expect(padded).toContain("**A**");
+    expect(padded.split("\n")[0]).toBe("| **A** |  |");
+  });
+});
+
+describe("CaseOverviewSection markdown rendering", () => {
+  const description = [
+    "# Heading text",
+    "",
+    "This has **bold text** and _italic text_ inline.",
+    "",
+    "- item one",
+    "- item two",
+  ].join("\n");
+
+  it("renders well-formed markdown to real HTML elements through the case-overview path", () => {
+    const { container } = render(
+      <CaseOverviewSection description={description} title="Overview" />,
+    );
+
+    // Bold renders as <strong>, not literal asterisks.
+    const strong = container.querySelector("strong");
+    expect(strong?.textContent).toBe("bold text");
+    expect(container.textContent).not.toContain("**bold text**");
+
+    // Underscore emphasis renders as <em>.
+    const em = container.querySelector("em");
+    expect(em?.textContent).toBe("italic text");
+
+    // A heading with a space after '#' renders as a heading element.
+    expect(screen.getByRole("heading", { name: "Heading text" })).toBeTruthy();
+
+    // A dash list renders as <ul>/<li>.
+    const items = Array.from(container.querySelectorAll("ul > li")).map((li) => li.textContent?.trim());
+    expect(items).toEqual(["item one", "item two"]);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses **BB-08** (bug bash, 2026-07-07): a report that bold `**` renders as literal asterisks on case pages.

**Verdict: the renderer is correct for well-formed input — this is not a renderer defect.** The reported sample was malformed (a trailing space before the closing `**`, and `**` spanning a blank line), which CommonMark/GFM correctly renders as literal asterisks. Rather than add risky heuristic "fixups" that could corrupt intentional literal asterisks, this PR locks the correct behavior in with a regression test so a future transform can't silently break emphasis.

## Why the renderer is fine

- `padColspanTableHeaders` / `rehypeColspan` (`src/utils/rehype-colspan.ts`) only touch GFM table colspan (a header line immediately followed by a `|---|` delimiter row); they never escape asterisks or rewrite inline emphasis, and they leave a `**bold**` table-header cell verbatim.
- `rehypeRaw` is standard raw-HTML passthrough and does not swallow the `strong`/`em` nodes remark produces.

## Changes

- Adds `src/components/case-detail/case-overview-section.test.tsx`:
  - A pure-function block asserting `padColspanTableHeaders` leaves well-formed emphasis/headings untouched and only pads a colspan-table header.
  - A component block that renders the real `CaseOverviewSection` through the full pipeline (`padColspanTableHeaders` + `react-markdown` + `remark-gfm` + `rehype-raw` + `rehypeColspan`) and asserts `**bold**` → `<strong>`, `_italic_` → `<em>`, `# H` → heading, and dash list → `<ul>/<li>`, and that the output does **not** contain literal `**bold text**`.
- No renderer change (none warranted).

## Follow-up (out of scope)

The remaining gap is authoring UX — a description editor with a live preview / guidance / WYSIWYG toolbar would prevent malformed input at the source. Tracked as an enhancement, not a bug.

## Testing

- `bun run lint` (eslint) — clean.
- `bunx vitest run` — 150/150 across 26 files (incl. the 3 new assertions).
- Rebased on latest `main`; no conflicts. Pre-existing `tsc` errors are unrelated (identical count vs `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
