### PR TITLE
feat(newsletter): dwell + broaden scope + 30-day re-ask for the signup popup

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router-dom";
 
 import { Footer } from "@/components/Footer";
 import { Navbar } from "@/components/Navbar";
+import { NewsletterSignupModal } from "@/components/home/newsletter-signup-modal";
 
 export function AppLayout() {
   return (
@@ -11,6 +12,9 @@ export function AppLayout() {
         <Outlet />
       </main>
       <Footer />
+      {/* Mounted once for the whole public shell; it self-gates to eligible
+          routes (home / case / updates) and arms a dwell timer there. */}
+      <NewsletterSignupModal />
     </div>
   );
 }

--- a/src/components/home/newsletter-signup-modal.test.tsx
+++ b/src/components/home/newsletter-signup-modal.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { NewsletterSignupModal } from "@/components/home/newsletter-signup-modal";
+
+// Passthrough i18n so assertions don't depend on translation resources.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+// The form pulls in the API client + form controls; the trigger logic under test
+// doesn't need them, so stub it to a marker.
+vi.mock("@/components/home/newsletter-form", () => ({
+  NewsletterForm: () => <div data-testid="newsletter-form" />,
+}));
+
+// Minimal jsdom polyfills the Radix Dialog touches when it opens.
+beforeEach(() => {
+  window.matchMedia ??= vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.scrollIntoView ??= vi.fn();
+  Element.prototype.hasPointerCapture ??= vi.fn(() => false);
+  Element.prototype.releasePointerCapture ??= vi.fn();
+});
+
+const STORAGE_KEY = "jawafdehi_newsletter_prompt";
+const DWELL_MS = 25000;
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <NewsletterSignupModal />
+    </MemoryRouter>,
+  );
+}
+
+describe("NewsletterSignupModal trigger", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  it("stays closed until the dwell elapses, then opens on an eligible route", () => {
+    renderAt("/case/some-case");
+    expect(screen.queryByRole("dialog")).toBeNull();
+    act(() => vi.advanceTimersByTime(DWELL_MS));
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("never opens on an ineligible route", () => {
+    renderAt("/about");
+    act(() => vi.advanceTimersByTime(DWELL_MS * 3));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("stays closed while a recent dismissal is stored", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ state: "dismissed", ts: Date.now() }),
+    );
+    renderAt("/");
+    act(() => vi.advanceTimersByTime(DWELL_MS));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/components/home/newsletter-signup-modal.test.tsx
+++ b/src/components/home/newsletter-signup-modal.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 
 import { NewsletterSignupModal } from "@/components/home/newsletter-signup-modal";
 
@@ -34,12 +34,28 @@ beforeEach(() => {
 
 const STORAGE_KEY = "jawafdehi_newsletter_prompt";
 const DWELL_MS = 25000;
+const CASE_PATH = "/case/case-081-cr-0107-patanjali";
 
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <NewsletterSignupModal />
     </MemoryRouter>,
+  );
+}
+
+/** Buttons that navigate between an eligible and an ineligible route in-app. */
+function Nav() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate("/about")}>
+        to-ineligible
+      </button>
+      <button type="button" onClick={() => navigate("/updates")}>
+        to-eligible
+      </button>
+    </>
   );
 }
 
@@ -54,7 +70,7 @@ describe("NewsletterSignupModal trigger", () => {
   });
 
   it("stays closed until the dwell elapses, then opens on an eligible route", () => {
-    renderAt("/case/some-case");
+    renderAt(CASE_PATH);
     expect(screen.queryByRole("dialog")).toBeNull();
     act(() => vi.advanceTimersByTime(DWELL_MS));
     expect(screen.queryByRole("dialog")).not.toBeNull();
@@ -74,5 +90,23 @@ describe("NewsletterSignupModal trigger", () => {
     renderAt("/");
     act(() => vi.advanceTimersByTime(DWELL_MS));
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens on return to an eligible route when the dwell fired on an ineligible one", () => {
+    render(
+      <MemoryRouter initialEntries={[CASE_PATH]}>
+        <Nav />
+        <NewsletterSignupModal />
+      </MemoryRouter>,
+    );
+    // Leave for an ineligible page before the dwell completes...
+    act(() => vi.advanceTimersByTime(DWELL_MS / 2));
+    fireEvent.click(screen.getByText("to-ineligible"));
+    // ...the dwell fires while ineligible, so it stays closed.
+    act(() => vi.advanceTimersByTime(DWELL_MS));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    // Returning to an eligible page opens it immediately (no second dwell).
+    fireEvent.click(screen.getByText("to-eligible"));
+    expect(screen.queryByRole("dialog")).not.toBeNull();
   });
 });

--- a/src/components/home/newsletter-signup-modal.tsx
+++ b/src/components/home/newsletter-signup-modal.tsx
@@ -49,16 +49,25 @@ export function NewsletterSignupModal() {
   const eligibleRef = useRef(false);
   eligibleRef.current = isEligiblePath(pathname);
   const armedRef = useRef(false);
+  const firedRef = useRef(false);
   const timerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (armedRef.current) return;
     if (getNewsletterPromptState() !== null) return;
+    // Dwell already elapsed on an earlier eligible view: open as soon as the
+    // visitor is back on an eligible page, rather than restarting the timer.
+    // (Covers firing while momentarily on an ineligible route.)
+    if (firedRef.current) {
+      if (eligibleRef.current) setOpen(true);
+      return;
+    }
+    if (armedRef.current) return;
     if (!eligibleRef.current) return;
-    // First eligible view: start the dwell. No cleanup here on purpose — we
-    // don't want a route change to clear the timer and reset the dwell.
+    // First eligible view: start the dwell once. No cleanup here on purpose — a
+    // route change must not clear the timer and reset the accumulated dwell.
     armedRef.current = true;
     timerRef.current = window.setTimeout(() => {
+      firedRef.current = true;
       if (getNewsletterPromptState() === null && eligibleRef.current) setOpen(true);
     }, OPEN_DELAY_MS);
   }, [pathname]);

--- a/src/components/home/newsletter-signup-modal.tsx
+++ b/src/components/home/newsletter-signup-modal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -11,24 +12,64 @@ import {
 import { NewsletterForm } from "@/components/home/newsletter-form";
 import { getNewsletterPromptState, setNewsletterPromptState } from "@/lib/newsletter";
 
-/** Delay before the prompt appears, so it doesn't interrupt the first paint. */
-const OPEN_DELAY_MS = 5000;
+/**
+ * Dwell before the prompt appears — long enough that it reads as a considered
+ * ask to an engaged reader rather than an immediate interruption on first paint.
+ */
+const OPEN_DELAY_MS = 25000;
 
 /**
- * Newsletter signup prompt shown once per browser when a visitor lands on the
- * site. Dismissing it (or subscribing anywhere) keeps it from reappearing.
+ * Routes the prompt may appear on: the home page and the content pages an
+ * engaged reader is most likely to land on from social/search — case pages and
+ * the updates feed. Other routes (about, privacy, admin, …) never arm it.
+ */
+function isEligiblePath(path: string): boolean {
+  return (
+    path === "/" ||
+    path === "/cases" ||
+    path.startsWith("/case/") ||
+    path === "/updates" ||
+    path.startsWith("/updates/")
+  );
+}
+
+/**
+ * Newsletter signup prompt. Arms a single dwell timer the first time a visitor
+ * is on an eligible page; the timer persists across in-app navigation (so the
+ * dwell accumulates rather than resetting on every route change). Dismissing it
+ * suppresses it for 30 days; subscribing anywhere suppresses it permanently.
  */
 export function NewsletterSignupModal() {
   const { t } = useTranslation();
+  const { pathname } = useLocation();
   const [open, setOpen] = useState(false);
 
+  // Mirror the current route in a ref so the timer callback can re-check
+  // eligibility at fire time without being re-created on every navigation.
+  const eligibleRef = useRef(false);
+  eligibleRef.current = isEligiblePath(pathname);
+  const armedRef = useRef(false);
+  const timerRef = useRef<number | null>(null);
+
   useEffect(() => {
+    if (armedRef.current) return;
     if (getNewsletterPromptState() !== null) return;
-    const timer = window.setTimeout(() => {
-      if (getNewsletterPromptState() === null) setOpen(true);
+    if (!eligibleRef.current) return;
+    // First eligible view: start the dwell. No cleanup here on purpose — we
+    // don't want a route change to clear the timer and reset the dwell.
+    armedRef.current = true;
+    timerRef.current = window.setTimeout(() => {
+      if (getNewsletterPromptState() === null && eligibleRef.current) setOpen(true);
     }, OPEN_DELAY_MS);
-    return () => window.clearTimeout(timer);
-  }, []);
+  }, [pathname]);
+
+  // Clear the timer only when the modal actually unmounts.
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    [],
+  );
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);

--- a/src/lib/newsletter.test.ts
+++ b/src/lib/newsletter.test.ts
@@ -54,4 +54,9 @@ describe("newsletter prompt state", () => {
     window.localStorage.setItem(STORAGE_KEY, "{not json");
     expect(getNewsletterPromptState()).toBeNull();
   });
+
+  it("treats non-object JSON (e.g. 'null') as absent, without throwing", () => {
+    window.localStorage.setItem(STORAGE_KEY, "null");
+    expect(getNewsletterPromptState()).toBeNull();
+  });
 });

--- a/src/lib/newsletter.test.ts
+++ b/src/lib/newsletter.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DISMISS_TTL_MS,
+  getNewsletterPromptState,
+  setNewsletterPromptState,
+} from "./newsletter";
+
+const STORAGE_KEY = "jawafdehi_newsletter_prompt";
+
+describe("newsletter prompt state", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+    // Fixed clock so dismissal-age math is deterministic.
+    vi.setSystemTime(new Date("2026-07-11T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getNewsletterPromptState()).toBeNull();
+  });
+
+  it("suppresses permanently after subscribing", () => {
+    setNewsletterPromptState("subscribed");
+    vi.setSystemTime(new Date("2027-01-01T00:00:00Z")); // ~6 months later
+    expect(getNewsletterPromptState()).toBe("subscribed");
+  });
+
+  it("suppresses a dismissal within the 30-day window", () => {
+    setNewsletterPromptState("dismissed");
+    vi.advanceTimersByTime(DISMISS_TTL_MS - 1000); // just inside the window
+    expect(getNewsletterPromptState()).toBe("dismissed");
+  });
+
+  it("re-asks once a dismissal ages past 30 days", () => {
+    setNewsletterPromptState("dismissed");
+    vi.advanceTimersByTime(DISMISS_TTL_MS + 1000); // just past the window
+    expect(getNewsletterPromptState()).toBeNull();
+  });
+
+  it("honours legacy plain-string values as a no-expiry suppression", () => {
+    window.localStorage.setItem(STORAGE_KEY, "dismissed");
+    expect(getNewsletterPromptState()).toBe("dismissed");
+    window.localStorage.setItem(STORAGE_KEY, "subscribed");
+    expect(getNewsletterPromptState()).toBe("subscribed");
+  });
+
+  it("treats corrupt storage as absent (re-askable)", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(getNewsletterPromptState()).toBeNull();
+  });
+});

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -37,11 +37,13 @@ export function getNewsletterPromptState(): NewsletterPromptValue | null {
     // Legacy plain-string values (pre-TTL builds): honour as a no-expiry suppression.
     if (raw === "subscribed" || raw === "dismissed") return raw;
 
-    const parsed = JSON.parse(raw) as Partial<StoredPrompt>;
-    if (parsed.state === "subscribed") return "subscribed";
-    if (parsed.state === "dismissed") {
-      const fresh =
-        typeof parsed.ts === "number" && Date.now() - parsed.ts < DISMISS_TTL_MS;
+    const parsed: unknown = JSON.parse(raw);
+    // Guard against non-object JSON (e.g. "null", a number) before reading fields.
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { state, ts } = parsed as Partial<StoredPrompt>;
+    if (state === "subscribed") return "subscribed";
+    if (state === "dismissed") {
+      const fresh = typeof ts === "number" && Date.now() - ts < DISMISS_TTL_MS;
       return fresh ? "dismissed" : null;
     }
     return null;

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,19 +1,50 @@
 /**
  * Newsletter signup prompt state.
  *
- * Remembers whether the visitor has dismissed the entry newsletter modal or
- * already subscribed, so the prompt is shown at most once per browser.
+ * Remembers whether the visitor dismissed the entry newsletter modal or already
+ * subscribed, so the prompt isn't shown too often:
+ *   - "subscribed" suppresses the prompt permanently (never re-ask a subscriber).
+ *   - "dismissed" suppresses it for {@link DISMISS_TTL_MS} (30 days), after which
+ *     the visitor becomes eligible again — a single accidental dismissal no
+ *     longer loses them forever.
+ *
+ * The value is stored as JSON with the timestamp it was written. Legacy plain
+ * string values ("dismissed" / "subscribed") written by earlier builds are still
+ * honoured (treated as a suppression with no expiry) so nobody who already acted
+ * gets re-prompted on their next visit.
  */
 
 const STORAGE_KEY = "jawafdehi_newsletter_prompt";
 
+/** How long a dismissal suppresses the prompt before the visitor is eligible again. */
+export const DISMISS_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
 export type NewsletterPromptValue = "dismissed" | "subscribed";
 
+type StoredPrompt = { state: NewsletterPromptValue; ts: number };
+
+/**
+ * The *effective* prompt state. Returns null when the visitor may be prompted:
+ * either nothing is stored, or a dismissal has aged past its TTL. A subscription
+ * never expires.
+ */
 export function getNewsletterPromptState(): NewsletterPromptValue | null {
   if (typeof window === "undefined") return null;
   try {
-    const v = window.localStorage.getItem(STORAGE_KEY);
-    return v === "dismissed" || v === "subscribed" ? v : null;
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    // Legacy plain-string values (pre-TTL builds): honour as a no-expiry suppression.
+    if (raw === "subscribed" || raw === "dismissed") return raw;
+
+    const parsed = JSON.parse(raw) as Partial<StoredPrompt>;
+    if (parsed.state === "subscribed") return "subscribed";
+    if (parsed.state === "dismissed") {
+      const fresh =
+        typeof parsed.ts === "number" && Date.now() - parsed.ts < DISMISS_TTL_MS;
+      return fresh ? "dismissed" : null;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -22,7 +53,8 @@ export function getNewsletterPromptState(): NewsletterPromptValue | null {
 export function setNewsletterPromptState(value: NewsletterPromptValue): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, value);
+    const payload: StoredPrompt = { state: value, ts: Date.now() };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   } catch {
     // ignore (private mode / storage disabled)
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import { CaseCard } from "@/components/CaseCard";
 import { Hero } from "@/components/home/hero";
 import { Faq } from "@/components/home/faq";
-import { NewsletterSignupModal } from "@/components/home/newsletter-signup-modal";
 import { ReportCaseCta } from "@/components/home/report-case-cta";
 import { ShareOurVision } from "@/components/home/share-our-vision";
 import { SupportingPartner } from "@/components/home/supportingpartner";
@@ -244,8 +243,6 @@ const Index = () => {
         <ShareOurVision />
         <SupportingPartner />
       </div>
-
-      <NewsletterSignupModal />
     </div>
   );
 };


### PR DESCRIPTION
## What & why

Reworks **when** the entry newsletter popup appears. Today it's: **home page only, 5s after load, once per browser forever**. That misses the funnel (social/search readers deep-link to case pages, where the popup never mounts), fires before anyone has read anything, and loses a lead permanently on a single accidental dismiss.

New behavior (per product decision):

| Lever | Before | After |
|---|---|---|
| **Timing** | 5s fixed | **~25s dwell** — reads as a considered ask, not a first-paint interruption |
| **Scope** | Home only | **Home + case pages (`/cases`, `/case/*`) + updates feed (`/updates`, `/updates/*`)** |
| **Frequency** | Once, forever | **Dismiss → suppressed 30 days**, then eligible again; **subscribe → permanent** |

## How

- **Mount moved to `AppLayout`** (was `Index`), so the modal spans the public shell. It **self-gates** via `useLocation` — only home/case/updates arm it; admin/embed/about/privacy/etc. never do.
- **Dwell timer arms once** on the first eligible view and **persists across in-app navigation** (a ref-held timeout, cleared only on unmount) so the 25s accumulates instead of resetting on every route hop. At fire it re-checks eligibility + un-prompted state.
- **30-day re-ask** in `lib/newsletter.ts`: storage is now `{ state, ts }`; `getNewsletterPromptState()` returns `null` once a *dismissal* ages past 30 days (a subscription never expires). **Legacy plain-string values** (`"dismissed"`/`"subscribed"`) from the current build are still honoured as a no-expiry suppression, so anyone who already acted isn't re-prompted.

## Tests

- `src/lib/newsletter.test.ts` — TTL expiry (inside/outside 30 days), subscribe permanence, legacy + corrupt values.
- `src/components/home/newsletter-signup-modal.test.tsx` — opens after the dwell on an eligible route, never on an ineligible one, stays closed while a recent dismissal is stored (minimal jsdom polyfills for the Radix Dialog).

Full suite green (**156 passed**), `tsc --noEmit` + `eslint` clean. No i18n/API changes — reuses the existing modal copy and the backend endpoint wired in JawafdehiAPI #310/#314.

## Note
Since the popup now also appears on case/updates pages, this is the piece that opens the **double-opt-in / consent** question on SendPulse list 719648 — worth confirming that behavior before the public funnel goes wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a newsletter signup prompt to eligible pages in the shared public shell (no longer tied to a single page).
  - The prompt appears after 25 seconds on eligible routes only.
  - Dismissed prompts stay hidden for 30 days; subscribed status remains suppressed permanently.
  - Existing newsletter preferences (including legacy saved values) are still respected.

- **Bug Fixes**
  - The dwell timer won’t reset unnecessarily during in-app navigation; returning after the dwell expires opens immediately.

- **Tests**
  - Added automated coverage for timing, route eligibility, dismissal persistence/TTL, and legacy preference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->