### PR TITLE
Authz v3: single content-staff role + is_admin-flag gating

### DIFF
--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -124,7 +124,10 @@ function Sidebar({
     <nav className="flex flex-col gap-5 p-4">
       {NAV.map((group) => {
         const visible = group.items.filter((it) => {
-          if (it.roles && !it.roles.some((r) => lower.includes(r.toLowerCase()))) return false;
+          // A superuser has an empty `roles` array in v3, so bypass the static
+          // `roles` allow-list for admins (else a role-gated item hides from them).
+          if (it.roles && !isAdmin && !it.roles.some((r) => lower.includes(r.toLowerCase())))
+            return false;
           if (it.canAccess && !it.canAccess(roles, isAdmin)) return false;
           return true;
         });

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -61,9 +61,9 @@ const NAV: NavGroup[] = [
     ],
   },
   {
-    // NES writes are gated on NES_Contributor / NES_Admin (+ superuser) by the
-    // backend (entities/permissions.py); platform readonly/caseworker/moderator
-    // are NOT accepted, so don't offer the (write) Entities section to them.
+    // v3: entity writes are gated on the single content-staff role (Caseworker,
+    // + superuser) by the backend (entities/permissions.py). ReadOnly is not
+    // accepted, so don't offer the (write) Entities section to it.
     headingKey: "admin.nav.entities",
     items: [
       {
@@ -75,8 +75,9 @@ const NAV: NavGroup[] = [
     ],
   },
   {
-    // Data Lake (court/material/firm) writes are gated on the NGM role set
-    // (courts/permissions.py HasNgmRole): Admin/Moderator/Caseworker + NGM tiers.
+    // v3: court-case / material / firm writes are gated on the single
+    // content-staff role (Caseworker, + superuser) by the backend
+    // (courts/permissions.py HasNgmRole). The old rate tiers are retired.
     headingKey: "admin.nav.dataLake",
     items: [
       { to: "/admin/datalake/courtcases", labelKey: "admin.nav.courtCases", icon: Gavel, canAccess: hasNgmWriteAccess },

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -12,6 +12,7 @@ import {
   hasAdminAccess,
   hasNesWriteAccess,
   hasNgmWriteAccess,
+  isModerator,
 } from "@/lib/roles";
 import { Button } from "@/components/ui/button";
 import { LanguageToggle } from "@/components/LanguageToggle";
@@ -45,7 +46,7 @@ interface NavItem {
   icon: typeof LayoutDashboard;
   end?: boolean;
   roles?: string[];
-  canAccess?: (roles: string[]) => boolean;
+  canAccess?: (roles: string[], isAdmin: boolean) => boolean;
 }
 interface NavGroup {
   headingKey: string;
@@ -97,14 +98,25 @@ const NAV: NavGroup[] = [
         to: "/admin/moderation",
         labelKey: "admin.nav.moderation",
         icon: ShieldCheck,
-        roles: ["admin", "moderator"],
+        // v3: privileged casework action → the single content-staff role
+        // (or superuser). Use the shared helper so it stays in sync with
+        // lib/roles and admits a group-less superuser via the is_admin flag.
+        canAccess: isModerator,
       },
     ],
   },
 ];
 
 // `onNavigate` lets the mobile drawer close itself when a link is followed.
-function Sidebar({ roles, onNavigate }: { roles: string[]; onNavigate?: () => void }) {
+function Sidebar({
+  roles,
+  isAdmin,
+  onNavigate,
+}: {
+  roles: string[];
+  isAdmin: boolean;
+  onNavigate?: () => void;
+}) {
   const { t } = useTranslation();
   const lower = roles.map((r) => r.toLowerCase());
   return (
@@ -112,7 +124,7 @@ function Sidebar({ roles, onNavigate }: { roles: string[]; onNavigate?: () => vo
       {NAV.map((group) => {
         const visible = group.items.filter((it) => {
           if (it.roles && !it.roles.some((r) => lower.includes(r.toLowerCase()))) return false;
-          if (it.canAccess && !it.canAccess(roles)) return false;
+          if (it.canAccess && !it.canAccess(roles, isAdmin)) return false;
           return true;
         });
         if (!visible.length) return null;
@@ -152,7 +164,7 @@ function Sidebar({ roles, onNavigate }: { roles: string[]; onNavigate?: () => vo
 // Shell wrapper. Used directly by AdminLayout (route element) — the page body
 // renders through <Outlet/>.
 function AdminShell({ children }: { children: ReactNode }) {
-  const { user, loading, logout } = useCaseworkAuth();
+  const { user, loading, logout, isAdmin } = useCaseworkAuth();
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
@@ -178,9 +190,10 @@ function AdminShell({ children }: { children: ReactNode }) {
     );
   }
 
-  // Role gate.
+  // Role gate. Admins are superusers with NO group in v3, so admit them via the
+  // is_admin flag (their `roles` list is empty).
   const roles = user.roles ?? [];
-  if (!hasAdminAccess(roles)) {
+  if (!hasAdminAccess(roles, isAdmin)) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
         <div className="w-full max-w-md space-y-4 rounded-2xl bg-white p-8 text-center shadow-xl">
@@ -258,13 +271,13 @@ function AdminShell({ children }: { children: ReactNode }) {
               </span>
             ) : null}
           </SheetTitle>
-          <Sidebar roles={roles} onNavigate={() => setNavOpen(false)} />
+          <Sidebar roles={roles} isAdmin={isAdmin} onNavigate={() => setNavOpen(false)} />
         </SheetContent>
       </Sheet>
 
       <div className="mx-auto flex max-w-7xl">
         <aside className="hidden w-64 shrink-0 border-r bg-white md:block">
-          <Sidebar roles={roles} />
+          <Sidebar roles={roles} isAdmin={isAdmin} />
         </aside>
         <main className="min-w-0 flex-1 px-4 py-6">{children}</main>
       </div>

--- a/src/components/admin/RequireWriteAccess.tsx
+++ b/src/components/admin/RequireWriteAccess.tsx
@@ -17,14 +17,15 @@ export default function RequireWriteAccess({
   children,
   message = "You don't have permission to edit this section. Ask an admin to grant you access.",
 }: {
-  // Predicate over the user's roles (e.g. hasNesWriteAccess from lib/roles).
-  can: (roles: string[]) => boolean;
+  // Predicate over the user's roles + is_admin flag (e.g. hasNesWriteAccess from
+  // lib/roles). The is_admin flag admits a group-less superuser (empty roles).
+  can: (roles: string[], isAdmin: boolean) => boolean;
   children: ReactNode;
   message?: string;
 }) {
-  const { user } = useCaseworkAuth();
+  const { user, isAdmin } = useCaseworkAuth();
   const roles = user?.roles ?? [];
-  if (!can(roles)) {
+  if (!can(roles, isAdmin)) {
     return (
       <div className="max-w-2xl">
         <FormError message={message} />

--- a/src/context/CaseworkAuthContext.tsx
+++ b/src/context/CaseworkAuthContext.tsx
@@ -49,6 +49,9 @@ function toCaseworkUser(
     "";
   return { username, roles, is_admin: roles.includes("admin") };
 }
+// NOTE: dev-login / me responses carry an explicit `is_admin` bool (a superuser
+// has an empty `roles` list in v3), so the gates below read `user.is_admin`
+// alongside `user.roles` — never infer admin-ness from `roles` alone.
 
 export function CaseworkAuthProvider({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
@@ -97,8 +100,8 @@ export function CaseworkAuthProvider({ children }: { children: React.ReactNode }
         error: auth.error?.message ?? null,
         login,
         logout,
-        isAdmin: rolesIsAdmin(user?.roles),
-        isModerator: rolesIsModerator(user?.roles),
+        isAdmin: rolesIsAdmin(user?.roles, user?.is_admin ?? false),
+        isModerator: rolesIsModerator(user?.roles, user?.is_admin ?? false),
         devAuthEnabled: DEV_AUTH_ENABLED,
         devLogin,
       }}

--- a/src/context/CaseworkAuthContext.tsx
+++ b/src/context/CaseworkAuthContext.tsx
@@ -47,7 +47,16 @@ function toCaseworkUser(
     (profile.preferred_username as string) ||
     (profile.name as string) ||
     "";
-  return { username, roles, is_admin: roles.includes("admin") };
+  // v3: prefer an explicit is_admin/is_superuser claim if the IdP emits one;
+  // otherwise fall back to the `admin` role key (which the Zitadel token DOES
+  // carry for a superuser — it's what drives is_superuser server-side).
+  const is_admin =
+    typeof profile.is_admin === "boolean"
+      ? profile.is_admin
+      : typeof profile.is_superuser === "boolean"
+        ? profile.is_superuser
+        : roles.includes("admin");
+  return { username, roles, is_admin };
 }
 // NOTE: dev-login / me responses carry an explicit `is_admin` bool (a superuser
 // has an empty `roles` list in v3), so the gates below read `user.is_admin`

--- a/src/lib/roles.test.ts
+++ b/src/lib/roles.test.ts
@@ -7,70 +7,75 @@ import {
   hasNgmWriteAccess,
 } from "./roles";
 
+// v3 authz model: one content-staff role reachable under three live Zitadel
+// keys — "moderator", "contributor", "caseworker" (dev-login sends the Django
+// group name "Caseworker"). Admin is a superuser with NO group, conveyed via the
+// `is_admin` bool (second arg), so a superuser has an EMPTY roles array.
+
 describe("roles helpers", () => {
-  it("hasAdminAccess: true for any admin-panel role, case-insensitive", () => {
+  it("hasAdminAccess: true for any content-staff or readonly role, case-insensitive", () => {
     expect(hasAdminAccess(["Caseworker"])).toBe(true);
-    expect(hasAdminAccess(["READONLY"])).toBe(true);
-    expect(hasAdminAccess(["admin"])).toBe(true);
     expect(hasAdminAccess(["moderator"])).toBe(true);
+    expect(hasAdminAccess(["contributor"])).toBe(true);
+    expect(hasAdminAccess(["READONLY"])).toBe(true);
   });
 
-  it("hasAdminAccess: false for the retired 'contributor' role, unknowns, or none", () => {
-    // "contributor" was renamed to "caseworker" platform-wide; no backend path
-    // emits it any more, so it must NOT admit anyone.
-    expect(hasAdminAccess(["contributor"])).toBe(false);
+  it("hasAdminAccess: superuser admitted via the is_admin flag (empty roles)", () => {
+    expect(hasAdminAccess([], true)).toBe(true);
+    expect(hasAdminAccess(undefined, true)).toBe(true);
+  });
+
+  it("hasAdminAccess: false for unknowns or no role/flag", () => {
     expect(hasAdminAccess(["viewer"])).toBe(false);
     expect(hasAdminAccess([])).toBe(false);
     expect(hasAdminAccess(undefined)).toBe(false);
   });
 
-  it("isModerator: only admin or moderator", () => {
-    expect(isModerator(["Admin"])).toBe(true);
-    expect(isModerator(["MODERATOR"])).toBe(true);
-    expect(isModerator(["caseworker"])).toBe(false);
+  it("isModerator: any content-staff role (moderator/contributor/caseworker) or superuser", () => {
+    expect(isModerator(["moderator"])).toBe(true);
+    expect(isModerator(["contributor"])).toBe(true);
+    expect(isModerator(["caseworker"])).toBe(true);
+    expect(isModerator(["Caseworker"])).toBe(true);
+    expect(isModerator([], true)).toBe(true); // superuser via flag
     expect(isModerator(["readonly"])).toBe(false);
     expect(isModerator(undefined)).toBe(false);
   });
 
-  it("isAdmin: only admin", () => {
+  it("isAdmin: only the superuser flag (v3: admin is not a role in `roles`)", () => {
+    expect(isAdmin([], true)).toBe(true);
+    expect(isAdmin(undefined, true)).toBe(true);
+    // Legacy "admin" role string still recognised for back-compat with any
+    // caller/payload that carries it, but production superusers use the flag.
     expect(isAdmin(["admin"])).toBe(true);
-    expect(isAdmin(["ADMIN", "moderator"])).toBe(true);
     expect(isAdmin(["moderator"])).toBe(false);
+    expect(isAdmin(["caseworker"])).toBe(false);
     expect(isAdmin(undefined)).toBe(false);
   });
 
-  it("hasNesWriteAccess: only NES roles (both OIDC + group spellings) or admin", () => {
-    // OIDC claim keys
-    expect(hasNesWriteAccess(["nes_contributor"])).toBe(true);
-    expect(hasNesWriteAccess(["nes_admin"])).toBe(true);
-    // Django group names (from dev-login / me_view), case-insensitive
-    expect(hasNesWriteAccess(["NES_Contributor"])).toBe(true);
-    expect(hasNesWriteAccess(["NES_Admin"])).toBe(true);
-    // admin -> Django superuser, which bypasses the NES permission classes
-    expect(hasNesWriteAccess(["admin"])).toBe(true);
-    // Platform roles WITHOUT an NES group are backend-403'd — must be hidden.
-    expect(hasNesWriteAccess(["caseworker"])).toBe(false);
-    expect(hasNesWriteAccess(["moderator"])).toBe(false);
+  it("hasNesWriteAccess: the content-staff role or superuser", () => {
+    expect(hasNesWriteAccess(["caseworker"])).toBe(true);
+    expect(hasNesWriteAccess(["moderator"])).toBe(true);
+    expect(hasNesWriteAccess(["contributor"])).toBe(true);
+    expect(hasNesWriteAccess(["Caseworker"])).toBe(true);
+    expect(hasNesWriteAccess([], true)).toBe(true); // superuser via flag
+    // Retired NES-specific keys no longer grant access on their own.
+    expect(hasNesWriteAccess(["nes_contributor"])).toBe(false);
     expect(hasNesWriteAccess(["readonly"])).toBe(false);
     expect(hasNesWriteAccess(["ReadOnly"])).toBe(false);
     expect(hasNesWriteAccess([])).toBe(false);
     expect(hasNesWriteAccess(undefined)).toBe(false);
   });
 
-  it("hasNgmWriteAccess: NGM role set (Admin/Moderator/Caseworker + tiers)", () => {
-    expect(hasNgmWriteAccess(["admin"])).toBe(true);
+  it("hasNgmWriteAccess: the content-staff role or superuser", () => {
     expect(hasNgmWriteAccess(["moderator"])).toBe(true);
+    expect(hasNgmWriteAccess(["contributor"])).toBe(true);
     expect(hasNgmWriteAccess(["caseworker"])).toBe(true);
     expect(hasNgmWriteAccess(["Caseworker"])).toBe(true);
-    // NGM tier roles — OIDC claim keys and Django group names.
-    expect(hasNgmWriteAccess(["ngm_silver"])).toBe(true);
-    expect(hasNgmWriteAccess(["ngm_gold"])).toBe(true);
-    expect(hasNgmWriteAccess(["ngm_platinum"])).toBe(true);
-    // readonly is NOT in the NGM set -> hidden.
+    expect(hasNgmWriteAccess([], true)).toBe(true); // superuser via flag
+    // Retired NGM rate tiers no longer grant access.
+    expect(hasNgmWriteAccess(["ngm_gold"])).toBe(false);
     expect(hasNgmWriteAccess(["readonly"])).toBe(false);
     expect(hasNgmWriteAccess(["ReadOnly"])).toBe(false);
-    // NES-only roles do NOT grant NGM writes.
-    expect(hasNgmWriteAccess(["nes_contributor"])).toBe(false);
     expect(hasNgmWriteAccess([])).toBe(false);
     expect(hasNgmWriteAccess(undefined)).toBe(false);
   });

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -3,67 +3,50 @@
 // role-less user isn't dropped into a panel that 403s on every call.
 //
 // SOURCE OF TRUTH for role names: the backend's role->group mapping in
-// jawafdehi-api/jawafdehi_shared/auth/oidc.py (DEFAULT_ROLE_TO_GROUP). The FE can
-// receive roles in EITHER spelling depending on the auth path:
-//   - OIDC (prod): profile.roles are the Zitadel *role-claim keys*, lowercase —
-//     e.g. "admin", "moderator", "caseworker", "readonly", "nes_contributor",
-//     "nes_admin", "ngm_silver", "ngm_gold", "ngm_platinum".
-//     (see src/context/CaseworkAuthContext.tsx toCaseworkUser)
-//   - dev-login / /api/casework/auth/me/: the backend returns the *Django Group
-//     names* (user.groups) — e.g. "Admin", "Moderator", "Caseworker", "ReadOnly",
-//     "NES_Contributor", "NES_Admin", "NGM_SilverTier", "NGM_GoldTier",
-//     "NGM_PlatinumTier". (see review/views.py _user_roles_payload)
-// The two differ by MORE than case (e.g. "nes_contributor" vs "NES_Contributor",
-// "ngm_gold" vs "NGM_GoldTier"), so each allow-list below carries BOTH spellings
-// and all matching is case-insensitive.
+// jawafdehi-api/jawafdehi_shared/auth/oidc.py (DEFAULT_ROLE_TO_GROUP). v3 authz
+// model:
+//   - admin        -> Django superuser (NO group). Conveyed to the FE as the
+//                     `is_admin` bool on the payload, NOT as a role in `roles`.
+//     Helpers that admit admins therefore take an `isAdminFlag` argument and OR
+//     it in (a superuser has an EMPTY `roles` list).
+//   - moderator / contributor / caseworker -> the single `Caseworker`
+//     content-staff group. All three Zitadel keys are live and reach the FE, so
+//     every content-staff allow-list below carries ALL of them.
+//   - readonly     -> ReadOnly.
+//   - job_poller   -> JobPoller (machine role; not a UI principal).
+//
+// The FE can receive roles in EITHER spelling: OIDC (prod) sends lowercase
+// role-claim keys (e.g. "moderator", "contributor", "readonly"); dev-login /
+// me sends Django Group names (e.g. "Caseworker", "ReadOnly"). Matching is
+// case-insensitive, so a group name like "Caseworker" folds to "caseworker".
 
-// Roles that may enter the admin panel at all (the panel-level gate). Mirrors the
-// platform role->group rows in DEFAULT_ROLE_TO_GROUP:
-//   admin/Admin, moderator/Moderator, caseworker/Caseworker, readonly/ReadOnly.
-// ("contributor" was renamed to "caseworker" platform-wide — no backend path
-// emits a "contributor" claim any more, so it is intentionally absent here.)
-export const ADMIN_ROLES = [
-  "admin",
+// The content-staff role keys/group-names (the single Caseworker role, however
+// it is spelled across the OIDC-key and Django-group surfaces).
+const CONTENT_STAFF_ROLES = [
   "moderator",
+  "contributor",
   "caseworker",
-  "readonly",
 ] as const;
+
+// Roles that may enter the admin panel at all (the panel-level gate): the
+// content-staff role plus the org-wide read role. (Admin is a superuser and is
+// admitted via the `is_admin` flag, not a role — see hasAdminAccess.)
+export const ADMIN_ROLES = [...CONTENT_STAFF_ROLES, "readonly"] as const;
 
 // Roles allowed to perform privileged casework actions (state transitions, the
-// moderation queue, regrade-all).
-export const MODERATOR_ROLES = ["admin", "moderator"] as const;
+// moderation queue, regrade-all). v3: the single content-staff role. (Admins
+// are admitted via the `is_admin` flag.)
+export const MODERATOR_ROLES = CONTENT_STAFF_ROLES;
 
-// Roles the backend accepts for NES entity WRITES (create / edit / add-name /
-// bulk-ingest / reindex). Backend gate: entities/permissions.py
-// HasNesContributorRole / HasNesAdminRole — groups NES_Contributor / NES_Admin
-// ONLY (superuser bypasses). Platform admin/moderator/caseworker are DELIBERATELY
-// excluded from NES writes per that module's DECISION note, so the ONLY platform
-// role that also clears this gate is "admin" (which the backend maps to Django
-// superuser via the OIDC authenticator's admin-role -> is_superuser sync).
-export const NES_WRITE_ROLES = [
-  "nes_contributor", // OIDC claim key / NES_Contributor group (case-insensitive)
-  "nes_admin", // OIDC claim key / NES_Admin group
-  "admin", // -> Django superuser, which bypasses the NES permission classes
-] as const;
+// Roles the backend accepts for entity WRITES (create / edit / reindex). v3:
+// entities/permissions.py accepts the single Caseworker content-staff role
+// (+ superuser). The old NES_Contributor / NES_Admin namespace is retired.
+export const NES_WRITE_ROLES = CONTENT_STAFF_ROLES;
 
 // Roles the backend accepts for NGM / "Data Lake" WRITES (court cases, courts,
-// firms, materials). Backend gate: courts/permissions.py HasNgmRole — groups
-// Admin, Moderator, Caseworker, and the three NGM rate-limit tiers (superuser
-// bypasses). The tier role-claim keys are ngm_silver/ngm_gold/ngm_platinum
-// (Groups NGM_SilverTier/NGM_GoldTier/NGM_PlatinumTier).
-export const NGM_WRITE_ROLES = [
-  "admin",
-  "moderator",
-  "caseworker",
-  // NGM tier roles. Matching is exact-element (case-insensitive), not substring,
-  // so BOTH the OIDC claim keys AND the Django group names are listed.
-  "ngm_silver", // OIDC claim key
-  "ngm_gold",
-  "ngm_platinum",
-  "ngm_silvertier", // Django group NGM_SilverTier (from dev-login / me_view)
-  "ngm_goldtier",
-  "ngm_platinumtier",
-] as const;
+// firms, materials). v3: courts/permissions.py HasNgmRole accepts the single
+// Caseworker content-staff role (+ superuser); the NGM rate tiers are retired.
+export const NGM_WRITE_ROLES = CONTENT_STAFF_ROLES;
 
 function normalize(roles: readonly string[] | undefined): string[] {
   return (roles ?? []).map((r) => r.toLowerCase());
@@ -74,30 +57,47 @@ function hasAny(roles: readonly string[] | undefined, allowed: readonly string[]
   return allowed.some((r) => lower.has(r.toLowerCase()));
 }
 
-// May the user open the admin panel at all?
-export function hasAdminAccess(roles: readonly string[] | undefined): boolean {
-  return hasAny(roles, ADMIN_ROLES);
+// May the user open the admin panel at all? Admits content-staff/readonly by
+// role, OR a superuser via the `is_admin` flag (superusers have no group).
+export function hasAdminAccess(
+  roles: readonly string[] | undefined,
+  isAdminFlag = false,
+): boolean {
+  return isAdminFlag || hasAny(roles, ADMIN_ROLES);
 }
 
-// Does the user hold admin OR moderator (privileged-action gate)?
-export function isModerator(roles: readonly string[] | undefined): boolean {
-  return hasAny(roles, MODERATOR_ROLES);
+// May the user perform privileged casework actions? Content-staff by role, OR a
+// superuser via the `is_admin` flag.
+export function isModerator(
+  roles: readonly string[] | undefined,
+  isAdminFlag = false,
+): boolean {
+  return isAdminFlag || hasAny(roles, MODERATOR_ROLES);
 }
 
-// Is the user specifically an admin?
-export function isAdmin(roles: readonly string[] | undefined): boolean {
-  return normalize(roles).includes("admin");
+// Is the user an admin (superuser)? v3: admin is NOT a role in `roles` — it is
+// the `is_admin` payload bool. Retained here as the single admin signal.
+export function isAdmin(
+  roles: readonly string[] | undefined,
+  isAdminFlag = false,
+): boolean {
+  return isAdminFlag || normalize(roles).includes("admin");
 }
 
-// May the user WRITE NES entities (create/edit/reindex)? Gates the Entities
-// section. The backend (entities/permissions.py) accepts only NES_Contributor /
-// NES_Admin (+ superuser); readonly/caseworker/moderator do NOT clear it.
-export function hasNesWriteAccess(roles: readonly string[] | undefined): boolean {
-  return hasAny(roles, NES_WRITE_ROLES);
+// May the user WRITE entities (create/edit/reindex)? Gates the Entities section.
+// Backend gate: entities/permissions.py (Caseworker + superuser).
+export function hasNesWriteAccess(
+  roles: readonly string[] | undefined,
+  isAdminFlag = false,
+): boolean {
+  return isAdminFlag || hasAny(roles, NES_WRITE_ROLES);
 }
 
 // May the user WRITE NGM / Data Lake records (courts, cases, firms, materials)?
 // Gates the Data Lake section. Backend gate: courts/permissions.py HasNgmRole.
-export function hasNgmWriteAccess(roles: readonly string[] | undefined): boolean {
-  return hasAny(roles, NGM_WRITE_ROLES);
+export function hasNgmWriteAccess(
+  roles: readonly string[] | undefined,
+  isAdminFlag = false,
+): boolean {
+  return isAdminFlag || hasAny(roles, NGM_WRITE_ROLES);
 }

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -40,7 +40,7 @@ interface Section {
   // i18n keys under `admin.dashboard.sections.*`, resolved at render.
   titleKey: string;
   bodyKey: string;
-  canAccess?: (roles: string[]) => boolean;
+  canAccess?: (roles: string[], isAdmin: boolean) => boolean;
 }
 
 const SECTIONS: Section[] = [
@@ -99,7 +99,7 @@ interface Metric {
   labelKey: string;
   subKey: string;
   // Narrow the metric to a subset of roles (matches the section predicates).
-  canAccess?: (roles: string[]) => boolean;
+  canAccess?: (roles: string[], isAdmin: boolean) => boolean;
   // Headline metric — rendered with emphasis (accent border/title).
   headline?: boolean;
 }
@@ -166,10 +166,14 @@ function MetricValue({ value, loadingLabel }: { value: Count; loadingLabel: stri
 
 export default function AdminDashboard() {
   const { t } = useTranslation();
-  const { user } = useCaseworkAuth();
+  const { user, isAdmin } = useCaseworkAuth();
   const roles = user?.roles ?? [];
-  const sections = SECTIONS.filter((s) => !s.canAccess || s.canAccess(roles));
-  const metrics = METRICS.filter((m) => !m.canAccess || m.canAccess(roles));
+  const sections = SECTIONS.filter(
+    (s) => !s.canAccess || s.canAccess(roles, isAdmin),
+  );
+  const metrics = METRICS.filter(
+    (m) => !m.canAccess || m.canAccess(roles, isAdmin),
+  );
 
   const [counts, setCounts] = useState<Metrics>({
     inReview: null,

--- a/tests/e2e-pw/auth.setup.ts
+++ b/tests/e2e-pw/auth.setup.ts
@@ -27,9 +27,11 @@ setup("authenticate as admin via dev-login", async ({ page }) => {
   // Use the REAL role snapshot the backend returned — do not fabricate it. If a
   // regression stopped dev-login granting admin, this fails HERE (loudly) instead
   // of the admin specs silently passing on a faked localStorage snapshot.
+  // v3 authz model: admin is a Django superuser with NO group, so `roles` is
+  // empty and admin-ness is carried by the `is_admin` bool.
   expect(
-    body.is_admin === true && (body.roles ?? []).includes("Admin"),
-    `dev-login did not return admin roles: ${JSON.stringify(body)}`,
+    body.is_admin === true,
+    `dev-login did not return an admin (is_admin) snapshot: ${JSON.stringify(body)}`,
   ).toBeTruthy();
 
   const devUser = {

--- a/tests/e2e/admin-dates-repro.mjs
+++ b/tests/e2e/admin-dates-repro.mjs
@@ -23,7 +23,7 @@ const check = (label, ok, detail = '') => {
 await page.addInitScript(() => {
   localStorage.setItem(
     'jawafdehi.devAuth.user',
-    JSON.stringify({ username: 'e2e-admin', roles: ['Admin'], is_admin: true }),
+    JSON.stringify({ username: 'e2e-admin', roles: [], is_admin: true }),
   );
   localStorage.setItem('jawafdehi.devAuth.csrf', 'e2e-csrf');
   // Pre-answer the cookie-consent banner: its fixed bottom bar otherwise

--- a/tests/e2e/mock-api.ts
+++ b/tests/e2e/mock-api.ts
@@ -74,7 +74,7 @@ Bun.serve({
     // --- DEV_AUTH session ---------------------------------------------------
     if (path === "/api/casework/auth/dev-login/" && method === "POST") {
       return json(
-        { username: "e2e-admin", roles: ["Admin"], is_admin: true, csrftoken: "e2e-csrf" },
+        { username: "e2e-admin", roles: [], is_admin: true, csrftoken: "e2e-csrf" },
         200,
         { "Set-Cookie": "sessionid=e2e-session; Path=/; SameSite=Lax" },
       );

--- a/tests/e2e/site-and-materials.mjs
+++ b/tests/e2e/site-and-materials.mjs
@@ -22,7 +22,7 @@ const check = (label, ok, detail = '') => {
 await page.addInitScript(() => {
   localStorage.setItem(
     'jawafdehi.devAuth.user',
-    JSON.stringify({ username: 'e2e-admin', roles: ['Admin'], is_admin: true }),
+    JSON.stringify({ username: 'e2e-admin', roles: [], is_admin: true }),
   );
   localStorage.setItem('jawafdehi.devAuth.csrf', 'e2e-csrf');
   localStorage.setItem('jawafdehi_analytics_consent', 'denied');


### PR DESCRIPTION
## Authz v3 — single content-staff role + `is_admin`-flag gating

Frontend half of the authz v3 refactor (pairs with the backend PR). The backend collapsed content roles to one `Caseworker` role (reachable via the live Zitadel keys `moderator`/`contributor`/`caseworker`) with the old Moderator's full powers; **admin is a group-less superuser conveyed via the `is_admin` payload bool** (a superuser has an empty `roles` array).

### Changes
- **`src/lib/roles.ts`**: content-staff allow-lists include `moderator`+`contributor`+`caseworker`; entity + court-data write gates = the content-staff role (dropped the retired `nes_*` / `ngm_tier` keys); `MODERATOR_ROLES` is the content-staff set. **All gate helpers take an `is_admin` flag** so a group-less superuser is admitted. Deleted the stale "contributor is retired" lore.
- **`CaseworkAuthContext`**: threads `user.is_admin` into `isAdmin`/`isModerator`.
- **`AdminLayout`**: panel gate + Sidebar + moderation nav honor `is_admin`; moderation nav uses the `isModerator` helper (was an inline `[admin,moderator]` literal). Fixed stale NAV comments describing the retired NES/NGM gates.
- **`RequireWriteAccess` + `Dashboard`**: thread `is_admin` into `canAccess` predicates.
- **`roles.test.ts`**: inverted the `contributor`/`caseworker` assertions; added `is_admin`-flag cases.

### Why the `is_admin` flag matters
Without it, once the backend stops injecting a synthetic `"Admin"` into the dev-login/`me` payload and the seed superuser has no group, dev-login returns `roles=[]` → a superuser would be **locked out of the admin panel**. Surfaced by the code review as a blocker; fixed here.

### Verification
tsc clean, 151 vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated admin access controls to recognize explicit administrator status separately from assigned roles.
  * Refined moderation, dashboard, navigation, and write-access permissions under the updated authorization rules.
  * Content-staff roles now consistently receive appropriate moderation and editing access.
  * Administrators can access protected areas even without assigned roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->