### PR TITLE
fix(materials): add press_release option to the datalake material-type form

### DIFF
--- a/src/lib/datalake-forms.ts
+++ b/src/lib/datalake-forms.ts
@@ -44,6 +44,7 @@ export const MATERIAL_TYPES = [
   { token: "court_order", label: "Court order / verdict" },
   { token: "manuscript", label: "Manuscript" },
   { token: "charge_sheet", label: "Charge sheet (अभियोगपत्र)" },
+  { token: "press_release", label: "Press release (प्रेस विज्ञप्ति)" },
   { token: "legal_corpus", label: "Legal corpus (acts/laws)" },
   { token: "official_report", label: "Official report" },
   { token: "document", label: "Generic document" },


### PR DESCRIPTION
Companion to **Jawafdehi/JawafdehiAPI#322**, which adds a first-class `press_release` material type (CIAA press releases were previously mis-typed as `charge_sheet`).

Adds the matching `press_release` option to the datalake create/edit material-type dropdown (`MATERIAL_TYPES`) so a caseworker can classify a press release correctly. The read-only `SourceTypeBadge` already humanises the token to "Press release" and picks a tone via the `PRESS` heuristic, so **no i18n change is needed** — the mislabelled badge disappears the moment the backend retypes the materials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)