### PR TITLE
feat(casework): autocomplete review submit + slim list + per-case review page

### DIFF
--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -31,6 +31,7 @@ import Moderation from "./pages/admin/casework/Moderation";
 import CaseworkLogin from "./pages/CaseworkLogin";
 import CaseworkCallback from "./pages/CaseworkCallback";
 import CaseworkReviews from "./pages/CaseworkReviews";
+import CaseworkCaseReviews from "./pages/CaseworkCaseReviews";
 import CaseworkReviewDetail from "./pages/CaseworkReviewDetail";
 import CaseworkRules from "./pages/CaseworkRules";
 import CaseworkHow from "./pages/CaseworkHow";
@@ -161,6 +162,7 @@ const AdminApp = () => (
               on the case; manage docs under Data Lake → Materials. */}
           {/* Casework (folded in from /portal) */}
           <Route path="reviews" element={<CaseworkReviews />} />
+          <Route path="reviews/case/:slug" element={<CaseworkCaseReviews />} />
           <Route path="reviews/:id" element={<CaseworkReviewDetail />} />
           <Route path="rules" element={<CaseworkRules />} />
           <Route path="how" element={<CaseworkHow />} />

--- a/src/components/casework/CaseSearchCombobox.tsx
+++ b/src/components/casework/CaseSearchCombobox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { listCases } from "@/services/admin-api";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -35,8 +35,6 @@ export function CaseSearchCombobox({
   const [debounced, setDebounced] = useState("");
   const [results, setResults] = useState<CaseHit[]>([]);
   const [loading, setLoading] = useState(false);
-  // Guards against a slow earlier request landing after a newer one.
-  const reqId = useRef(0);
 
   useEffect(() => {
     const t = setTimeout(() => setDebounced(query.trim()), 250);
@@ -49,18 +47,23 @@ export function CaseSearchCombobox({
       setLoading(false);
       return;
     }
-    const id = ++reqId.current;
+    // `active` flips false on cleanup (a newer query, or unmount), so a slow
+    // earlier request can't overwrite fresher results or set state after unmount.
+    let active = true;
     setLoading(true);
     listCases<CaseHit>({ search: debounced, page_size: 10 })
       .then((page) => {
-        if (id === reqId.current) setResults(page.results ?? []);
+        if (active) setResults(page.results ?? []);
       })
       .catch(() => {
-        if (id === reqId.current) setResults([]);
+        if (active) setResults([]);
       })
       .finally(() => {
-        if (id === reqId.current) setLoading(false);
+        if (active) setLoading(false);
       });
+    return () => {
+      active = false;
+    };
   }, [debounced]);
 
   const pick = (slug: string) => {

--- a/src/components/casework/CaseSearchCombobox.tsx
+++ b/src/components/casework/CaseSearchCombobox.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+import { listCases } from "@/services/admin-api";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Loader2, Search } from "lucide-react";
+
+// A case as returned by GET /api/cases/ (only the fields the picker needs).
+interface CaseHit {
+  slug: string;
+  title?: string;
+  state?: string;
+}
+
+const MIN_QUERY = 2;
+
+// Server-backed case autocomplete for submitting a review. Debounced query →
+// GET /api/cases/?search= (full-text over title/description/key_allegations);
+// picking a case yields its canonical slug, which the caller submits verbatim.
+export function CaseSearchCombobox({
+  onPick,
+  disabled,
+}: {
+  onPick: (slug: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [results, setResults] = useState<CaseHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  // Guards against a slow earlier request landing after a newer one.
+  const reqId = useRef(0);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    if (debounced.length < MIN_QUERY) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    const id = ++reqId.current;
+    setLoading(true);
+    listCases<CaseHit>({ search: debounced, page_size: 10 })
+      .then((page) => {
+        if (id === reqId.current) setResults(page.results ?? []);
+      })
+      .catch(() => {
+        if (id === reqId.current) setResults([]);
+      })
+      .finally(() => {
+        if (id === reqId.current) setLoading(false);
+      });
+  }, [debounced]);
+
+  const pick = (slug: string) => {
+    setOpen(false);
+    setQuery("");
+    setResults([]);
+    onPick(slug);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-start font-normal text-muted-foreground"
+        >
+          <Search className="h-4 w-4 mr-2 shrink-0" />
+          Search a case to review…
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0 w-[--radix-popover-trigger-width] min-w-[20rem]" align="start">
+        {/* shouldFilter=false — results come pre-filtered from the server. */}
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder="Search cases by title…"
+          />
+          <CommandList>
+            {loading && (
+              <div className="flex items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Searching…
+              </div>
+            )}
+            {!loading && (
+              <CommandEmpty>
+                {debounced.length < MIN_QUERY
+                  ? "Type at least 2 characters."
+                  : "No matching cases."}
+              </CommandEmpty>
+            )}
+            {results.map((c) => (
+              <CommandItem
+                key={c.slug}
+                value={c.slug}
+                onSelect={() => pick(c.slug)}
+                className="flex flex-col items-start gap-0.5"
+              >
+                <span className="text-sm font-medium truncate w-full">{c.title || c.slug}</span>
+                <span className="font-mono text-xs text-slate-400 truncate w-full">
+                  {c.slug}
+                  {c.state ? ` · ${c.state}` : ""}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/casework/ReviewRow.tsx
+++ b/src/components/casework/ReviewRow.tsx
@@ -1,0 +1,67 @@
+import type { ReviewListItem, ReviewerInfo } from "@/types/casework";
+import { dispositionColor, statusColor, fmtDate, fmtDur, scoreBand } from "@/lib/casework-ui";
+
+// Distinct "provider·model" labels for the reviewer(s) that graded a run.
+function reviewerLabels(reviewers: ReviewerInfo[] | null): string[] {
+  if (!reviewers?.length) return [];
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const r of reviewers) {
+    const label = r.model ? `${r.provider}·${r.model}` : r.provider;
+    if (label && !seen.has(label)) {
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  return labels;
+}
+
+// One review execution rendered as a compact row: id, time, status/stage,
+// reviewers, overall score, disposition, duration. The per-case review page
+// lists a case's whole run history with these; clicking opens the run detail.
+export function ReviewRow({ review: r, onClick }: { review: ReviewListItem; onClick: () => void }) {
+  const reviewers = reviewerLabels(r.reviewers);
+  return (
+    <li
+      className="px-4 py-2.5 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
+      onClick={onClick}
+    >
+      <span className="text-xs font-mono text-slate-400 w-12">#{r.id}</span>
+      <span className="text-xs text-slate-500 w-40 hidden md:inline">
+        🕓 {fmtDate(r.completed_at || r.created_at)}
+      </span>
+      <span className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(r.status)}`}>
+        {r.status === "running" || r.status === "pending" ? r.stage || r.status : r.status}
+      </span>
+      {reviewers.length > 0 && (
+        <span
+          className="text-xs text-slate-400 font-mono hidden lg:inline truncate max-w-[14rem]"
+          title={`Graded by ${reviewers.join(", ")}`}
+        >
+          {reviewers.join(", ")}
+        </span>
+      )}
+      <span className="flex-1" />
+      {r.overall_score != null && (
+        <span
+          className="text-sm font-bold w-10 text-right"
+          style={{ color: scoreBand(r.overall_score) }}
+        >
+          {r.overall_score}
+        </span>
+      )}
+      {r.disposition && (
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(r.disposition)}`}
+        >
+          {r.disposition}
+        </span>
+      )}
+      {r.duration_seconds != null && (
+        <span className="text-xs text-slate-400 w-14 text-right hidden lg:inline">
+          {fmtDur(r.duration_seconds)}
+        </span>
+      )}
+    </li>
+  );
+}

--- a/src/pages/CaseworkCaseReviews.tsx
+++ b/src/pages/CaseworkCaseReviews.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import CaseworkLayout from "@/components/CaseworkLayout";
+import { listReviews, submitReview, apiErrorMessage } from "@/services/casework-api";
+import type { ReviewListItem } from "@/types/casework";
+import { Button } from "@/components/ui/button";
+import { ReviewRow } from "@/components/casework/ReviewRow";
+import { dispositionColor, statusColor, fmtDate, scoreBand } from "@/lib/casework-ui";
+import { Loader2, ArrowLeft, ExternalLink, RefreshCw } from "lucide-react";
+
+// Per-case review page: a case's whole run history (newest-first) plus its
+// latest score summary. The full per-run breakdown (rules, radar, sources)
+// lives one level deeper on the run detail page (/admin/reviews/:id).
+export default function CaseworkCaseReviews() {
+  const { slug = "" } = useParams();
+  const navigate = useNavigate();
+  const [runs, setRuns] = useState<ReviewListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [rerunning, setRerunning] = useState(false);
+
+  const load = useCallback(
+    async (isPoll = false) => {
+      if (!slug) return;
+      try {
+        // page_size=100: a single case rarely has more runs than that, so this
+        // loads the whole history in one request (newest-first from the backend).
+        const page = await listReviews({ slug, page_size: 100 });
+        setRuns(page.results);
+      } catch {
+        if (!isPoll) setErr("Failed to load reviews for this case.");
+      } finally {
+        if (!isPoll) setLoading(false);
+      }
+    },
+    [slug]
+  );
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll while the newest run is still in progress.
+  useEffect(() => {
+    const latest = runs[0];
+    if (latest?.status === "pending" || latest?.status === "running") {
+      const t = setInterval(() => load(true), 3000);
+      return () => clearInterval(t);
+    }
+  }, [runs, load]);
+
+  const onRerun = async () => {
+    setRerunning(true);
+    setErr("");
+    try {
+      const fresh = await submitReview({ slug });
+      navigate(`/admin/reviews/${fresh.id}`);
+    } catch (e: unknown) {
+      setErr(apiErrorMessage(e, "Re-run failed."));
+      setRerunning(false);
+    }
+  };
+
+  const latest = runs[0];
+  const title = latest?.case_title || slug;
+
+  return (
+    <CaseworkLayout>
+      <div className="space-y-5">
+        <button
+          onClick={() => navigate("/admin/reviews")}
+          className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          <ArrowLeft className="h-4 w-4" /> All reviews
+        </button>
+
+        <div className="bg-white border rounded-xl p-5">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="min-w-0">
+              <div className="font-mono text-xs text-slate-500">{slug}</div>
+              <h1 className="text-lg font-bold">{title}</h1>
+              <a
+                href={`/case/${slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 mt-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLink className="h-3.5 w-3.5" /> View case on jawafdehi.org
+              </a>
+              {latest && (
+                <div className="flex items-center gap-2 mt-2 flex-wrap text-xs">
+                  <span
+                    className={`px-2 py-0.5 rounded-full border ${statusColor(latest.status)}`}
+                  >
+                    {latest.status === "running" || latest.status === "pending"
+                      ? latest.stage || latest.status
+                      : latest.status}
+                  </span>
+                  <span className="text-slate-400">
+                    🕓 {fmtDate(latest.completed_at || latest.created_at)}
+                  </span>
+                  <span className="text-slate-400">
+                    {runs.length} run{runs.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+              )}
+            </div>
+            <div className="flex items-start gap-3">
+              {latest?.overall_score != null && (
+                <div className="text-right">
+                  <div
+                    className="text-3xl font-extrabold"
+                    style={{ color: scoreBand(latest.overall_score) }}
+                  >
+                    {latest.overall_score}
+                  </div>
+                  {latest.disposition && (
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(latest.disposition)}`}
+                    >
+                      {latest.disposition}
+                    </span>
+                  )}
+                </div>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRerun}
+                disabled={rerunning}
+                title="Run a fresh review for this case against the current rules"
+              >
+                {rerunning ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4 mr-1" />
+                )}
+                Re-run
+              </Button>
+            </div>
+          </div>
+          {err && <p className="mt-3 text-sm text-red-600">{err}</p>}
+        </div>
+
+        {/* Run history */}
+        {loading ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading runs…
+          </div>
+        ) : runs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No reviews for this case yet. Use Re-run above to grade it.
+          </p>
+        ) : (
+          <div className="bg-white border rounded-xl overflow-hidden">
+            <div className="px-4 py-2.5 bg-slate-50 border-b text-sm font-semibold">
+              Runs ({runs.length})
+            </div>
+            <ul className="divide-y">
+              {runs.map((r) => (
+                <ReviewRow
+                  key={r.id}
+                  review={r}
+                  onClick={() => navigate(`/admin/reviews/${r.id}`)}
+                />
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </CaseworkLayout>
+  );
+}

--- a/src/pages/CaseworkCaseReviews.tsx
+++ b/src/pages/CaseworkCaseReviews.tsx
@@ -21,7 +21,11 @@ export default function CaseworkCaseReviews() {
 
   const load = useCallback(
     async (isPoll = false) => {
-      if (!slug) return;
+      if (!slug) {
+        // Without this the spinner (loading starts true) would never clear.
+        if (!isPoll) setLoading(false);
+        return;
+      }
       try {
         // page_size=100: a single case rarely has more runs than that, so this
         // loads the whole history in one request (newest-first from the backend).
@@ -40,13 +44,22 @@ export default function CaseworkCaseReviews() {
     load();
   }, [load]);
 
-  // Poll while the newest run is still in progress.
+  // Poll while the newest run is still in progress. Recursive setTimeout (not
+  // setInterval) so a slow request can't pile up behind the previous one.
   useEffect(() => {
     const latest = runs[0];
-    if (latest?.status === "pending" || latest?.status === "running") {
-      const t = setInterval(() => load(true), 3000);
-      return () => clearInterval(t);
-    }
+    if (latest?.status !== "pending" && latest?.status !== "running") return;
+    let active = true;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      await load(true);
+      if (active) timer = setTimeout(tick, 3000);
+    };
+    timer = setTimeout(tick, 3000);
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
   }, [runs, load]);
 
   const onRerun = async () => {

--- a/src/pages/CaseworkReviewDetail.tsx
+++ b/src/pages/CaseworkReviewDetail.tsx
@@ -117,10 +117,10 @@ export default function CaseworkReviewDetail() {
     <CaseworkLayout>
       <div className="space-y-5">
         <button
-          onClick={() => navigate("/admin/reviews")}
+          onClick={() => navigate(`/admin/reviews/case/${encodeURIComponent(review.slug)}`)}
           className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
         >
-          <ArrowLeft className="h-4 w-4" /> All reviews
+          <ArrowLeft className="h-4 w-4" /> All runs for this case
         </button>
 
         {/* Hero */}

--- a/src/pages/CaseworkReviews.tsx
+++ b/src/pages/CaseworkReviews.tsx
@@ -4,18 +4,16 @@ import CaseworkLayout from "@/components/CaseworkLayout";
 import {
   listReviewsGrouped,
   submitReview,
-  buildSubmitPayload,
-  looksLikeReviewIri,
   regradeAll,
   apiErrorMessage,
 } from "@/services/casework-api";
-import type { GroupedCase, ReviewListItem, ReviewerInfo } from "@/types/casework";
+import type { GroupedCase, ReviewListItem } from "@/types/casework";
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
 import { toast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { dispositionColor, statusColor, fmtDate, fmtDur, scoreBand } from "@/lib/casework-ui";
-import { Loader2, Plus, RefreshCw, Repeat } from "lucide-react";
+import { CaseSearchCombobox } from "@/components/casework/CaseSearchCombobox";
+import { dispositionColor, statusColor, fmtDate, scoreBand } from "@/lib/casework-ui";
+import { Loader2, RefreshCw, Repeat, ChevronRight } from "lucide-react";
 
 const PAGE_SIZE = 20;
 
@@ -37,21 +35,6 @@ function mergeGroups(prev: GroupedCase[], fresh: GroupedCase[]): GroupedCase[] {
   return [...bySlug.values()].sort((a, b) => (b.latest?.id ?? 0) - (a.latest?.id ?? 0));
 }
 
-// Distinct "provider·model" labels for the reviewer(s) that graded a run.
-function reviewerLabels(reviewers: ReviewerInfo[] | null): string[] {
-  if (!reviewers?.length) return [];
-  const seen = new Set<string>();
-  const labels: string[] = [];
-  for (const r of reviewers) {
-    const label = r.model ? `${r.provider}·${r.model}` : r.provider;
-    if (label && !seen.has(label)) {
-      seen.add(label);
-      labels.push(label);
-    }
-  }
-  return labels;
-}
-
 export default function CaseworkReviews() {
   const navigate = useNavigate();
   const { isModerator } = useCaseworkAuth();
@@ -62,11 +45,10 @@ export default function CaseworkReviews() {
   const [count, setCount] = useState(0);
   const [hasNext, setHasNext] = useState(false);
   const [nextPage, setNextPage] = useState(2);
-  const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [rerunningSlug, setRerunningSlug] = useState<string | null>(null);
   const [err, setErr] = useState("");
-  // Separate from `err` (which renders under the submit input) so a regrade-all
+  // Separate from `err` (which renders under the submit picker) so a regrade-all
   // failure surfaces next to the Regrade-all button, not the submit form.
   const [regradeErr, setRegradeErr] = useState("");
   const [conflictId, setConflictId] = useState<number | null>(null);
@@ -140,11 +122,11 @@ export default function CaseworkReviews() {
     }
   };
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!input.trim()) return;
+  // Submit a review for the case picked from the autocomplete. We already hold
+  // the canonical slug, so send it verbatim (same payload as re-run).
+  const onPickCase = async (slug: string) => {
     setSubmitting(true);
-    const ok = await runSubmit(buildSubmitPayload(input), "Submit failed.");
+    const ok = await runSubmit({ slug }, "Submit failed.");
     if (!ok) setSubmitting(false);
   };
 
@@ -175,8 +157,6 @@ export default function CaseworkReviews() {
     }
   };
 
-  const shownReviews = groups.reduce((n, g) => n + (g.executions?.length ?? 0), 0);
-
   return (
     <CaseworkLayout>
       <div className="space-y-6">
@@ -184,8 +164,7 @@ export default function CaseworkReviews() {
           <div>
             <h1 className="text-xl font-bold">Case reviews</h1>
             <p className="text-sm text-muted-foreground">
-              Submit a Jawafdehi case IRI or a court-case IRI to run a multi-dimensional
-              quality review.
+              Search a corruption case to run a multi-dimensional quality review.
             </p>
           </div>
           {isModerator && (
@@ -211,46 +190,31 @@ export default function CaseworkReviews() {
           )}
         </div>
 
-        <form onSubmit={onSubmit} className="flex gap-2 items-start">
-          <div className="flex-1">
-            <Input
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="https://jawafdehi.org/case/<slug> or …/courtcase/<court>/<case-no>"
-            />
-            {input.trim() && !looksLikeReviewIri(input) && !err && (
-              <p className="text-sm text-amber-600 mt-1">
-                Enter a case IRI (https://jawafdehi.org/case/&lt;slug&gt;) or a court-case
-                IRI (…/courtcase/&lt;court&gt;/&lt;case-number&gt;).
-              </p>
-            )}
-            {err && (
-              <p className="text-sm text-red-600 mt-1">
-                {err}
-                {conflictId != null && (
-                  <>
-                    {" "}
-                    <button
-                      type="button"
-                      className="underline font-medium"
-                      onClick={() => navigate(`/admin/reviews/${conflictId}`)}
-                    >
-                      View existing review
-                    </button>
-                  </>
-                )}
-              </p>
-            )}
+        <div className="max-w-xl">
+          <div className="flex items-center gap-2">
+            <div className="flex-1">
+              <CaseSearchCombobox onPick={onPickCase} disabled={submitting} />
+            </div>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
           </div>
-          <Button type="submit" disabled={submitting || !input.trim()}>
-            {submitting ? (
-              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4 mr-1" />
-            )}
-            Review
-          </Button>
-        </form>
+          {err && (
+            <p className="text-sm text-red-600 mt-1">
+              {err}
+              {conflictId != null && (
+                <>
+                  {" "}
+                  <button
+                    type="button"
+                    className="underline font-medium"
+                    onClick={() => navigate(`/admin/reviews/${conflictId}`)}
+                  >
+                    View existing review
+                  </button>
+                </>
+              )}
+            </p>
+          )}
+        </div>
 
         {loading ? (
           <div className="flex items-center gap-2 text-muted-foreground text-sm">
@@ -258,48 +222,18 @@ export default function CaseworkReviews() {
           </div>
         ) : groups.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            No reviews yet. Submit a case above.
+            No reviews yet. Search a case above to run one.
           </p>
         ) : (
-          <div className="space-y-3">
+          <div className="space-y-2">
             {groups.map((g) => (
-              <div key={g.slug} className="bg-white border rounded-xl overflow-hidden">
-                <div className="px-4 py-2.5 bg-slate-50 border-b flex items-center justify-between">
-                  <div className="min-w-0">
-                    <div className="font-mono text-xs text-slate-500 truncate">{g.slug}</div>
-                    <div className="text-sm font-medium truncate">{g.case_title || "—"}</div>
-                  </div>
-                  <div className="flex items-center gap-3 ml-3">
-                    <span className="text-xs text-slate-500 whitespace-nowrap">
-                      {g.executions?.length ?? 0} review
-                      {(g.executions?.length ?? 0) === 1 ? "" : "s"}
-                    </span>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={rerunningSlug === g.slug}
-                      title="Run a fresh review for this case against the current rules"
-                      onClick={() => onRerun(g.slug)}
-                    >
-                      {rerunningSlug === g.slug ? (
-                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                      ) : (
-                        <RefreshCw className="h-3.5 w-3.5 mr-1" />
-                      )}
-                      Re-run
-                    </Button>
-                  </div>
-                </div>
-                <ul className="divide-y">
-                  {(g.executions ?? []).map((r) => (
-                    <ReviewRow
-                      key={r.id}
-                      review={r}
-                      onClick={() => navigate(`/admin/reviews/${r.id}`)}
-                    />
-                  ))}
-                </ul>
-              </div>
+              <CaseRow
+                key={g.slug}
+                group={g}
+                rerunning={rerunningSlug === g.slug}
+                onOpen={() => navigate(`/admin/reviews/case/${encodeURIComponent(g.slug)}`)}
+                onRerun={() => onRerun(g.slug)}
+              />
             ))}
 
             {hasNext && (
@@ -313,8 +247,7 @@ export default function CaseworkReviews() {
               </div>
             )}
             <p className="text-center text-xs text-slate-400">
-              Showing {groups.length} of {count} case{count === 1 ? "" : "s"} ({shownReviews}{" "}
-              review{shownReviews === 1 ? "" : "s"})
+              Showing {groups.length} of {count} case{count === 1 ? "" : "s"}
             </p>
           </div>
         )}
@@ -323,49 +256,81 @@ export default function CaseworkReviews() {
   );
 }
 
-function ReviewRow({ review: r, onClick }: { review: ReviewListItem; onClick: () => void }) {
-  const reviewers = reviewerLabels(r.reviewers);
+// One case as a single compact row: title/slug + its LATEST run's score,
+// disposition, status and time. Clicking opens the per-case review page (the
+// case's full run history); the full per-run breakdown lives one level deeper.
+function CaseRow({
+  group: g,
+  rerunning,
+  onOpen,
+  onRerun,
+}: {
+  group: GroupedCase;
+  rerunning: boolean;
+  onOpen: () => void;
+  onRerun: () => void;
+}) {
+  const latest: ReviewListItem | undefined = g.latest;
+  const runs = g.executions?.length ?? 0;
+  const inProgress = latest?.status === "pending" || latest?.status === "running";
   return (
-    <li
-      className="px-4 py-2.5 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
-      onClick={onClick}
+    <div
+      className="bg-white border rounded-xl px-4 py-3 flex items-center gap-3 hover:bg-slate-50 cursor-pointer"
+      onClick={onOpen}
     >
-      <span className="text-xs font-mono text-slate-400 w-12">#{r.id}</span>
-      <span className="text-xs text-slate-500 w-40 hidden md:inline">
-        🕓 {fmtDate(r.completed_at || r.created_at)}
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium truncate">{g.case_title || g.slug}</div>
+        <div className="font-mono text-xs text-slate-400 truncate">{g.slug}</div>
+      </div>
+
+      {latest && (
+        <>
+          <span className="text-xs text-slate-400 whitespace-nowrap hidden md:inline">
+            🕓 {fmtDate(latest.completed_at || latest.created_at)}
+          </span>
+          <span className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(latest.status)}`}>
+            {inProgress ? latest.stage || latest.status : latest.status}
+          </span>
+          {latest.overall_score != null && (
+            <span
+              className="text-base font-bold w-9 text-right"
+              style={{ color: scoreBand(latest.overall_score) }}
+            >
+              {latest.overall_score}
+            </span>
+          )}
+          {latest.disposition && (
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(latest.disposition)}`}
+            >
+              {latest.disposition}
+            </span>
+          )}
+        </>
+      )}
+
+      <span className="text-xs text-slate-400 whitespace-nowrap hidden lg:inline w-14 text-right">
+        {runs} run{runs === 1 ? "" : "s"}
       </span>
-      <span className={`text-xs px-2 py-0.5 rounded-full border ${statusColor(r.status)}`}>
-        {r.status === "running" || r.status === "pending" ? r.stage || r.status : r.status}
-      </span>
-      {reviewers.length > 0 && (
-        <span
-          className="text-xs text-slate-400 font-mono hidden lg:inline truncate max-w-[14rem]"
-          title={`Graded by ${reviewers.join(", ")}`}
-        >
-          {reviewers.join(", ")}
-        </span>
-      )}
-      <span className="flex-1" />
-      {r.overall_score != null && (
-        <span
-          className="text-sm font-bold w-10 text-right"
-          style={{ color: scoreBand(r.overall_score) }}
-        >
-          {r.overall_score}
-        </span>
-      )}
-      {r.disposition && (
-        <span
-          className={`text-xs px-2 py-0.5 rounded-full border ${dispositionColor(r.disposition)}`}
-        >
-          {r.disposition}
-        </span>
-      )}
-      {r.duration_seconds != null && (
-        <span className="text-xs text-slate-400 w-14 text-right hidden lg:inline">
-          {fmtDur(r.duration_seconds)}
-        </span>
-      )}
-    </li>
+
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={rerunning}
+        title="Run a fresh review for this case against the current rules"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRerun();
+        }}
+      >
+        {rerunning ? (
+          <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+        ) : (
+          <RefreshCw className="h-3.5 w-3.5 mr-1" />
+        )}
+        Re-run
+      </Button>
+      <ChevronRight className="h-4 w-4 text-slate-300 shrink-0" />
+    </div>
   );
 }

--- a/src/services/casework-api.test.ts
+++ b/src/services/casework-api.test.ts
@@ -1,54 +1,60 @@
-import { describe, it, expect } from "vitest";
-import { buildSubmitPayload, looksLikeReviewIri } from "./casework-api";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-describe("buildSubmitPayload", () => {
-  it("sends a Jawafdehi case IRI as `iri`", () => {
-    expect(buildSubmitPayload("https://jawafdehi.org/case/alpha-case")).toEqual({
-      iri: "https://jawafdehi.org/case/alpha-case",
+// The OIDC token fetch touches the browser UserManager; stub it so the request
+// interceptor is inert in tests.
+vi.mock("./oidc", () => ({ getAccessToken: vi.fn().mockResolvedValue(null) }));
+
+// Capture what the shared axios instance is asked to fetch (mirrors
+// admin-api.test.ts). Each verb records its (url, params/body) and resolves an
+// empty body so the wrappers just relay the shape.
+const { calls } = vi.hoisted(() => ({
+  calls: [] as { method: string; url: string; body?: unknown; config?: unknown }[],
+}));
+
+vi.mock("axios", () => {
+  const record =
+    (method: string) =>
+    (url: string, body?: unknown, config?: unknown) => {
+      calls.push({ method, url, body, config });
+      // GET signature is (url, config); POST is (url, body, config).
+      return Promise.resolve({ data: { id: 7 }, headers: {} });
+    };
+  const instance = {
+    get: (url: string, config?: unknown) => {
+      calls.push({ method: "get", url, config });
+      return Promise.resolve({ data: { count: 0, next: null, previous: null, results: [] }, headers: {} });
+    },
+    post: record("post"),
+    put: record("put"),
+    patch: record("patch"),
+    delete: record("delete"),
+    interceptors: { request: { use: () => undefined } },
+  };
+  return { default: { create: () => instance } };
+});
+
+import { submitReview, listReviews } from "./casework-api";
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("submitReview", () => {
+  it("POSTs the case slug to the submit endpoint", async () => {
+    await submitReview({ slug: "case-081-cr-0136-oxygen-plant" });
+    expect(calls[0]).toMatchObject({
+      method: "post",
+      url: "/api/casework/reviews/submit/",
+      body: { slug: "case-081-cr-0136-oxygen-plant" },
     });
-  });
-
-  it("sends a court-case IRI as `iri`", () => {
-    expect(
-      buildSubmitPayload("https://jawafdehi.org/courtcase/special/080-cr-0111")
-    ).toEqual({ iri: "https://jawafdehi.org/courtcase/special/080-cr-0111" });
-  });
-
-  it("trims surrounding whitespace", () => {
-    expect(buildSubmitPayload("  https://jawafdehi.org/case/alpha-case  ")).toEqual({
-      iri: "https://jawafdehi.org/case/alpha-case",
-    });
-  });
-
-  it("forwards non-IRI input verbatim (the backend rejects it with a clear 400)", () => {
-    expect(buildSubmitPayload("080-CR-0111")).toEqual({ iri: "080-CR-0111" });
   });
 });
 
-describe("looksLikeReviewIri", () => {
-  it("accepts case and court-case IRIs", () => {
-    expect(looksLikeReviewIri("https://jawafdehi.org/case/alpha-case")).toBe(true);
-    expect(
-      looksLikeReviewIri("https://jawafdehi.org/courtcase/special/080-cr-0111")
-    ).toBe(true);
-    expect(looksLikeReviewIri("  https://jawafdehi.org/case/alpha-case  ")).toBe(true);
-  });
-
-  it("rejects case numbers, names, and legacy court refs", () => {
-    expect(looksLikeReviewIri("080-CR-0111")).toBe(false);
-    expect(looksLikeReviewIri("Giribandhu")).toBe(false);
-    expect(looksLikeReviewIri("special:081-CR-0136")).toBe(false);
-    expect(looksLikeReviewIri("case-081-cr-0136-oxygen-plant")).toBe(false);
-  });
-
-  it("mirrors the backend: court-case numbers are lowercase-only (uppercase is not canonical)", () => {
-    // Court-case IRIs are strictly lowercase everywhere on the platform, so an
-    // uppercase number is not a valid court-case IRI — keep this in sync with
-    // the backend so the hint never says "ok" for something it will 400.
-    expect(
-      looksLikeReviewIri("https://jawafdehi.org/courtcase/special/080-CR-0111")
-    ).toBe(false);
-    // A case slug, by contrast, may contain uppercase.
-    expect(looksLikeReviewIri("https://jawafdehi.org/case/Case-Alpha")).toBe(true);
+describe("listReviews", () => {
+  it("scopes the flat list to one case via ?slug=", async () => {
+    await listReviews({ slug: "case-a", page_size: 100 });
+    expect(calls[0].method).toBe("get");
+    expect(calls[0].url).toBe("/api/casework/reviews/");
+    expect(calls[0].config).toMatchObject({ params: { slug: "case-a", page_size: 100 } });
   });
 });

--- a/src/services/casework-api.ts
+++ b/src/services/casework-api.ts
@@ -19,37 +19,20 @@ const CASEWORK = "/api/casework";
 // ---- Reviews ----
 
 export interface SubmitReviewPayload {
-  // Caseworkers submit an `iri`: a Jawafdehi case IRI
-  // (https://jawafdehi.org/case/<slug>) or a court-case IRI
-  // (https://jawafdehi.org/courtcase/<court>/<case-number>). The backend
-  // resolves it to the case's canonical slug.
-  iri?: string;
-  // `slug` is used only by the internal re-run / regrade path, which already
-  // holds the resolved canonical slug.
+  // The submit UI resolves the case via autocomplete and sends its canonical
+  // `slug` (the same payload the re-run / regrade paths use). `iri` is still
+  // accepted by the backend (a Jawafdehi case IRI or a court-case IRI) for
+  // programmatic callers, but the portal no longer produces it.
   slug?: string;
-}
-
-// A submitted IRI is either a Jawafdehi case IRI or a court-case IRI. The
-// backend is the authority (it resolves + validates against the DB); this is a
-// lenient client-side shape check so the form can flag obviously-wrong input
-// (a bare case number, a name) before a round-trip.
-const REVIEW_IRI_RE =
-  /^https?:\/\/[^/]+\/(?:case\/[a-zA-Z][a-zA-Z0-9-]*|courtcase\/[a-z0-9][a-z0-9_-]*\/[a-z0-9][a-z0-9._-]*)$/;
-
-export function looksLikeReviewIri(raw: string): boolean {
-  return REVIEW_IRI_RE.test(raw.trim());
-}
-
-// The submit box demands an IRI (a Jawafdehi case IRI or a court-case IRI).
-// Send it verbatim as `iri`; the backend resolves it to the canonical case slug
-// and returns a clear 400 if it names no case.
-export function buildSubmitPayload(raw: string): SubmitReviewPayload {
-  return { iri: raw.trim() };
+  iri?: string;
 }
 
 export async function listReviews(params?: {
   page?: number;
   page_size?: number;
+  // Scope the flat list to one case's runs (newest-first). Used by the
+  // per-case review page to load a case's whole run history.
+  slug?: string;
 }): Promise<Paginated<ReviewListItem>> {
   const { data } = await client.get<Paginated<ReviewListItem> | ReviewListItem[]>(`${CASEWORK}/reviews/`, {
     params,

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -9,6 +9,7 @@ Drives the real SPA in headless Chromium (Playwright) against a mock backend tha
 - `admin-dates-repro.mjs` — admin case editor: BS/AD date pairing, the BS-picker corruption/crash path, bigo comma formatting, timeline inline inserts, and the save wire format.
 - `site-and-materials.mjs` — field-based material edit form (PUT body shape), case-detail evidence-title links to `/material/*`, home-page case-card thumbnail fallback.
 - `case-detail.mjs` — redesigned case page: banner (breadcrumb, badges, court-case @id IRI links), section jump nav, material-based evidence cards, PDF preview dialog, `/courtcase` page, `/case/<court-ref>` slug redirect, guest-chat-removal 404.
+- `casework-reviews.mjs` — casework review flow: autocomplete case-search submit (no raw-IRI box), the slimmed one-row-per-case list (latest run only), the per-case review page (`/admin/reviews/case/:slug`) run history, and the run-detail breakdown. Uses the in-memory review store the mock seeds (one case, two runs) and appends on submit.
 - `smoke.mjs` — quick home-page load check.
 
 ## Running

--- a/tests/e2e/casework-reviews.mjs
+++ b/tests/e2e/casework-reviews.mjs
@@ -1,0 +1,132 @@
+// Headless verify driver for the redesigned casework review flow:
+//   1. autocomplete case-search submit (no more raw-IRI box)
+//   2. slimmed list — one row per case, LATEST run only
+//   3. new per-case review page (/admin/reviews/case/:slug) with run history
+//   4. run detail (/admin/reviews/:id) still serves the full breakdown
+// Requires: mock API on :48000 (bun tests/e2e/mock-api.ts) and the dev server
+// started with VITE_DEV_AUTH=true (port via E2E_BASE_URL, default :40115).
+//   node tests/e2e/casework-reviews.mjs
+import { chromium } from "playwright";
+
+const BASE = process.env.E2E_BASE_URL || "http://127.0.0.1:40115";
+const SHOTS = process.env.E2E_SHOTS_DIR || "/tmp/e2e-shots";
+const PATANJALI = "case-081-cr-0107-patanjali"; // seeded with two runs (88, 74)
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const pageErrors = [];
+page.on("pageerror", (e) => pageErrors.push(String(e).split("\n")[0]));
+
+let failures = 0;
+const check = (label, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"}: ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+// Dev-auth session snapshot (see src/services/dev-auth-constants.ts) + cookie
+// consent pre-answered so its fixed bar can't intercept clicks.
+await page.addInitScript(() => {
+  localStorage.setItem(
+    "jawafdehi.devAuth.user",
+    JSON.stringify({ username: "e2e-admin", roles: [], is_admin: true }),
+  );
+  localStorage.setItem("jawafdehi.devAuth.csrf", "e2e-csrf");
+  localStorage.setItem("jawafdehi_analytics_consent", "denied");
+});
+
+// === 1. List loads, one row per case, LATEST run only ======================
+console.log("\n== List: slim, one row per case ==");
+await page.goto(BASE + "/admin/reviews", { waitUntil: "networkidle" });
+await page.getByRole("heading", { name: "Case reviews" }).waitFor({ timeout: 30000 });
+
+// The IRI box is gone; the submit control is the autocomplete combobox.
+check(
+  "no raw-IRI textbox",
+  (await page.locator('input[placeholder*="jawafdehi.org/case"]').count()) === 0,
+);
+check("autocomplete combobox present", (await page.getByRole("combobox").count()) === 1);
+
+// Seeded patanjali case: latest run is 88/PASS; the older 74 must NOT show.
+check("latest score (88) shown on list", (await page.getByText("88", { exact: true }).count()) >= 1);
+check("older run score (74) hidden on list", (await page.getByText("74", { exact: true }).count()) === 0);
+const rerunButtons = await page.getByRole("button", { name: "Re-run" }).count();
+check("one Re-run per case (1 case seeded)", rerunButtons === 1, `count=${rerunButtons}`);
+await page.screenshot({ path: `${SHOTS}/reviews-list.png`, fullPage: true });
+
+// === 2. Autocomplete submit ================================================
+console.log("\n== Autocomplete: search + submit ==");
+await page.getByRole("combobox").click();
+const search = page.getByPlaceholder("Search cases by title…");
+await search.waitFor({ timeout: 10000 });
+await search.click();
+await search.pressSequentially("Ncell", { delay: 30 });
+await page.waitForResponse(
+  (r) => r.url().includes("/api/cases/") && r.url().toLowerCase().includes("search=ncell"),
+  { timeout: 10000 },
+);
+await page.getByRole("option").first().waitFor({ timeout: 10000 });
+const optionCount = await page.getByRole("option").count();
+check("autocomplete returned matches for 'Ncell'", optionCount >= 1, `options=${optionCount}`);
+
+const [submitReq] = await Promise.all([
+  page.waitForRequest(
+    (r) => r.method() === "POST" && r.url().includes("/api/casework/reviews/submit/"),
+    { timeout: 10000 },
+  ),
+  page.getByRole("option").first().click(),
+]);
+const submittedSlug = submitReq.postDataJSON().slug;
+check("submit sent a case slug", typeof submittedSlug === "string" && submittedSlug.length > 0, submittedSlug);
+check("submitted a Ncell case", String(submittedSlug).startsWith("case-ncell"), submittedSlug);
+
+// === 3. Lands on run detail (full breakdown) ===============================
+console.log("\n== Run detail after submit ==");
+await page.waitForURL(/\/admin\/reviews\/\d+$/, { timeout: 15000 });
+await page.getByText("View case on jawafdehi.org").waitFor({ timeout: 15000 });
+check("run detail shows the score (91)", (await page.getByText("91", { exact: true }).count()) >= 1);
+check(
+  "run detail renders the rule breakdown",
+  (await page.getByText("Sources attached").count()) >= 1,
+);
+await page.screenshot({ path: `${SHOTS}/reviews-run-detail.png`, fullPage: true });
+
+// === 4. Back-link -> per-case page =========================================
+console.log("\n== Per-case page (run history) ==");
+await page.getByRole("button", { name: /All runs for this case/ }).click();
+await page.waitForURL(new RegExp(`/admin/reviews/case/${submittedSlug}$`), { timeout: 15000 });
+check(
+  "per-case page shows 1 run for the just-submitted case",
+  (await page.getByText(/Runs \(1\)/).count()) === 1,
+);
+
+// Click the run row -> back to its detail.
+await page.locator("ul li").first().click();
+await page.waitForURL(/\/admin\/reviews\/\d+$/, { timeout: 15000 });
+check("run row opens the run detail", /\/admin\/reviews\/\d+$/.test(page.url()), page.url());
+
+// === 5. List row click -> per-case page; multi-run history ==================
+console.log("\n== List row navigation + multi-run history ==");
+await page.goto(BASE + "/admin/reviews", { waitUntil: "networkidle" });
+await page.getByRole("heading", { name: "Case reviews" }).waitFor({ timeout: 30000 });
+// Two cases now (patanjali + the submitted Ncell) -> two Re-run buttons.
+const rerun2 = await page.getByRole("button", { name: "Re-run" }).count();
+check("list now has one row per case (2 cases)", rerun2 === 2, `count=${rerun2}`);
+
+// Directly load the patanjali per-case page: its ?slug= history has BOTH runs.
+await page.goto(BASE + `/admin/reviews/case/${PATANJALI}`, { waitUntil: "networkidle" });
+check("patanjali per-case page shows Runs (2)", (await page.getByText(/Runs \(2\)/).count()) === 1);
+check("history shows the latest run (88)", (await page.getByText("88", { exact: true }).count()) >= 1);
+check("history shows the older run (74)", (await page.getByText("74", { exact: true }).count()) >= 1);
+await page.screenshot({ path: `${SHOTS}/reviews-per-case.png`, fullPage: true });
+
+// The dev SSR harness emits a hydration-mismatch error on every full admin-route
+// load (reproducible on unchanged pages like /admin/rules), so ignore that known
+// artifact and only fail on unexpected runtime errors.
+const IGNORE = /Hydration failed|error while hydrating/;
+const realErrors = pageErrors.filter((e) => !IGNORE.test(e));
+console.log("\npageErrors (real):", realErrors.length ? realErrors : "none");
+console.log(`pageErrors (ignored hydration): ${pageErrors.length - realErrors.length}`);
+if (realErrors.length) failures += realErrors.length;
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+await browser.close();
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/e2e/mock-api.ts
+++ b/tests/e2e/mock-api.ts
@@ -52,6 +52,112 @@ for (const m of materialsList.results) {
   materialsByTail.set(materialTail(String(m["@id"])), m);
 }
 
+// ---------------------------------------------------------------------------
+// Casework reviews (in-memory). submit appends a fresh run; the store stays
+// newest-first so grouping and the flat ?slug= list mirror the real backend's
+// -created_at ordering.
+// ---------------------------------------------------------------------------
+let reviewSeq = 500;
+const reviews: Json[] = [];
+
+function makeResult(slug: string, title: string, score: number, disposition: string): Json {
+  const rule = (key: string, ruleTitle: string, category: string, kind: string, sc: number) => ({
+    key,
+    title: ruleTitle,
+    category,
+    kind,
+    condition_text: "",
+    applies_to: [],
+    weight: 1,
+    is_gate: false,
+    gate_min: 0,
+    gate_failed: false,
+    score: sc,
+    confidence: "high",
+    variance: 0,
+    std: 0,
+    issues: [],
+    notes: [],
+    suggestions: [],
+    rationale: "Deterministic check passed.",
+    description: "",
+    good_examples: "",
+    bad_examples: "",
+  });
+  return {
+    slug,
+    title,
+    state: "IN_REVIEW",
+    case_type: { type: "criminal", label: "Criminal", rationale: "" },
+    overall_score: score,
+    disposition,
+    // Three categories so the detail radar chart (>= 3 axes) renders.
+    rules: [
+      rule("has_sources", "Sources attached", "Evidence", "deterministic", 100),
+      rule("summary_quality", "Summary quality", "Narrative", "llm", score),
+      rule("entity_coverage", "Entity coverage", "Entities", "llm", Math.max(0, score - 3)),
+    ],
+    categories: [
+      { category: "Evidence", score: 100, rules: 1 },
+      { category: "Narrative", score, rules: 1 },
+      { category: "Entities", score: Math.max(0, score - 3), rules: 1 },
+    ],
+    gate_failures: [],
+    gates_pass: true,
+    narrative: `Automated review summary for ${title}.`,
+    info: [],
+    judge_error: null,
+    llm_samples: 3,
+    thresholds: { pass: 80, revise: 60 },
+    model_id_used: "anthropic/opus-4.8",
+    source_summary: [
+      {
+        title: "Charge sheet",
+        source_type: "pdf",
+        conversion_status: "converted",
+        conversion_note: "",
+        markdown_chars: 1234,
+        markdown: "# Charge sheet\n\nBody text.",
+        url: [],
+      },
+    ],
+  };
+}
+
+function makeReview(slug: string, title: string, score: number, disposition: string): Json {
+  const id = ++reviewSeq;
+  return {
+    id,
+    slug,
+    case_title: title,
+    status: "done",
+    stage: "done",
+    case_state: "IN_REVIEW",
+    case_type: "criminal",
+    source_count: 1,
+    sources_converted: 1,
+    overall_score: score,
+    disposition,
+    reviewers: [{ tier: "premium", provider: "anthropic", model: "opus-4.8", calls: 3 }],
+    created_at: "2026-07-13T10:00:00Z",
+    completed_at: "2026-07-13T10:01:00Z",
+    started_at: "2026-07-13T10:00:05Z",
+    updated_at: "2026-07-13T10:01:00Z",
+    duration_seconds: 61,
+    error: "",
+    result: makeResult(slug, title, score, disposition),
+  };
+}
+
+// Seed one case with two runs so the list shows a case row and the per-case
+// page shows a run history out of the box.
+{
+  const seedSlug = String(caseDetail.slug);
+  const seedTitle = String(caseDetail.title || seedSlug);
+  reviews.unshift(makeReview(seedSlug, seedTitle, 74, "REVISE"));
+  reviews.unshift(makeReview(seedSlug, seedTitle, 88, "PASS"));
+}
+
 const json = (body: unknown, status = 200, headers: Record<string, string> = {}) =>
   new Response(JSON.stringify(body), {
     status,
@@ -83,7 +189,54 @@ Bun.serve({
       return new Response(null, { status: 204 });
     }
 
-    // --- casework review surface (admin shell dashboards) -------------------
+    // --- casework reviews ---------------------------------------------------
+    // Grouped list: one entry per case (all its runs), newest-case-first.
+    if (path === "/api/casework/reviews/grouped/" && method === "GET") {
+      const bySlug = new Map<string, Json[]>();
+      for (const r of reviews) {
+        const s = String(r.slug);
+        if (!bySlug.has(s)) bySlug.set(s, []);
+        bySlug.get(s)!.push(r);
+      }
+      const results = [...bySlug.entries()].map(([s, execs]) => ({
+        slug: s,
+        case_title: execs[0].case_title,
+        latest: execs[0],
+        executions: execs,
+      }));
+      return json({ count: results.length, next: null, previous: null, results });
+    }
+    // Submit: append a fresh run for the case named by slug (or a /case/ IRI).
+    if (path === "/api/casework/reviews/submit/" && method === "POST") {
+      const body = (await req.json()) as Json;
+      let slug = typeof body.slug === "string" ? body.slug : "";
+      if (!slug && typeof body.iri === "string") {
+        const m = body.iri.match(/\/case\/([^/]+)\/?$/);
+        if (m) slug = decodeURIComponent(m[1]);
+      }
+      if (!slug) return json({ detail: "slug or iri required" }, 400);
+      const c = casesBySlug.get(slug);
+      const title = c ? String(c.title || slug) : slug;
+      const review = makeReview(slug, title, 91, "PASS");
+      reviews.unshift(review);
+      return json(review, 201);
+    }
+    if (path === "/api/casework/reviews/regrade-all/" && method === "POST") {
+      return json({ regrading: 0, review_ids: [] });
+    }
+    const reviewIdMatch = path.match(/^\/api\/casework\/reviews\/(\d+)\/$/);
+    if (reviewIdMatch && method === "GET") {
+      const id = Number(reviewIdMatch[1]);
+      const r = reviews.find((x) => x.id === id);
+      return r ? json(r) : json({ detail: "Not found." }, 404);
+    }
+    // Flat list, optionally scoped to one case's runs via ?slug=.
+    if (path === "/api/casework/reviews/" && method === "GET") {
+      const slug = url.searchParams.get("slug");
+      const results = slug ? reviews.filter((r) => r.slug === slug) : reviews;
+      return json({ count: results.length, next: null, previous: null, results });
+    }
+    // Defensive: any other casework review path.
     if (path.startsWith("/api/casework/reviews")) return json(emptyPage);
     if (path === "/api/casework/rules/") return json([]);
     if (path === "/api/casework/config/") return json({});
@@ -98,6 +251,17 @@ Bun.serve({
       let results = [...casesBySlug.values()];
       const state = url.searchParams.get("state");
       if (state) results = results.filter((c) => c.state === state);
+      // Full-text search: the real /api/cases/ searches title/description/
+      // key_allegations. The mock adds slug too (harmless superset) so tests can
+      // type an ASCII token even when titles are Devanagari.
+      const search = url.searchParams.get("search");
+      if (search) {
+        const q = search.toLowerCase();
+        results = results.filter((c) =>
+          [c.title, c.slug, c.description, c.key_allegations]
+            .some((v) => String(v ?? "").toLowerCase().includes(q)),
+        );
+      }
       const pageSize = Number(url.searchParams.get("page_size") || 0);
       const count = results.length;
       if (pageSize > 0) results = results.slice(0, pageSize);


### PR DESCRIPTION
## What

Reworks the casework review UI (`/admin/reviews`) around two changes:

1. **Autocomplete submit** — the free-text IRI box is replaced with a debounced case-search combobox over `/api/cases/?search=`. Caseworkers find a corruption case by title/number and pick it; the app submits the resolved slug (same payload the re-run path already used).
2. **Slim list + per-case page** — each case collapses to **one row showing only its latest run** (score, disposition, status, time). The full run history moves to a new **per-case review page**; the deep per-run breakdown stays on the run detail page.

## Navigation

`list (latest per case)` → `/admin/reviews/case/:slug (run history)` → `/admin/reviews/:id (full breakdown)`

## Changes

- `components/casework/CaseSearchCombobox.tsx` — new debounced, server-backed case picker (Popover + Command).
- `components/casework/ReviewRow.tsx` — extracted run-row (shared).
- `pages/CaseworkReviews.tsx` — combobox submit; one compact row per case → opens the per-case page. Polling / load-more / regrade-all / 409-conflict handling preserved.
- `pages/CaseworkCaseReviews.tsx` — **new** route `/admin/reviews/case/:slug`: case header + latest-score summary + run history.
- `pages/CaseworkReviewDetail.tsx` — unchanged breakdown; back-link now returns to the per-case page.
- `services/casework-api.ts` — drop dead IRI helpers (`looksLikeReviewIri`, `buildSubmitPayload`); add `slug` arg to `listReviews`.
- `AdminApp.tsx` — register the new route.

## Depends on

Jawafdehi/JawafdehiAPI#323 (adds `?slug=` to `GET /api/casework/reviews/`, which the per-case run history fetches). Works against prod today only after that ships.

## Tests

- **Headless Chromium e2e** — new `tests/e2e/casework-reviews.mjs` (+ review store & case-search added to `tests/e2e/mock-api.ts`): search → submit → run detail → per-case history → run detail; asserts the list shows latest-only (older run hidden) while the per-case page shows all runs. 16/16 checks pass.
- Unit tests reworked for the new submit/list surface (`casework-api.test.ts`).
- Full unit suite: 158/158 pass. Touched files: eslint clean, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)