### PR TITLE
feat(analytics): track archive searches as GA4 view_search_results

### DIFF
--- a/src/pages/ArchiveSearch.tsx
+++ b/src/pages/ArchiveSearch.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, LayoutGrid, List, X } from "lucide-react";
 import { Helmet } from "react-helmet-async";
@@ -43,6 +43,7 @@ import {
   toggleArchiveSearchParam,
 } from "@/utils/archive-search-params";
 import { getFacetItemLabel } from "@/utils/case-entities";
+import { trackEvent } from "@/utils/analytics";
 
 type RefinementName = SidebarFilterName | "type";
 
@@ -122,6 +123,22 @@ export default function ArchiveSearch({
       setLastSuccessfulData(data);
     }
   }, [data, isError, isPlaceholderData]);
+
+  // Report genuine archive searches to GA4. Fire once per distinct query term
+  // (deduped via the ref) when fresh results land — never on pagination, sort,
+  // or filter refinements of the same term, and never for term-less browsing.
+  const lastTrackedQuery = useRef<string | null>(null);
+  useEffect(() => {
+    const term = params.q?.trim();
+    if (!term || !data || isPlaceholderData || isError) return;
+    if (lastTrackedQuery.current === term) return;
+    lastTrackedQuery.current = term;
+    trackEvent("view_search_results", {
+      search_term: term,
+      result_type: selectedRecordType,
+      results_count: data.count,
+    });
+  }, [params.q, data, isPlaceholderData, isError, selectedRecordType]);
 
   const displayData = data || lastSuccessfulData;
   const isInitialLoading = isLoading && !displayData;

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -28,7 +28,7 @@ const Privacy = () => {
                 Jawafdehi Initiative Privacy Policy
               </h1>
               <p className="font-page-lede font-page-lede-inverse">
-                Last updated: June 23, 2026
+                Last updated: July 13, 2026
               </p>
             </div>
           </div>
@@ -80,7 +80,7 @@ const Privacy = () => {
 
               <h3 id="analytics-data">2.3 Analytics Data</h3>
               <p>
-                With your consent, we use Google Analytics 4 to understand how visitors use the Platform (for example, which pages are viewed). Google Analytics sets cookies and processes usage data. Google Analytics 4 does not log or store full IP addresses, and we do not use Google Analytics for advertising or cross-context behavioral tracking. Analytics do not load and no analytics cookies are set unless you opt in through our cookie banner. You can decline analytics at any time without affecting your use of the Platform (see Section 4).
+                With your consent, we use Google Analytics 4 to understand how visitors use the Platform — for example, which pages are viewed and what visitors search for in the public archive. When you run a search, the words you type into the archive search box are recorded as part of an analytics event, together with the number of results returned. Because our archive concerns public corruption records, a search may include a person's name; if you would rather not have your search terms recorded, decline analytics in the cookie banner, and if you are concerned about your safety avoid entering identifying details (see Section 7). Google Analytics sets cookies and processes usage data. Google Analytics 4 does not log or store full IP addresses, and we do not use Google Analytics for advertising or cross-context behavioral tracking. Analytics do not load and no analytics cookies are set unless you opt in through our cookie banner. You can decline analytics at any time without affecting your use of the Platform (see Section 4).
               </p>
 
               <h3 id="error-monitoring">2.4 Error Monitoring</h3>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -22,6 +22,12 @@ export type AnalyticsEvent =
   | { name: 'case_view'; params: { case_id: string; slug: string } }
   | { name: 'entity_view'; params: { entity_type: string; entity_id: string; slug: string } }
   | { name: 'language_switch'; params: { from_lang: string; to_lang: string } }
+  // Archive site search. `view_search_results` is GA4's canonical site-search
+  // event, so `search_term` populates the built-in Search terms reporting
+  // directly — the SPA fires it manually because enhanced measurement cannot
+  // observe client-side (History API) navigations. `result_type`/`results_count`
+  // are extra params (register as custom dimensions/metrics to surface in reports).
+  | { name: 'view_search_results'; params: { search_term: string; result_type?: string; results_count?: number } }
   | { name: 'allegation_submitted'; params?: Record<string, never> };
 
 type AnalyticsEventParams<T extends AnalyticsEvent['name']> =


### PR DESCRIPTION
## What

Track what visitors search for in the public archive by sending GA4's canonical `view_search_results` event with the `search_term`, so queries flow into GA4's built-in Search terms reporting — and disclose that collection in the Privacy policy.

## Why

We have GA4 (`G-ZDV84KYJDJ`) but archive searches aren't captured today. GA4 enhanced measurement's Site Search only fires off a `page_view` that carries the `?q=` param — and this SPA does not emit a `page_view` on client-side (History API) navigation, so typing a query in the box produces no event. Firing `view_search_results` manually closes that gap and works for every entry point (typed search, direct `?q=` URL, command palette).

## How

- `src/utils/analytics.ts` — add a typed `view_search_results` event (`search_term`, plus optional `result_type` / `results_count`) to the `AnalyticsEvent` union.
- `src/pages/ArchiveSearch.tsx` — fire the event once per genuine search when fresh results land. A per-term ref dedupes it, so it does **not** re-fire on pagination, sort changes, or filter refinements of the same term, and never fires for term-less browsing.
- `src/pages/Privacy.tsx` — Section 2.3 now discloses that search-box terms (and result counts) are recorded as an analytics event, warns a query may contain a person's name, and points to the decline/omit-details options. "Last updated" bumped.

Keyed off `params.q` (the URL query), so it covers all three ways a search reaches the page.

## GA4 setup after merge

1. Verify in **Realtime** / **DebugView** that `view_search_results` appears with a `search_term` after a live search.
2. Turn **off** the enhanced-measurement Site Search toggle for the web data stream so this manual event is the single source of truth (avoids double-counting the occasional direct-URL landing).
3. Optionally register `result_type` (custom dimension) and `results_count` (custom metric) to surface them in reports.

## Verification

- `tsc --noEmit` — clean
- `eslint` on all changed files — clean

Only fires in a consented production build (gtag is consent-gated and host-gated), so this is invisible on dev/preview and for visitors who decline analytics cookies.

## Privacy

Search queries on a corruption-case archive will often contain individuals' names, which reach Google verbatim once tracked. The Privacy page's analytics section (2.3) is updated in this PR to disclose that, keeping consent informed. The cookie banner is left as-is: it already names Google Analytics and links to the full policy (standard layered-consent pattern), and changing its copy would pull in the Nepali i18n string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
