### PR TITLE
feat(casework): show review pickup time + a11y follow-ups

### DIFF
--- a/src/components/casework/ReviewResultView.tsx
+++ b/src/components/casework/ReviewResultView.tsx
@@ -34,6 +34,14 @@ export function ReviewResultView({ review }: { review: ReviewDetail }) {
   const passT = result?.thresholds?.pass ?? 80;
   const inProgress = review.status === "pending" || review.status === "running";
 
+  // Elapsed is the time actually spent running the review: finished − picked up.
+  // Fall back to the worker-measured duration for older rows that predate the
+  // pickup-time stamp (started_at null).
+  const elapsedSeconds =
+    review.started_at && review.completed_at
+      ? (new Date(review.completed_at).getTime() - new Date(review.started_at).getTime()) / 1000
+      : review.duration_seconds;
+
   const grouped = useMemo(() => {
     const g = new Map<string, RuleResult[]>();
     for (const rr of result?.rules || []) {
@@ -74,11 +82,23 @@ export function ReviewResultView({ review }: { review: ReviewDetail }) {
                   {result?.case_type?.label || review.case_type}
                 </span>
               )}
-              <span className="text-slate-400">
-                🕓 {fmtDate(review.completed_at || review.created_at)}
+              <span className="text-slate-400" title="Submitted for review">
+                🕓 {fmtDate(review.created_at)}
               </span>
-              {review.duration_seconds != null && (
-                <span className="text-slate-400">⏱ {fmtDur(review.duration_seconds)}</span>
+              {review.started_at && (
+                <span className="text-slate-400" title="Picked up by a worker">
+                  🚀 {fmtDate(review.started_at)}
+                </span>
+              )}
+              {review.completed_at && (
+                <span className="text-slate-400" title="Finished">
+                  🏁 {fmtDate(review.completed_at)}
+                </span>
+              )}
+              {elapsedSeconds != null && (
+                <span className="text-slate-400" title="Elapsed (finished − picked up)">
+                  ⏱ {fmtDur(elapsedSeconds)}
+                </span>
               )}
               <span className="text-slate-400">
                 sources {review.sources_converted}/{review.source_count}

--- a/src/components/casework/ReviewResultView.tsx
+++ b/src/components/casework/ReviewResultView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReviewDetail, RuleResult, SourceSummary } from "@/types/casework";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -29,6 +29,16 @@ export function ReviewResultView({ review }: { review: ReviewDetail }) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [source, setSource] = useState<SourceSummary | null>(null);
   const [showRaw, setShowRaw] = useState(false);
+
+  // Close the source viewer on Escape (keyboard a11y).
+  useEffect(() => {
+    if (!source) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSource(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [source]);
 
   const result = review.result || null;
   const passT = result?.thresholds?.pass ?? 80;


### PR DESCRIPTION
## What
Show the full review timeline on the per-case review detail hero, and add a couple of a11y follow-ups.

## Commits
1. **Pickup time + elapsed** — the hero showed one timestamp (finished, falling back to created) plus the worker-measured duration. Now it shows 🕓 submitted · 🚀 picked up · 🏁 finished · ⏱ elapsed, where `elapsed = finished − picked up` (falls back to `duration_seconds` for rows that predate the pickup-time stamp).
2. **Review-view a11y polish** — close the source viewer on Escape; only render the failed-status error box when there's actual error text; preserve existing query params when writing `?run=`; bail on a non-numeric review id.

## Depends on
The API PR that populates `CaseReview.started_at`. Existing reviews were backfilled, so the timeline renders for history immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
