### PR TITLE
feat(casework): allow closing a case from DRAFT

### DIFF
--- a/src/components/admin/case/CaseStateControl.tsx
+++ b/src/components/admin/case/CaseStateControl.tsx
@@ -30,6 +30,13 @@ interface Transition {
 const TRANSITIONS: Record<string, Transition[]> = {
   DRAFT: [
     { to: "IN_REVIEW", labelKey: "submitForReview", variant: "default" },
+    {
+      to: "CLOSED",
+      labelKey: "close",
+      variant: "destructive",
+      privileged: true,
+      confirmKey: "closeConfirm",
+    },
   ],
   IN_REVIEW: [
     { to: "PUBLISHED", labelKey: "publish", variant: "default", privileged: true },


### PR DESCRIPTION
## What
Allow **closing a case from `DRAFT`** in the case state control.

The control offered Close only from `IN_REVIEW` and `PUBLISHED`, so a `DRAFT` case had no way to be closed from the UI — its only action was "Submit for review." This adds the `CLOSED` transition to `DRAFT`, mirroring the existing privileged, confirm-gated close action and reusing the existing i18n keys.

The backend already permits `DRAFT → CLOSED` via `can_transition_case_state` (soft-delete → `CLOSED` + audit entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
