### PR TITLE
feat(casework): show resolved entity names in the case-editor entity list

### DIFF
--- a/src/components/admin/case/EntityRelationshipsEditor.tsx
+++ b/src/components/admin/case/EntityRelationshipsEditor.tsx
@@ -52,12 +52,12 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
 
   const remove = (i: number) => onChange(rows.filter((_, idx) => idx !== i));
 
-  const addRow = (nes_id = "") => {
+  const addRow = (nes_id = "", display_name?: string) => {
     // The appended row lands at the current end of the list; queue that index for focus.
     pendingFocus.current = rows.length;
     onChange([
       ...rows,
-      { nes_id, relationship_type: "ACCUSED", outcome: "CHARGED", notes: "" },
+      { nes_id, relationship_type: "ACCUSED", outcome: "CHARGED", notes: "", display_name },
     ]);
   };
 
@@ -133,7 +133,7 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
                     variant="ghost"
                     aria-label={`Link ${entityName(e) || id}`}
                     onClick={() => {
-                      addRow(id);
+                      addRow(id, entityName(e) || undefined);
                       setResults([]);
                       setQuery("");
                     }}
@@ -158,6 +158,14 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
             return (
               <div key={i} className="grid gap-2 rounded border p-2 sm:grid-cols-[1fr_10rem_10rem_auto]">
                 <div className="space-y-1">
+                  {r.display_name && (
+                    <span
+                      className="block truncate text-sm font-medium"
+                      title={r.display_name}
+                    >
+                      {r.display_name}
+                    </span>
+                  )}
                   <Input
                     ref={(el) => {
                       if (el && pendingFocus.current === i) {
@@ -167,7 +175,11 @@ export default function EntityRelationshipsEditor({ rows, onChange }: Props) {
                       }
                     }}
                     value={r.nes_id}
-                    onChange={(e) => update(i, { nes_id: e.target.value })}
+                    // Hand-editing the IRI invalidates the resolved name; drop it
+                    // so a stale label can't sit above a different entity.
+                    onChange={(e) =>
+                      update(i, { nes_id: e.target.value, display_name: undefined })
+                    }
                     aria-invalid={iriMissing || iriBad}
                     className={cn(
                       "font-mono text-xs",

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -102,6 +102,9 @@ export interface EntityRelationshipRow {
   // A verdict is meaningful only for ACCUSED; every other role carries null.
   outcome: OutcomeType | null;
   notes: string;
+  // Display-only human name resolved from NES (mirrors EvidenceRow.title, BB-20).
+  // Not sent in the patch — buildEntitiesPatch only emits the canonical fields.
+  display_name?: string;
 }
 
 export interface TimelineEventRow {

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -131,12 +131,16 @@ function parseEntities(c: Record<string, unknown>): EntityRelationshipRow[] {
     // `role` as fallbacks. Reading only the latter two coerced every loaded row
     // to ACCUSED, so a whole-list save silently rewrote all non-accused roles.
     const relationship_type = asRelType(e.type ?? e.relationship_type ?? e.role);
+    // The case-read API resolves each entity's name into `display_name`; keep it
+    // for display only (like evidence's `title`). Empty when NES can't resolve.
+    const display_name = str(e.display_name) || undefined;
     return {
       nes_id: str(e.nes_id ?? e.entity ?? e["@id"]),
       relationship_type,
       // A verdict is meaningful only for ACCUSED; every other role is null.
       outcome: relationship_type === "ACCUSED" ? asOutcome(e.outcome) : null,
       notes: str(e.notes),
+      display_name,
     };
   });
 }


### PR DESCRIPTION
## What
Show **resolved entity names** in the case-editor entity-relationship list.

The editor rendered only the raw entity `@id` IRI, so a linked entity read as e.g. `.../entity/location/yu-ke-214fcf` with no hint it means "UK" — unlike evidence, which shows the material's resolved title.

## Change (frontend only — the API already returns the name)
The case-read API already resolves each entity's `display_name`. This captures it on the editor row (display-only, **not** sent in the patch — mirrors evidence's `title`) and renders it above the IRI input. Freshly linked search hits carry their name too, and hand-editing an IRI drops the now-stale name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
