### PR TITLE
feat(case-detail): follow canonical slug redirect to update URL (BB-38 FE)

### DIFF
--- a/src/pages/CaseDetail.test.tsx
+++ b/src/pages/CaseDetail.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { CaseDetail as CaseDetailType } from "@/types/jds";
+
+// Spy on useNavigate while keeping the rest of react-router-dom real (MemoryRouter,
+// useParams, Link, Navigate) so the route param drives `id` as it does in the app.
+const navigateSpy = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: "en" },
+  }),
+}));
+
+const getCaseById = vi.fn();
+const getCaseByCourtRef = vi.fn();
+vi.mock("@/services/jds-api", () => ({
+  getCaseById: (...args: unknown[]) => getCaseById(...args),
+  getCaseByCourtRef: (...args: unknown[]) => getCaseByCourtRef(...args),
+}));
+
+vi.mock("@/services/api", () => ({ getEntityById: vi.fn() }));
+vi.mock("@/services/datalake-api", () => ({ getCourtCase: vi.fn() }));
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+
+// Stub the heavy presentational children so the test isolates the redirect logic.
+vi.mock("@/components/FloatingShareSidebar", () => ({ FloatingShareSidebar: () => null }));
+vi.mock("@/components/ReportCaseDialog", () => ({ ReportCaseDialog: () => null }));
+vi.mock("@/components/DisqusComments", () => ({ DisqusComments: () => null }));
+vi.mock("@/components/case-detail/case-detail-banner", () => ({ CaseDetailBanner: () => null }));
+vi.mock("@/components/case-detail/case-contact-strip", () => ({ CaseContactStrip: () => null }));
+vi.mock("@/components/case-detail/case-disclaimer-banner", () => ({ CaseDisclaimerBanner: () => null }));
+vi.mock("@/components/case-detail/case-overview-section", () => ({ CaseOverviewSection: () => null }));
+vi.mock("@/components/case-detail/case-section-jump-nav", () => ({ CaseSectionJumpNav: () => null }));
+vi.mock("@/components/case-detail/missing-details-section", () => ({ MissingDetailsSection: () => null }));
+vi.mock("@/components/case-detail/notes-section", () => ({ NotesSection: () => null }));
+vi.mock("@/components/case-detail/case-timeline-section", () => ({ CaseTimelineSection: () => null }));
+vi.mock("@/components/case-detail/mobile-share-expander", () => ({ MobileShareExpander: () => null }));
+vi.mock("@/components/case-detail/court-cases-section", () => ({ CourtCasesSection: () => null }));
+vi.mock("@/components/case-detail/evidence-section", () => ({ EvidenceSection: () => null }));
+vi.mock("@/components/case-detail/involved-parties-section", () => ({ InvolvedPartiesSection: () => null }));
+vi.mock("@/components/case-detail/key-allegations-section", () => ({ KeyAllegationsSection: () => null }));
+
+import CaseDetail from "@/pages/CaseDetail";
+
+const makeCase = (slug: string | null): CaseDetailType => ({
+  id: 42,
+  slug,
+  case_type: "CORRUPTION",
+  state: "PUBLISHED",
+  title: "Test case",
+  case_start_date: null,
+  case_end_date: null,
+  entities: [],
+  tags: [],
+  key_allegations: [],
+  court_cases: [],
+  bigo: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  description: "",
+  timeline: [],
+  evidence: [],
+  notes: "",
+  missing_details: null,
+});
+
+const renderAt = (routeSlug: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/case/${routeSlug}`]}>
+          <Routes>
+            <Route path="/case/:id" element={<CaseDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+};
+
+beforeEach(() => {
+  navigateSpy.mockReset();
+  getCaseById.mockReset();
+  getCaseByCourtRef.mockReset();
+});
+
+describe("CaseDetail canonical slug redirect (BB-38)", () => {
+  it("replaces the URL with the canonical slug when the route slug is stale", async () => {
+    // The API 301-redirects the old slug and fetch follows it, so the case that
+    // comes back carries the canonical slug — here, different from the route.
+    getCaseById.mockResolvedValue(makeCase("current-slug"));
+
+    renderAt("old-slug");
+
+    await waitFor(() =>
+      expect(navigateSpy).toHaveBeenCalledWith("/case/current-slug", { replace: true }),
+    );
+    expect(getCaseById).toHaveBeenCalledWith("old-slug");
+  });
+
+  it("does not redirect (no loop) when the route slug is already canonical", async () => {
+    getCaseById.mockResolvedValue(makeCase("current-slug"));
+
+    renderAt("current-slug");
+
+    // Give the query time to resolve and any effect to run.
+    await waitFor(() => expect(getCaseById).toHaveBeenCalledWith("current-slug"));
+    await Promise.resolve();
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect when the loaded case has no canonical slug", async () => {
+    getCaseById.mockResolvedValue(makeCase(null));
+
+    renderAt("42");
+
+    await waitFor(() => expect(getCaseById).toHaveBeenCalledWith("42"));
+    await Promise.resolve();
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CaseDetail.test.tsx
+++ b/src/pages/CaseDetail.test.tsx
@@ -110,6 +110,21 @@ describe("CaseDetail canonical slug redirect (BB-38)", () => {
     expect(getCaseById).toHaveBeenCalledWith("old-slug");
   });
 
+  it("redirects a /case/<court-ref> URL to the canonical case slug", async () => {
+    // Court-ref-style URLs (e.g. /case/081-CR-0116) resolve via getCaseByCourtRef;
+    // the effect must replace the URL with the resolved case's canonical slug.
+    // This covers the path the old court-ref-only <Navigate> block used to handle.
+    getCaseByCourtRef.mockResolvedValue(makeCase("current-slug"));
+
+    renderAt("081-CR-0116");
+
+    await waitFor(() =>
+      expect(navigateSpy).toHaveBeenCalledWith("/case/current-slug", { replace: true }),
+    );
+    expect(getCaseByCourtRef).toHaveBeenCalledWith("081-CR-0116");
+    expect(getCaseById).not.toHaveBeenCalled();
+  });
+
   it("does not redirect (no loop) when the route slug is already canonical", async () => {
     getCaseById.mockResolvedValue(makeCase("current-slug"));
 

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -1,5 +1,5 @@
 import { type MouseEvent, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, Link, Navigate } from "react-router-dom";
+import { useParams, useNavigate, Link, Navigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { FloatingShareSidebar } from "@/components/FloatingShareSidebar";
@@ -71,6 +71,7 @@ const CaseDetail = () => {
   const { t, i18n } = useTranslation();
   const currentLang = i18n.language;
   const { id } = useParams();
+  const navigate = useNavigate();
   const trackedCaseIdRef = useRef<string | null>(null);
   const isMobile = useIsMobile();
   const [activeSection, setActiveSection] = useState("allegations");
@@ -91,6 +92,20 @@ const CaseDetail = () => {
     enabled: id != null && legacyTargetSlug == null,
     staleTime: 5 * 60 * 1000,
   });
+
+  // BB-38: follow the canonical slug once the case loads. The API 301-redirects
+  // stale/old slugs to the current one and `fetch` follows the redirect
+  // transparently, so `caseData.slug` is always canonical. When it differs from
+  // the route param — a stale slug, a legacy numeric id, or a /case/<court-ref>
+  // URL — replace the URL so the user lands on /case/<current-slug> without
+  // adding a history entry. Guarded to only fire when the slug is truthy and
+  // actually different, which prevents redirect loops once the URL is canonical.
+  useEffect(() => {
+    const canonicalSlug = caseData?.slug;
+    if (canonicalSlug && canonicalSlug !== id) {
+      navigate(`/case/${canonicalSlug}`, { replace: true });
+    }
+  }, [caseData?.slug, id, navigate]);
 
   // Subject entities: accused for CORRUPTION cases, else any named (non-location)
   // entity so cases without an accused (e.g. TAX_EVASION) still name a subject.
@@ -280,12 +295,6 @@ const CaseDetail = () => {
   // happen after all hooks have run so we don't violate rules-of-hooks.
   if (legacyTargetSlug) {
     return <Navigate to={`/case/${legacyTargetSlug}`} replace />;
-  }
-
-  // /case/<court-ref> URLs: once the case resolves, replace with its canonical
-  // slug. Cases without a slug stay on the court-ref URL.
-  if (isCourtRef && caseData?.slug && caseData.slug !== id) {
-    return <Navigate to={`/case/${caseData.slug}`} replace />;
   }
 
   if (isLoading) {


### PR DESCRIPTION
## What

On the case-detail page, after the case loads, if the loaded `caseData.slug` (canonical) differs from the slug in the route (`useParams` `id`), replace the browser URL with `/case/<current-slug>` using `navigate(..., { replace: true })` — so the user lands on the canonical URL without adding a history entry.

Implemented in `src/pages/CaseDetail.tsx` as a small `useEffect` using React Router's `useNavigate`/`useParams` (no raw `window.history`). It is guarded to fire only when the canonical slug is truthy and actually different, which prevents redirect loops once the URL is canonical. This generalizes and replaces the prior court-ref-only `<Navigate>` redirect block, and also cleanly covers legacy numeric-id URLs → canonical slug.

## Why (BB-38)

Pairs with the backend PR **JawafdehiAPI `fix/bb38-slug-redirects`**, which makes `/api/cases/<old-slug>/` return a `301` to the canonical `/api/cases/<current-slug>/`. `fetch` follows the 301 transparently, so the case JSON that comes back carries the canonical `slug`. Without this FE change the user would stay on the stale/old URL; this makes the URL canonical after load.

## How verified

- New vitest spec `src/pages/CaseDetail.test.tsx`: mounts `CaseDetail` at a stale route slug with the mocked API returning a case whose canonical `slug` differs, and asserts `navigate('/case/<current-slug>', { replace: true })` fires. Also asserts NO redirect (no loop) when the route slug already matches, and no redirect when the loaded case has no slug.
- `bun run test` → 161 passed (30 files); `bun run lint` → clean; `bun run build:dev` → success.
- Headless smoke: loaded a normal case at its canonical slug on the dev server — renders fine, no redirect loop, no HTTP errors.

## Caveat

Full end-to-end (old-slug → 301 → canonical-slug URL update) depends on the paired backend 301 being deployed; that backend PR is not deployed yet, so this was verified via the unit test (client redirect logic) + smoke, not a live 301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)