### PR TITLE
i18n: make the language switcher the single source of truth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,6 @@
         "embla-carousel-react": "^8.6.0",
         "gh-pages": "^6.3.0",
         "i18next": "^25.6.3",
-        "i18next-browser-languagedetector": "^8.2.0",
         "input-otp": "^1.4.2",
         "isomorphic-dompurify": "^3.17.0",
         "lucide-react": "^0.462.0",
@@ -1020,8 +1019,6 @@
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "i18next": ["i18next@25.10.10", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ=="],
-
-    "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/index.html
+++ b/index.html
@@ -1,10 +1,12 @@
 <!doctype html>
-<html lang="ne">
+<html lang="ne" translate="no">
 
 <head>
   <meta charset="UTF-8" />
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- The in-app EN/NE language switcher is the single source of truth for language; suppress browser/Google page auto-translation so it can't compete with or re-translate curated content. -->
+  <meta name="google" content="notranslate" />
   <!--helmet-title-->
   <!--helmet-meta-->
   <!-- fallback static meta for non-JS crawlers -->

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "embla-carousel-react": "^8.6.0",
     "gh-pages": "^6.3.0",
     "i18next": "^25.6.3",
-    "i18next-browser-languagedetector": "^8.2.0",
     "input-otp": "^1.4.2",
     "isomorphic-dompurify": "^3.17.0",
     "lucide-react": "^0.462.0",

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -33,7 +33,7 @@ export const LanguageToggle = ({ quiet = false }: LanguageToggleProps) => {
         await updateLanguage();
       });
     }
-    // Language preference is automatically persisted via localStorage by i18next-browser-languagedetector
+    // Language preference is persisted to localStorage by the languageChanged handler in src/i18n/config.ts.
   };
 
   return (

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -144,7 +144,8 @@ When the Entity API supports i18n, dynamic content translation can be integrated
 
 - `react-i18next` - React bindings for i18next
 - `i18next` - Core internationalization framework
-- `i18next-browser-languagedetector` - Language detection from browser/localStorage
+
+Language detection and localStorage persistence are handled directly in `config.ts` (no `i18next-browser-languagedetector`); the stored preference is the single source of truth and browser/Google auto-translation is suppressed via `translate="no"` + `<meta name="google" content="notranslate">` in `index.html`.
 
 ## Resources
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -5,7 +5,8 @@ import neTranslations from './locales/ne.json';
 
 const isSSR = typeof window === 'undefined';
 
-const getBrowserLanguage = (): 'en' | 'ne' => {
+// Nepali-first: everyone defaults to Nepali; English is opt-in via the language toggle and remembered across visits. We intentionally do NOT auto-detect navigator.language, to avoid a Nepali->English flash on the Nepali-only prerender and to keep the stored preference the single source of truth (browser/Google auto-translation is suppressed in index.html).
+const getPreferredLanguage = (): 'en' | 'ne' => {
   if (isSSR) return 'ne';
 
   let storedLanguage: string | null = null;
@@ -14,10 +15,7 @@ const getBrowserLanguage = (): 'en' | 'ne' => {
   } catch {
     // Storage blocked or unavailable
   }
-  if (storedLanguage?.startsWith('en')) return 'en';
-  if (storedLanguage?.startsWith('ne')) return 'ne';
-
-  return window.navigator.language.toLowerCase().startsWith('en') ? 'en' : 'ne';
+  return storedLanguage?.startsWith('en') ? 'en' : 'ne';
 };
 
 i18n
@@ -57,10 +55,10 @@ if (!isSSR) {
     }
   });
 
-  const browserLanguage = getBrowserLanguage();
-  if (browserLanguage !== i18n.language) {
+  const preferredLanguage = getPreferredLanguage();
+  if (preferredLanguage !== i18n.language) {
     window.requestAnimationFrame(() => {
-      void i18n.changeLanguage(browserLanguage);
+      void i18n.changeLanguage(preferredLanguage);
     });
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -213,11 +213,7 @@ export default defineConfig(async ({ mode, isSsrBuild }) => {
               manualChunks: {
                 "react-vendor": ["react", "react-dom", "react-router-dom"],
                 query: ["@tanstack/react-query", "axios"],
-                i18n: [
-                  "i18next",
-                  "react-i18next",
-                  "i18next-browser-languagedetector",
-                ],
+                i18n: ["i18next", "react-i18next"],
                 // The markdown rendering stack (react-markdown + remark/rehype +
                 // the micromark/mdast/hast transitive tree — ~250 modules) is
                 // only used to render case descriptions on CaseDetail. That page


### PR DESCRIPTION
Consolidate language handling so the in-app EN/NE toggle is the only mechanism that determines language, and suppress browser/Google page auto-translation so it cannot compete with or re-translate curated content.

- Suppress auto-translation: add translate="no" on <html> and <meta name="google" content="notranslate"> in index.html.
- Default Nepali-first: drop navigator.language auto-detection so a first-time visitor always gets the Nepali the page already renders (no hydration language flash); a stored preference is still honored and English stays opt-in via the toggle, persisted to localStorage.
- Remove the unused i18next-browser-languagedetector dependency — detection and persistence are handled directly in config.ts — and update the vite manualChunks group, package.json, bun.lock, and the i18n README.
- Correct a stale comment that credited the removed detector with persistence.