### PR TITLE
feat(case-detail): noindex non-PUBLISHED case pages (unlisted)

### DIFF
--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -368,6 +368,12 @@ const CaseDetail = () => {
       <Helmet>
         <title>{metaTitle}</title>
         <meta name="description" content={metaDescription} />
+        {/* Non-PUBLISHED cases are "unlisted": reachable by direct slug but kept
+            out of search engines (the API serves IN_REVIEW by slug, but these are
+            provisional, pre-publication records — see the under-review banner). */}
+        {caseData.state !== "PUBLISHED" && (
+          <meta name="robots" content="noindex, nofollow" />
+        )}
         <link rel="canonical" href={canonicalUrl} />
         <meta property="og:site_name" content={SITE_NAME} />
         <meta property="og:type" content="article" />

--- a/tests/e2e-pw/public-security.spec.ts
+++ b/tests/e2e-pw/public-security.spec.ts
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Hippocratic-3.0
 //
 // Adversarial (anonymous) browser checks. Jawafdehi holds pre-publication
-// allegations; a non-public case (DRAFT / IN_REVIEW / CLOSED) must never leak its
-// content to an anonymous visitor through the SPA — not on direct load, not in
-// search, not via the admin surface.
+// allegations. Visibility model:
+//   - DRAFT / CLOSED are fully hidden: content never leaks to anon (direct load
+//     404s) and they never appear in search or the admin surface (to anon).
+//   - IN_REVIEW is "unlisted": reachable by anon on DIRECT load (exact slug),
+//     rendered behind an "under review" banner and marked noindex — but NOT
+//     discoverable (absent from search + listings). Knowing a slug is allowed;
+//     enumerating slugs is not.
 //
 // These run against a REAL backend seeded by `seed_dev`, which creates:
 //   seed-published  PUBLISHED  "Published: embezzlement at Board Y"   (public)
@@ -28,11 +32,19 @@ test.beforeEach(async ({ page }) => {
 // unambiguous evidence the case leaked), plus the public case as a POSITIVE
 // CONTROL that the marker-matching is real and not always-green.
 const PUBLIC = { slug: "seed-published", marker: /embezzlement at Board Y/i };
-const NONPUBLIC = [
+// Fully hidden: direct load 404s, no content leak, absent from search.
+const HIDDEN = [
   { slug: "seed-draft", state: "DRAFT", marker: /alleged kickbacks at Dept A/i },
-  { slug: "seed-in-review", state: "IN_REVIEW", marker: /procurement fraud Ministry X/i },
   { slug: "seed-closed", state: "CLOSED", marker: /dismissed complaint Z/i },
 ];
+// Unlisted: renders on direct load (by exact slug), but not discoverable.
+const UNLISTED = {
+  slug: "seed-in-review",
+  state: "IN_REVIEW",
+  marker: /procurement fraud Ministry X/i,
+};
+// Everything that must stay OUT of search (unlisted + hidden alike).
+const ABSENT_FROM_SEARCH = [...HIDDEN, UNLISTED];
 
 test("POSITIVE CONTROL: the published case IS visible to anon (proves the leak checks have teeth)", async ({
   page,
@@ -43,7 +55,7 @@ test("POSITIVE CONTROL: the published case IS visible to anon (proves the leak c
   await expect(page.getByText(PUBLIC.marker).first()).toBeVisible();
 });
 
-for (const c of NONPUBLIC) {
+for (const c of HIDDEN) {
   test(`direct-loading the ${c.state} case /case/${c.slug} does not leak its content to anon`, async ({
     page,
   }) => {
@@ -64,6 +76,24 @@ for (const c of NONPUBLIC) {
   });
 }
 
+test(`direct-loading the IN_REVIEW case /case/${UNLISTED.slug} is unlisted-but-accessible (renders + noindex)`, async ({
+  page,
+}) => {
+  await page.goto(`/case/${UNLISTED.slug}`);
+  // Unlisted, NOT hidden: an anon visitor with the exact slug sees the case
+  // content render (the API serves IN_REVIEW by direct slug).
+  await expect(page.getByText(UNLISTED.marker).first()).toBeVisible();
+  // It renders behind an "under review" provisional banner (EN or NE copy).
+  await expect(
+    page.getByText(/under review|समीक्षा गरिरहेको/i).first(),
+  ).toBeVisible();
+  // ...and is kept out of search engines via a robots noindex directive.
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    "content",
+    /noindex/i,
+  );
+});
+
 test("searching for a non-public-only term surfaces no non-public case", async ({
   page,
 }) => {
@@ -76,13 +106,17 @@ test("searching for a non-public-only term surfaces no non-public case", async (
 
   // For the negative query, anchor on the results surface having SETTLED (the
   // "no records found" state) before asserting absence, so the check can't pass
-  // vacuously while the query is still in flight.
-  await page.goto("/search?q=kickbacks");
-  await expect(
-    page.getByText(/no archive records found/i).first(),
-  ).toBeVisible();
-  for (const c of NONPUBLIC) {
-    await expect(page.locator(`a[href="/case/${c.slug}"]`)).toHaveCount(0);
+  // vacuously while the query is still in flight. 'kickbacks' is DRAFT-only;
+  // 'procurement' is IN_REVIEW-only — the latter proves that an unlisted case,
+  // though reachable by direct slug, is still NOT discoverable via search.
+  for (const term of ["kickbacks", "procurement"]) {
+    await page.goto(`/search?q=${term}`);
+    await expect(
+      page.getByText(/no archive records found/i).first(),
+    ).toBeVisible();
+    for (const c of ABSENT_FROM_SEARCH) {
+      await expect(page.locator(`a[href="/case/${c.slug}"]`)).toHaveCount(0);
+    }
   }
 });
 

--- a/tests/ssr/worker.case-noindex.test.ts
+++ b/tests/ssr/worker.case-noindex.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import worker from '../../worker';
+
+// The Cloudflare worker injects share metadata for a case page when it isn't a
+// pre-rendered asset (handleCaseMetaFallback). For an "unlisted" (non-PUBLISHED)
+// case it must ALSO inject <meta name="robots" content="noindex"> so crawlers
+// keep provisional, pre-publication records out of search — link-only, not
+// indexed. PUBLISHED cases stay indexable.
+
+const INDEX_HTML =
+  '<!doctype html><html><head><title>Jawafdehi</title></head><body></body></html>';
+
+function makeEnv() {
+  return {
+    ASSETS: {
+      // The case path is not a static asset (404 → fall through to the meta
+      // fallback); the "/" index request returns the SPA shell.
+      fetch: async (req: Request) => {
+        const path = new URL(req.url).pathname;
+        if (path === '/') {
+          return new Response(INDEX_HTML, {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      },
+    },
+  };
+}
+
+function stubCaseApi(state: string) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL | Request) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes('/cases/')) {
+        return new Response(
+          JSON.stringify({
+            title: 'Some Case',
+            slug: 'some-case',
+            state,
+            description: 'A description of the case.',
+            key_allegations: ['An allegation'],
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('', { status: 404 });
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('worker case-meta fallback: unlisted cases get noindex', () => {
+  it('injects robots noindex for an IN_REVIEW (unlisted) case', async () => {
+    stubCaseApi('IN_REVIEW');
+    const res = await worker.fetch(
+      new Request('https://jawafdehi.org/case/some-case'),
+      makeEnv(),
+    );
+    const html = await res.text();
+    // Went through the meta fallback (share card present) ...
+    expect(html).toContain('og:title');
+    // ... and carries a noindex robots directive.
+    expect(html).toMatch(/<meta[^>]*name="robots"[^>]*noindex/i);
+  });
+
+  it('does NOT inject robots noindex for a PUBLISHED case', async () => {
+    stubCaseApi('PUBLISHED');
+    const res = await worker.fetch(
+      new Request('https://jawafdehi.org/case/some-case'),
+      makeEnv(),
+    );
+    const html = await res.text();
+    expect(html).toContain('og:title');
+    expect(html).not.toContain('noindex');
+  });
+});

--- a/worker.ts
+++ b/worker.ts
@@ -304,11 +304,15 @@ function buildMetaTags(input: {
   type?: 'article' | 'website';
   publishedTime?: string | null;
   modifiedTime?: string | null;
+  // When set (e.g. "noindex, nofollow"), emit a robots meta so crawlers keep
+  // "unlisted" (non-PUBLISHED) records out of search — link-only, not indexed.
+  robots?: string | null;
 }): string {
   const type = input.type ?? 'article';
   return `
 <title>${escapeHtml(input.title)}</title>
 <meta name="description" content="${escapeHtml(input.description)}" />
+${input.robots ? `<meta name="robots" content="${escapeHtml(input.robots)}" />` : ''}
 <link rel="canonical" href="${escapeHtml(input.canonicalUrl)}" />
 <meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />
 <meta property="og:type" content="${escapeHtml(type)}" />
@@ -343,6 +347,7 @@ function stripOverriddenHeadTags(head: string): string {
     .replace(/<meta\b[^>]*\bproperty=["'](?:og|article):[^"']*["'][^>]*>/gi, () => '')
     .replace(/<meta\b[^>]*\bname=["']twitter:[^"']*["'][^>]*>/gi, () => '')
     .replace(/<meta\b[^>]*\bname=["']description["'][^>]*>/gi, () => '')
+    .replace(/<meta\b[^>]*\bname=["']robots["'][^>]*>/gi, () => '')
     .replace(/<link\b[^>]*\brel=["']canonical["'][^>]*>/gi, () => '');
 }
 
@@ -430,6 +435,9 @@ async function handleCaseMetaFallback(request: Request, env: Env, slug: string):
     type: 'article',
     publishedTime: typeof caseData.created_at === 'string' ? caseData.created_at : null,
     modifiedTime: typeof caseData.updated_at === 'string' ? caseData.updated_at : null,
+    // IN_REVIEW cases are served by direct slug but are "unlisted": keep them
+    // out of search engines (only PUBLISHED is indexable). Share cards still work.
+    robots: caseData.state === 'PUBLISHED' ? null : 'noindex, nofollow',
   });
   return metaHtmlResponse(injectHeadMeta(indexHtml, `${titleRaw} | Jawafdehi`, metaTags));
 }


### PR DESCRIPTION
## What

Companion to **JawafdehiAPI #339** (serve IN_REVIEW cases by direct slug). Now that the API returns IN_REVIEW cases to anonymous callers by exact slug, the public `/case/<slug>` page renders them. Keep these **provisional, pre-publication** records out of search engines while still allowing link-only access and share cards — the "unlisted" model.

## Change

- **`CaseDetail` Helmet** emits `<meta name="robots" content="noindex, nofollow">` for any non-PUBLISHED case. This covers the SSR render (which now gets a 200 for IN_REVIEW). The existing **"under review" banner** (`caseDetail.inReviewBanner`) already renders for these — no new banner needed.
- **Cloudflare worker** (`handleCaseMetaFallback`) — the crawler-facing share-meta path — injects the same `noindex` for non-PUBLISHED cases, so crawlers are covered regardless of which path serves them. `buildMetaTags` gained an optional `robots` field; `robots` was added to the head-strip list so the worker's directive is authoritative (no duplicate tags).

## Already handled (no change needed)

- **Listing / search / sitemap** already exclude non-PUBLISHED cases — the sitemap script reads the anonymous list endpoint (PUBLISHED-only), and the search indexer evicts non-PUBLISHED. So IN_REVIEW is *unlisted*, not discoverable.

## Tests

New `tests/ssr/worker.case-noindex.test.ts`: IN_REVIEW → `noindex` injected; PUBLISHED → not. Full suite green (187), tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)