### PR TITLE
fix(footer): point Site Status link to external UptimeRobot status page

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -140,7 +140,7 @@ export const Footer = () => {
     { label: t("footer.contributorPortal"), to: `${API_BASE_URL}/admin`, external: true },
     { label: t("nav.faq"), to: "/faq" },
     { label: t("footer.githubRepo"), to: "https://github.com/Jawafdehi/Jawafdehi", external: true },
-    { label: t("footer.siteStatus"), to: "https://status.jawafdehi.org/status/public", external: true },
+    { label: t("footer.siteStatus"), to: "https://stats.uptimerobot.com/lwVRcc5suC", external: true },
     { label: t("footer.privacy"), to: "/privacy" },
     { label: t("footer.terms"), to: "/terms" },
   ];


### PR DESCRIPTION
## What
Repoint the footer **Site Status** link from `https://status.jawafdehi.org/status/public` → the external UptimeRobot public status page `https://stats.uptimerobot.com/lwVRcc5suC`.

## Why
`status.jawafdehi.org` (self-hosted Uptime Kuma) has been converted to a **fully internal, SSO-gated** dashboard — the public `/status/public` page and its Traefik oauth-bypass have been removed (infra change already live). Because that Kuma instance runs *inside* the same cluster it monitors and shares the cluster's Zitadel auth, it can't act as a public status page during an outage — as shown by today's incident, where the node hosting Kuma went down and took the public status page with it.

The public-facing status now lives on **UptimeRobot**, an external monitor independent of this cluster.

## Rollout
Infra lockdown is already applied in-cluster. Merging + deploying this repoints the public footer link to the working external page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the footer’s site status link to point to the new service status page.
  - The link remains labeled consistently and opens as an external resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->