### PR TITLE
test(e2e): pin public-security spec to English (Nepali-first default)

### DIFF
--- a/tests/e2e-pw/public-security.spec.ts
+++ b/tests/e2e-pw/public-security.spec.ts
@@ -24,8 +24,19 @@ async function dismissConsent(page: Page) {
   );
 }
 
+// The UI defaults to Nepali (i18n is the single source of truth — see
+// src/i18n/config.ts, which reads `i18nextLng` from localStorage on boot).
+// This spec asserts on the ENGLISH UI copy (not-found affordance, admin login,
+// "no records"), so pin the language to `en` via that same source of truth —
+// otherwise those strings render in Nepali and the English matchers miss.
+// (public-smoke.spec.ts pins `ne` the same way.)
+async function pinLanguageEnglish(page: Page) {
+  await page.addInitScript(() => localStorage.setItem("i18nextLng", "en"));
+}
+
 test.beforeEach(async ({ page }) => {
   await dismissConsent(page);
+  await pinLanguageEnglish(page);
 });
 
 // A distinctive title fragment per non-public case (unique to that row so a hit is


### PR DESCRIPTION
## Why

`JawafdehiAPI#339`'s `e2e` gate runs this repo's Playwright suite. Three `public-security.spec.ts` tests fail — DRAFT/CLOSED "does not leak" and the anon admin-login redirect — because the pages now render in **Nepali** while the specs assert **English** copy:

- admin: `button "जवाफदेही Auth बाट लगइन गर्नुहोस्"` vs. matcher `/login with jawafdehi auth/i`
- not-found: Nepali affordance vs. `/failed to load case.../i`

**Root cause:** `#221` made the language switcher the single source of truth with a **Nepali-first default** (`src/i18n/config.ts` → `lng:'ne'`, read from `localStorage['i18nextLng']`). The Playwright suite only runs on **API** PRs, so #221 (an FE PR) merged without exercising these specs; it first surfaced on #339's e2e. Not caused by #339 or #226.

## Fix

Seed `i18nextLng=en` in `beforeEach` via `addInitScript` — the same localStorage source of truth the app reads on boot, and the **same pinning pattern `public-smoke.spec.ts` already uses** (it pins `ne`). Test-only; no product/behavior change. The IN_REVIEW test already matches bilingually, so it's unaffected.

## Verification

eslint + tsc clean; `playwright test --list` compiles all 6 specs. Full e2e runs on the API side — this unblocks `JawafdehiAPI#339`'s `e2e` once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test consistency by ensuring the interface uses English during each test run.
  * Prevented language-dependent assertions from failing when another default language is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->