### PR TITLE
feat(materials): caseworker visibility-policy control in the material editor

### DIFF
--- a/src/components/admin/datalake/MaterialVisibilityControl.test.tsx
+++ b/src/components/admin/datalake/MaterialVisibilityControl.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Radix Select relies on pointer/layout APIs jsdom lacks; swap it for a native
+// <select> so onValueChange can be driven deterministically with fireEvent.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value?: string;
+    onValueChange: (v: string) => void;
+    disabled?: boolean;
+    children?: ReactNode;
+  }) => (
+    <select
+      data-testid="policy-select"
+      value={value ?? ""}
+      disabled={disabled}
+      onChange={(e) => onValueChange(e.currentTarget.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children?: ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+// The toast hook is a side-effect; stub it so we can assert it fired.
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...a: unknown[]) => toast(...a) }));
+
+// Isolate the network call. adminErrorMessage just relays the fallback here.
+const { patchMock } = vi.hoisted(() => ({ patchMock: vi.fn() }));
+vi.mock("@/services/admin-api", () => ({
+  patchMaterialVisibilityPolicy: patchMock,
+  adminErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+import MaterialVisibilityControl from "./MaterialVisibilityControl";
+
+const IRI = "https://jawafdehi.org/material/ciaa/press-2081-042";
+
+beforeEach(() => {
+  toast.mockClear();
+  patchMock.mockReset();
+});
+
+describe("MaterialVisibilityControl", () => {
+  it("shows the current policy and its derived visibility", () => {
+    render(<MaterialVisibilityControl iri={IRI} policy="PUBLIC" visibility="LISTED" />);
+    expect(screen.getByText("LISTED")).toBeTruthy();
+    expect((screen.getByTestId("policy-select") as HTMLSelectElement).value).toBe(
+      "PUBLIC",
+    );
+  });
+
+  it("PATCHes the chosen policy and reflects the server-recomputed visibility", async () => {
+    // A public doc marked PRIVATE resolves to PRIVATE visibility on the server.
+    patchMock.mockResolvedValue({
+      "jawafdehi:visibilityPolicy": "PRIVATE",
+      "jawafdehi:visibility": "PRIVATE",
+    });
+    render(<MaterialVisibilityControl iri={IRI} policy="PUBLIC" visibility="LISTED" />);
+
+    fireEvent.change(screen.getByTestId("policy-select"), {
+      target: { value: "PRIVATE" },
+    });
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalledWith(IRI, "PRIVATE"));
+    // The badge follows the server's recomputed visibility, not the raw policy.
+    await waitFor(() => expect(screen.getByText("PRIVATE")).toBeTruthy());
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Visibility updated" }),
+    );
+  });
+
+  it("reverts the selection and surfaces an error when the PATCH fails", async () => {
+    patchMock.mockRejectedValue(new Error("boom"));
+    render(<MaterialVisibilityControl iri={IRI} policy="PUBLIC" visibility="LISTED" />);
+
+    fireEvent.change(screen.getByTestId("policy-select"), {
+      target: { value: "CASE_GATED" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to update visibility")).toBeTruthy(),
+    );
+    // Reverted to the original policy; the derived-visibility badge never moved.
+    expect((screen.getByTestId("policy-select") as HTMLSelectElement).value).toBe(
+      "PUBLIC",
+    );
+    expect(screen.getByText("LISTED")).toBeTruthy();
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/admin/datalake/MaterialVisibilityControl.tsx
+++ b/src/components/admin/datalake/MaterialVisibilityControl.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import {
+  patchMaterialVisibilityPolicy,
+  adminErrorMessage,
+} from "@/services/admin-api";
+import { MATERIAL_VISIBILITY_POLICIES } from "@/lib/datalake-forms";
+import { FieldError } from "@/components/admin/FormError";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+import { Loader2 } from "lucide-react";
+
+// Badge tone for the derived `visibility` so a caseworker sees at a glance
+// whether the document is actually public right now: LISTED (public) reads
+// prominent; the withheld states read muted.
+const VISIBILITY_TONE: Record<string, "default" | "secondary" | "outline"> = {
+  LISTED: "default",
+  UNLISTED: "secondary",
+  PRIVATE: "outline",
+};
+
+interface Props {
+  // Full material @id IRI — the PATCH addresses the material by ?iri=.
+  iri: string;
+  // Current caseworker policy + the resulting derived visibility, read from the
+  // authed GET's jawafdehi:visibilityPolicy / jawafdehi:visibility annotations.
+  policy: string;
+  visibility: string;
+}
+
+// Caseworker control for a material's visibility policy. Deliberately SEPARATE
+// from the document-field form (whose Save PUTs the doc): the policy is a control
+// key the API strips from stored JSON-LD, so it is set out-of-band via a dedicated
+// PATCH that also recomputes the cached `visibility`. It therefore applies
+// immediately on change — mirroring CaseStateControl — not on the form's Save.
+export default function MaterialVisibilityControl({
+  iri,
+  policy: initialPolicy,
+  visibility: initialVisibility,
+}: Props) {
+  const [policy, setPolicy] = useState(initialPolicy);
+  const [visibility, setVisibility] = useState(initialVisibility);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onChange = async (next: string) => {
+    if (next === policy || saving) return;
+    const prev = policy;
+    // Optimistic — the Select reflects the choice immediately; revert on failure.
+    setPolicy(next);
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await patchMaterialVisibilityPolicy<Record<string, unknown>>(
+        iri,
+        next,
+      );
+      // Trust the server's echo (jawafdehi:visibility[Policy]) for both the
+      // applied policy and the freshly-recomputed derived visibility.
+      const appliedPolicy =
+        typeof updated["jawafdehi:visibilityPolicy"] === "string"
+          ? (updated["jawafdehi:visibilityPolicy"] as string)
+          : next;
+      const appliedVisibility =
+        typeof updated["jawafdehi:visibility"] === "string"
+          ? (updated["jawafdehi:visibility"] as string)
+          : visibility;
+      setPolicy(appliedPolicy);
+      setVisibility(appliedVisibility);
+      toast({
+        title: "Visibility updated",
+        description: `${appliedPolicy} → now ${appliedVisibility}`,
+      });
+    } catch (err) {
+      setPolicy(prev);
+      setError(adminErrorMessage(err, "Failed to update visibility"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border bg-white p-4">
+      <div className="flex items-center gap-2">
+        <Label className="text-sm font-semibold">Visibility</Label>
+        <Badge variant={VISIBILITY_TONE[visibility] ?? "outline"}>
+          {visibility || "—"}
+        </Badge>
+        {saving && (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Who can see this document, independent of the cases that cite it. Applies
+        immediately — it is not part of Save.
+      </p>
+      <Select value={policy || undefined} onValueChange={onChange} disabled={saving}>
+        <SelectTrigger className="max-w-md" aria-label="Visibility policy">
+          <SelectValue placeholder="Pick a visibility policy" />
+        </SelectTrigger>
+        <SelectContent>
+          {MATERIAL_VISIBILITY_POLICIES.map((p) => (
+            <SelectItem key={p.token} value={p.token}>
+              {p.label}
+            </SelectItem>
+          ))}
+          {/* A stored value outside the known vocabulary stays selectable so
+              opening the form doesn't force a change. */}
+          {policy &&
+            !MATERIAL_VISIBILITY_POLICIES.some((p) => p.token === policy) && (
+              <SelectItem value={policy}>{policy}</SelectItem>
+            )}
+        </SelectContent>
+      </Select>
+      <FieldError message={error} />
+    </div>
+  );
+}

--- a/src/lib/datalake-forms.ts
+++ b/src/lib/datalake-forms.ts
@@ -66,6 +66,19 @@ export const MATERIAL_SOURCE_TYPES = [
   { token: "MISC", label: "Miscellaneous" },
 ] as const;
 
+// Caseworker-controlled visibility policy (materials.models.Policy). The policy
+// is the INPUT that decides a material's cached `visibility` (LISTED / UNLISTED /
+// PRIVATE): PUBLIC always lists the document; CASE_GATED defers to the states of
+// the cases that cite it (public only once one is in review / published); PRIVATE
+// always withholds it. The policy is set out-of-band from the document body —
+// via PATCH /api/materials/ (see patchMaterialVisibilityPolicy) — because the API
+// strips these control keys from stored JSON-LD; it never rides along in a PUT.
+export const MATERIAL_VISIBILITY_POLICIES = [
+  { token: "PUBLIC", label: "Public — always listed" },
+  { token: "CASE_GATED", label: "Case-gated — follows the citing cases" },
+  { token: "PRIVATE", label: "Private — never public" },
+] as const;
+
 // Link roles for a material's associatedMedia entries (`jawafdehi:linkRole`) —
 // the DocumentSource link-role vocabulary.
 export const MATERIAL_LINK_ROLES = [

--- a/src/pages/MaterialProfile.tsx
+++ b/src/pages/MaterialProfile.tsx
@@ -70,9 +70,13 @@ function scalar(v: unknown): string | null {
 }
 
 // Keys handled explicitly in the header/links/full-text/provenance, never in Details.
+// The jawafdehi:visibility[Policy] pair is a caseworker-only annotation the API
+// adds on authed reads; it is an editor concern (see MaterialVisibilityControl),
+// not a public detail, so keep it out of the generic grid.
 const HANDLED_KEYS = new Set([
   "@id", "@type", "@context", "additionalType", "name", "alternateName",
   "description", "text", "url", "sameAs", "identifier", "associatedMedia",
+  "jawafdehi:visibility", "jawafdehi:visibilityPolicy",
 ]);
 
 // A roled source link (mirrors the data-lake DocumentSource link roles).

--- a/src/pages/admin/datalake/MaterialForm.tsx
+++ b/src/pages/admin/datalake/MaterialForm.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/datalake-forms";
 import DeleteButton from "@/components/admin/DeleteButton";
 import MaterialFileUpload from "@/components/admin/datalake/MaterialFileUpload";
+import MaterialVisibilityControl from "@/components/admin/datalake/MaterialVisibilityControl";
 import FormPageShell from "@/components/admin/FormPageShell";
 import AdminFormActions from "@/components/admin/AdminFormActions";
 import { FieldError } from "@/components/admin/FormError";
@@ -203,6 +204,17 @@ export default function MaterialForm() {
       : "";
   const rows = mediaRows(doc);
   const canSave = !saving && !loading && !rawError && iriValid && hasName;
+  // Caseworker visibility policy + its derived visibility, surfaced only on an
+  // authed read (jawafdehi:visibility[Policy]). Presence gates the out-of-band
+  // control below; the values seed it.
+  const visibilityPolicy =
+    typeof doc["jawafdehi:visibilityPolicy"] === "string"
+      ? (doc["jawafdehi:visibilityPolicy"] as string)
+      : "";
+  const visibility =
+    typeof doc["jawafdehi:visibility"] === "string"
+      ? (doc["jawafdehi:visibility"] as string)
+      : "";
 
   const setMediaRows = (next: MediaRow[]) =>
     patchDoc({
@@ -502,6 +514,19 @@ export default function MaterialForm() {
           }
         />
       </form>
+
+      {/* Visibility policy — an out-of-band caseworker control (immediate PATCH,
+          NOT part of Save). Edit-mode only, and only once an authed read has
+          surfaced jawafdehi:visibilityPolicy. Keyed on the (locked) IRI so it
+          reseeds if the loaded material changes. */}
+      {editing && visibilityPolicy && (
+        <MaterialVisibilityControl
+          key={iri}
+          iri={iri}
+          policy={visibilityPolicy}
+          visibility={visibility}
+        />
+      )}
 
       {/* F8 — file upload. Only in edit mode (the material must exist so its
           {source}/{ident} path is known). Prefer the components parsed from the

--- a/src/services/admin-api.test.ts
+++ b/src/services/admin-api.test.ts
@@ -68,6 +68,7 @@ import {
   uploadMaterialFile,
   listMaterials,
   deleteMaterial,
+  patchMaterialVisibilityPolicy,
   listCases,
   patchCase,
   patchCaseWithEtag,
@@ -143,6 +144,21 @@ describe("admin-api unified paths (no /api/nes or /api/ngm)", () => {
       "/api/materials/",
       "/api/materials/ciaa/press-2081-042",
     ]);
+  });
+
+  it("PATCHes a material's visibility policy to /api/materials/ addressed by ?iri=", async () => {
+    // The policy is set out-of-band (the API strips control keys from the doc),
+    // so it travels as a bare {visibility_policy} body with the full @id in ?iri=.
+    await patchMaterialVisibilityPolicy(
+      "https://jawafdehi.org/material/ciaa/press-2081-042",
+      "PRIVATE",
+    );
+    expect(calls[0]).toMatchObject({
+      method: "patch",
+      url: "/api/materials/",
+      body: { visibility_policy: "PRIVATE" },
+      config: { params: { iri: "https://jawafdehi.org/material/ciaa/press-2081-042" } },
+    });
   });
 
   it("keeps Jawafdehi cases on /api/cases and PATCHes with RFC-6902 ops", async () => {

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -324,6 +324,24 @@ export async function replaceMaterial<T = Record<string, unknown>>(
   return data;
 }
 
+// Set a material's caseworker-controlled visibility policy (materials.models.Policy:
+// PUBLIC | CASE_GATED | PRIVATE) out-of-band from its document body. The backend
+// strips these control keys from stored JSON-LD, so the policy travels via this
+// dedicated PATCH — which writes the column, recomputes the cached `visibility`,
+// and returns the doc annotated with jawafdehi:visibility[Policy] (an authed read).
+// Addressed by full @id via ?iri= (the canonical whole-IRI form).
+export async function patchMaterialVisibilityPolicy<T = Record<string, unknown>>(
+  iri: string,
+  visibilityPolicy: string,
+): Promise<T> {
+  const { data } = await client.patch<T>(
+    "/api/materials/",
+    { visibility_policy: visibilityPolicy },
+    { params: { iri } },
+  );
+  return data;
+}
+
 // Soft-delete a material by its <source>/<ident> path components (204).
 export async function deleteMaterial(
   source: string,


### PR DESCRIPTION
## What

The front-end counterpart to the API's material **`visibility_policy`** model (shipped in JawafdehiAPI #343). Adds an edit-mode **Visibility** control to the data-lake material editor so a caseworker can set a document's policy — **Public / Case-gated / Private** — directly from the UI.

This closes the loop on the original bug: an already-public document (a court order, CIAA press release, charge sheet) is no longer stuck at whatever visibility a citing **draft** case demoted it to. A caseworker can now mark it `PUBLIC` in one click.

| Policy | Resulting visibility |
| --- | --- |
| **Public** | always `LISTED` |
| **Case-gated** | follows the citing cases (`UNLISTED` in review → `LISTED` published) |
| **Private** | never public |

## How

The policy is deliberately **out-of-band from the document body**. The API strips the control keys (`visibility_policy`, `jawafdehi:visibility`, `jawafdehi:visibilityPolicy`) from stored JSON-LD, so riding the value along in the editor's Save **PUT would silently no-op**. Instead the control issues a dedicated `PATCH /api/materials/?iri=<iri>` that writes the column, recomputes the cached `visibility`, and echoes both back annotated on the doc.

Consequences of that design, reflected here:
- The control **applies immediately on change** (mirroring `CaseStateControl`), not on the form's Save. It's rendered as its own card after the form, edit-mode only, and only once an authed read has surfaced `jawafdehi:visibilityPolicy`.
- It's **optimistic** — reflects the choice at once, reverts + surfaces the error on failure — and trusts the server echo for the freshly-recomputed derived visibility (shown as a badge).
- **Auth gating** is already satisfied: the editor route is wrapped in `RequireWriteAccess can={hasNgmWriteAccess}`, so only content-staff caseworkers/admins ever reach it. The `jawafdehi:visibility[Policy]` annotations only exist on authed reads.

## Changes
- `admin-api.ts` — `patchMaterialVisibilityPolicy(iri, policy)`
- `datalake-forms.ts` — `MATERIAL_VISIBILITY_POLICIES` vocab
- `MaterialVisibilityControl.tsx` — the new control
- `MaterialForm.tsx` — wire it in (edit mode, gated on the annotation)
- `MaterialProfile.tsx` — keep the authed-only annotations out of the public Details grid (a caseworker viewing the public page gets them in the payload)
- tests — API-helper routing + the control (happy path, revert-on-error)

## Testing
- `vitest`: the two touched suites pass (25 tests). Full suite: **213 pass**; the only reds are 2 pre-existing `tests/ssr/worker.*` files (an `AbortSignal`/undici runtime quirk in `worker.ts`) that fail identically on clean `main`.
- `eslint`: clean on all changed files.
- `tsc`: no new errors introduced by these files.

## Notes / follow-ups
- **i18n:** the data-lake admin form family (`MaterialForm`, `EvidenceEditor`, `MaterialFileUpload`) is currently English-only and does not use `useTranslation`. This control matches that convention (hard-coded English) to avoid a lone translated label in an otherwise-English form. A separate pass could i18n the whole family.
- **Create mode** is intentionally out of scope: a brand-new material can't be `PATCH`ed before it exists, and the API's source-based birth default (`corpus→PUBLIC`, `upload→CASE_GATED`) already does the right thing; the policy can be adjusted immediately after first save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)