### PR TITLE
feat(admin): localized case-type labels in the case editor

### DIFF
--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -37,6 +37,7 @@ import {
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { formatAmountInput, stripAmountFormatting } from "@/utils/number";
+import { getCaseTypeLabelKey } from "@/utils/case-entities";
 import EntityRelationshipsEditor from "@/components/admin/case/EntityRelationshipsEditor";
 import TimelineEditor from "@/components/admin/case/TimelineEditor";
 import EvidenceEditor from "@/components/admin/case/EvidenceEditor";
@@ -645,15 +646,18 @@ export default function AdminCaseForm() {
               value={form.case_type}
               onValueChange={(v) => set("case_type", v)}
             >
-              <SelectTrigger>
+              <SelectTrigger id="case-type" data-testid="case-type-select">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {CASE_TYPES.map((ct) => (
-                  <SelectItem key={ct} value={ct}>
-                    {ct}
-                  </SelectItem>
-                ))}
+                {CASE_TYPES.map((ct) => {
+                  const labelKey = getCaseTypeLabelKey(ct);
+                  return (
+                    <SelectItem key={ct} value={ct}>
+                      {labelKey ? t(labelKey) : ct}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
           </div>

--- a/src/pages/admin/jawafdehi/AdminCaseForm.tsx
+++ b/src/pages/admin/jawafdehi/AdminCaseForm.tsx
@@ -641,7 +641,7 @@ export default function AdminCaseForm() {
             )}
           </div>
           <div className="space-y-1">
-            <Label>{t("admin.caseForm.labelCaseType")}</Label>
+            <Label htmlFor="case-type">{t("admin.caseForm.labelCaseType")}</Label>
             <Select
               value={form.case_type}
               onValueChange={(v) => set("case_type", v)}
@@ -654,7 +654,7 @@ export default function AdminCaseForm() {
                   const labelKey = getCaseTypeLabelKey(ct);
                   return (
                     <SelectItem key={ct} value={ct}>
-                      {labelKey ? t(labelKey) : ct}
+                      {labelKey ? t(labelKey, { defaultValue: ct }) : ct}
                     </SelectItem>
                   );
                 })}


### PR DESCRIPTION
## What

The admin case editor's **Case type** dropdown rendered raw enum tokens (`MONEY_LAUNDERING`, `ABUSE_OF_OFFICE`, …). This maps each option through the existing `getCaseTypeLabelKey()` helper so the dropdown shows the localized label ("Money Laundering" / "सम्पत्ति शुद्धीकरण"), consistent with every other case-type display site. Adds a stable `id="case-type"` / `data-testid="case-type-select"` on the trigger for e2e selection.

## Why

Surfaced while authoring the platform's first **money-laundering** case: `MONEY_LAUNDERING` was already a selectable option, but showed as the raw underscored token — unlike the polished, localized labels used everywhere else. No functional gap; this is a labelling + testability fix.

## Testing

Drove the full authoring flow headlessly (Playwright) against a real Django backend — dev-login → create a `MONEY_LAUNDERING` case (the dropdown now reads **"Money Laundering"**) → add entities / evidence / court-case ref → Save → Submit for review → Publish. Edge cases verified through the panel:

- an ML case publishes with only a non-accused (RELATED) subject (ML needs a subject, not an accused);
- a CORRUPTION case is still blocked without an ACCUSED entity;
- an ML case with only a LOCATION entity is blocked;
- a published case's slug stays immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Case-type options now display localized labels correctly in the admin case form.

* **Tests**
  * Added stable identifiers to the case-type selector for more reliable automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->