### PR TITLE
fix(config): update Jawafdehi WhatsApp contact number

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,11 +1,11 @@
-export const JAWAFDEHI_WHATSAPP_NUMBER = "+977 9749226442";
+export const JAWAFDEHI_WHATSAPP_NUMBER = "+977 9768630501";
 export const JAWAFDEHI_EMAIL = "inquiry@jawafdehi.org";
 
 export const JAWAFDEHI_SOCIALS = {
   facebook: "https://www.facebook.com/jawafdehi",
   youtube: "https://www.youtube.com/@Jawafdehi",
   linkedin: "https://www.linkedin.com/company/jawafdehi-initiative",
-  whatsapp: "https://api.whatsapp.com/send?phone=9779749226442",
+  whatsapp: "https://api.whatsapp.com/send?phone=9779768630501",
   linktree: "https://linktr.ee/jawafdehi",
 };
 


### PR DESCRIPTION
## What
Updates the site's WhatsApp contact number in `src/config/constants.ts`:

- `JAWAFDEHI_WHATSAPP_NUMBER`: `+977 9749226442` → `+977 9768630501`
- `JAWAFDEHI_SOCIALS.whatsapp` click-to-chat link: `…phone=9779749226442` → `…phone=9779768630501`

## Where it shows
`JAWAFDEHI_WHATSAPP_NUMBER` renders in the **Report a case** dialog (`ReportCaseDialog.tsx`) and case-detail page (`CaseDetail.tsx`); the social link appears in the site socials. This is the single source of truth for the number — no other code references the old digits.

## Not touched (intentionally)
- Mailing-list CSVs under `management`/`work` — those record a **team member's personal** number, not the site contact.
- Historical task notes referencing the prior fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the WhatsApp contact number and link to the new phone number.
  * WhatsApp contact actions now direct users to the updated number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->