### PR TITLE
fix(analytics): restore case_view + add search result-click tracking

### DIFF
--- a/src/pages/ArchiveSearch.tsx
+++ b/src/pages/ArchiveSearch.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, MouseEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, LayoutGrid, List, X } from "lucide-react";
 import { Helmet } from "react-helmet-async";
@@ -32,6 +32,7 @@ import type {
   ArchiveSearchFacets,
   ArchiveSearchParams,
   ArchiveSearchResponse,
+  ArchiveSearchResult,
   ArchiveSearchResultType,
   ArchiveSearchSort,
   ArchiveSearchType,
@@ -412,6 +413,7 @@ export default function ArchiveSearch({
               data={displayData}
               isError={showError}
               isLoading={isInitialLoading || isRefreshing}
+              searchTerm={params.q}
               viewMode={viewMode}
             />
 
@@ -467,11 +469,13 @@ function ArchiveSearchResults({
   data,
   isError,
   isLoading,
+  searchTerm,
   viewMode,
 }: Readonly<{
   data: ArchiveSearchResponse | undefined;
   isError: boolean;
   isLoading: boolean;
+  searchTerm?: string;
   viewMode: "list" | "card";
 }>) {
   const { t } = useTranslation();
@@ -516,15 +520,23 @@ function ArchiveSearchResults({
     );
   }
 
+  // 1-based rank across the whole result set (accounts for the current page),
+  // sent with each result click so we can measure rank-of-first-click.
+  const rankOf = (index: number) => (data.page - 1) * data.page_size + index + 1;
+
   if (viewMode === "card") {
     return (
       <div className={cardGridClass}>
-        {data.results.map((result) => (
-          <SearchResultCard
+        {data.results.map((result, index) => (
+          <TrackedSearchResult
             key={`${result.type}-${result.id}`}
+            rank={rankOf(index)}
             result={result}
+            searchTerm={searchTerm}
             viewMode="card"
-          />
+          >
+            <SearchResultCard result={result} viewMode="card" />
+          </TrackedSearchResult>
         ))}
       </div>
     );
@@ -532,13 +544,51 @@ function ArchiveSearchResults({
 
   return (
     <div className="space-y-3">
-      {data.results.map((result) => (
-        <SearchResultCard
+      {data.results.map((result, index) => (
+        <TrackedSearchResult
           key={`${result.type}-${result.id}`}
+          rank={rankOf(index)}
           result={result}
+          searchTerm={searchTerm}
           viewMode="list"
-        />
+        >
+          <SearchResultCard result={result} viewMode="list" />
+        </TrackedSearchResult>
       ))}
+    </div>
+  );
+}
+
+// Wraps a result so a click that navigates to the record (lands on an <a>, not a
+// tag/filter button) emits a GA4 `select_search_result` event carrying the
+// result's 1-based rank. Click-through and rank-of-first-click can only be
+// observed client-side — the server never learns which result was chosen.
+function TrackedSearchResult({
+  rank,
+  result,
+  searchTerm,
+  viewMode,
+  children,
+}: Readonly<{
+  rank: number;
+  result: ArchiveSearchResult;
+  searchTerm?: string;
+  viewMode: "list" | "card";
+  children: ReactNode;
+}>) {
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!(event.target as HTMLElement).closest("a")) return;
+    trackEvent("select_search_result", {
+      result_type: result.type,
+      rank,
+      search_term: searchTerm || undefined,
+    });
+  };
+  // `h-full` keeps card-grid cell heights consistent (inner card stretches to
+  // fill); list view needs no wrapper sizing.
+  return (
+    <div className={viewMode === "card" ? "h-full" : undefined} onClick={handleClick}>
+      {children}
     </div>
   );
 }

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -140,18 +140,25 @@ const CaseDetail = () => {
 
   useEffect(() => {
     const loadedCaseId = caseData?.id?.toString();
+    const canonicalSlug = caseData?.slug;
 
-    if (!id || !loadedCaseId || isError) {
+    if (!id || !loadedCaseId || !canonicalSlug || isError) {
       return;
     }
 
-    if (loadedCaseId !== id || trackedCaseIdRef.current === loadedCaseId) {
+    // Only fire once we're on the case's canonical slug URL. This skips the
+    // brief pre-canonical render for legacy /case/<numeric>, /case/<court-ref>,
+    // and stale-slug URLs (the effect re-runs after navigate() lands on the
+    // canonical slug). The previous guard compared the *numeric* caseData.id to
+    // the *slug* route param — once cases moved to slug URLs those never matched,
+    // so case_view silently stopped firing (0 events for ~2 months).
+    if (canonicalSlug !== id || trackedCaseIdRef.current === loadedCaseId) {
       return;
     }
 
-    trackEvent("case_view", { case_id: loadedCaseId, slug: `/case/${id}` });
+    trackEvent("case_view", { case_id: loadedCaseId, slug: `/case/${canonicalSlug}` });
     trackedCaseIdRef.current = loadedCaseId;
-  }, [id, caseData?.id, isError]);
+  }, [id, caseData?.id, caseData?.slug, isError]);
 
   const resolvedEntities: Record<string, Entity> = {};
   uniqueNesIds.forEach((nesId, i) => {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -28,6 +28,10 @@ export type AnalyticsEvent =
   // observe client-side (History API) navigations. `result_type`/`results_count`
   // are extra params (register as custom dimensions/metrics to surface in reports).
   | { name: 'view_search_results'; params: { search_term: string; result_type?: string; results_count?: number } }
+  // Archive search result click — powers click-through rate and rank-of-first-
+  // click (which result, at what 1-based position, for which term). Register
+  // `rank`/`result_type`/`search_term` as custom dimensions to surface in reports.
+  | { name: 'select_search_result'; params: { result_type: string; rank: number; search_term?: string } }
   | { name: 'allegation_submitted'; params?: Record<string, never> };
 
 type AnalyticsEventParams<T extends AnalyticsEvent['name']> =


### PR DESCRIPTION
## What
- **Fix `case_view`** (silently dead ~2 months): the effect guard compared the numeric `caseData.id` to the *slug* route param, so once cases moved to slug URLs it always returned early. Now gates on the canonical slug and skips the pre-canonical redirect render.
- **Add `select_search_result`** — emits `result_type`, 1-based `rank`, and `search_term` on archive result clicks → enables click-through rate + rank-of-first-click. Only anchor navigations count (tag/filter buttons excluded).

## Why
Search is the #2 page (per Cloudflare RUM) but search analytics were nearly blind: `view_search_results` is consent-limited, there was no click/rank signal at all, and `case_view` had gone to zero. This restores case-engagement tracking and adds the missing result-click signal.

## Testing
- `tsc --noEmit`: clean.
- ⚠️ **Needs runtime QA in GA4 DebugView** (confirm `case_view` fires on case load and `select_search_result` fires with the correct rank on result click) before merge — analytics can't be verified by typecheck alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)