### PR TITLE
feat(case-detail): move "Edit case" to the top, shown only when logged in (#1)

### DIFF
--- a/src/components/case-detail/case-contact-strip.tsx
+++ b/src/components/case-detail/case-contact-strip.tsx
@@ -1,24 +1,20 @@
-import { ExternalLink, Mail, MessageCircle } from "lucide-react";
+import { Mail, MessageCircle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
 interface CaseContactStripProps {
   email: string;
   whatsappNumber: string;
-  editUrl: string;
   emailLabel: string;
   whatsappLabel: string;
-  editLabel: string;
   title: string;
 }
 
 export function CaseContactStrip({
   email,
   whatsappNumber,
-  editUrl,
   emailLabel,
   whatsappLabel,
-  editLabel,
   title,
 }: Readonly<CaseContactStripProps>) {
   return (
@@ -58,13 +54,6 @@ export function CaseContactStrip({
     <MessageCircle className="h-4 w-4" aria-hidden="true" />
   </a>
 </Button>
-
-          <Button asChild className="px-3" variant="disclosure" size="navCta">
-            <a href={editUrl} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              <span>{editLabel}</span>
-            </a>
-          </Button>
         </div>
       </div>
     </aside>

--- a/src/hooks/use-is-logged-in.test.ts
+++ b/src/hooks/use-is-logged-in.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+import { useIsLoggedIn } from "@/hooks/use-is-logged-in";
+
+// The hook reads the persisted session directly (public pages sit outside the
+// admin auth providers), so mock both sources.
+vi.mock("@/services/dev-auth", () => ({ getStoredDevUser: vi.fn() }));
+vi.mock("@/services/oidc", () => ({ getUserManager: vi.fn() }));
+
+import { getStoredDevUser } from "@/services/dev-auth";
+import { getUserManager } from "@/services/oidc";
+
+const getUser = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(getStoredDevUser).mockReset().mockReturnValue(null);
+  getUser.mockReset().mockResolvedValue(null);
+  vi.mocked(getUserManager)
+    .mockReset()
+    .mockReturnValue({ getUser } as unknown as ReturnType<typeof getUserManager>);
+});
+
+describe("useIsLoggedIn", () => {
+  it("is false with no dev-auth and no OIDC session", async () => {
+    const { result } = renderHook(() => useIsLoggedIn());
+    // Let the async OIDC lookup settle; it must resolve to logged-out.
+    await act(async () => {});
+    expect(getUser).toHaveBeenCalled();
+    expect(result.current).toBe(false);
+  });
+
+  it("is true when a dev-auth session is stored, without touching OIDC", () => {
+    vi.mocked(getStoredDevUser).mockReturnValue({
+      username: "admin",
+      roles: [],
+      is_admin: true,
+    } as never);
+    const { result } = renderHook(() => useIsLoggedIn());
+    expect(result.current).toBe(true);
+    // Dev-auth short-circuits before the OIDC manager is consulted.
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it("is true when the OIDC manager has a non-expired user", async () => {
+    getUser.mockResolvedValue({ expired: false });
+    const { result } = renderHook(() => useIsLoggedIn());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("stays false when the OIDC user is expired", async () => {
+    getUser.mockResolvedValue({ expired: true });
+    const { result } = renderHook(() => useIsLoggedIn());
+    await act(async () => {});
+    expect(getUser).toHaveBeenCalled();
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-is-logged-in.ts
+++ b/src/hooks/use-is-logged-in.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+import { getStoredDevUser } from "@/services/dev-auth";
+import { getUserManager } from "@/services/oidc";
+
+// Is there an active login session? PUBLIC pages (CaseDetail et al.) render
+// OUTSIDE the admin OIDC / CaseworkAuth providers — those live only in AdminApp,
+// mounted at /admin/* — so `useCaseworkAuth()` is unavailable here and would
+// throw. This reads the persisted session directly instead: the dev-auth user
+// (localStorage) plus the OIDC user from the localStorage-backed UserManager
+// singleton, so a logged-in caseworker browsing the public site can be offered
+// staff affordances (e.g. an "Edit case" link) without mounting the admin auth
+// stack.
+//
+// It only answers "is someone signed in", NOT "may they edit" — the API and the
+// admin route guards remain the authorization authority; a signed-in non-staff
+// visitor who follows the link still hits the login/permission wall there.
+//
+// SSR-safe: starts `false` and only flips true in a client effect, so the
+// pre-rendered/hydrated markup matches (the server has no session to read).
+export function useIsLoggedIn(): boolean {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    // Dev-auth (username/password) is synchronous and already SSR-guarded.
+    if (getStoredDevUser()) {
+      setLoggedIn(true);
+      return;
+    }
+
+    let alive = true;
+    getUserManager()
+      .getUser()
+      .then((user) => {
+        if (alive && user && !user.expired) setLoggedIn(true);
+      })
+      .catch(() => {
+        // No session, or storage unavailable → stay logged-out.
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return loggedIn;
+}

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -11,6 +11,7 @@ import {
   AlertTriangle,
   ArrowLeft,
   AlertCircle,
+  SquarePen,
 } from "lucide-react";
 import { CaseDetailBanner } from "@/components/case-detail/case-detail-banner";
 import { CaseContactStrip } from "@/components/case-detail/case-contact-strip";
@@ -19,6 +20,7 @@ import { CaseOverviewSection } from "@/components/case-detail/case-overview-sect
 import { CaseSectionJumpNav, type CaseJumpSection } from "@/components/case-detail/case-section-jump-nav";
 import { MissingDetailsSection } from "@/components/case-detail/missing-details-section";
 import { NotesSection } from "@/components/case-detail/notes-section";
+import { useIsLoggedIn } from "@/hooks/use-is-logged-in";
 import { CaseTimelineSection } from "@/components/case-detail/case-timeline-section";
 import { MobileShareExpander } from "@/components/case-detail/mobile-share-expander";
 import { CourtCasesSection } from "@/components/case-detail/court-cases-section";
@@ -72,6 +74,9 @@ const CaseDetail = () => {
   const currentLang = i18n.language;
   const { id } = useParams();
   const navigate = useNavigate();
+  // The public case page renders outside the admin auth providers; this reads any
+  // persisted session so a logged-in caseworker sees an "Edit case" link up top.
+  const isLoggedIn = useIsLoggedIn();
   const trackedCaseIdRef = useRef<string | null>(null);
   const isMobile = useIsMobile();
   const [activeSection, setActiveSection] = useState("allegations");
@@ -417,7 +422,31 @@ const CaseDetail = () => {
       <CaseDetailBanner
         caseData={caseData}
         resolvedEntities={resolvedEntities}
-        actions={<ReportCaseDialog caseId={id || ""} caseTitle={caseData.title} />}
+        actions={
+          <>
+            {/* Staff-only "Edit case", shown at the top of the page for any
+                logged-in user (the API + admin route guards remain the
+                authorization authority). Moved here from the old bottom contact
+                strip. Opens the case admin in a new tab. */}
+            {isLoggedIn && id && (
+              <Button
+                asChild
+                variant="outline"
+                className="gap-2 border-primary/20 bg-background text-primary hover:bg-primary/5 hover:text-primary"
+              >
+                <a
+                  href={`${API_BASE_URL}/admin/cases/case/${id}/change/`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <SquarePen className="h-4 w-4" aria-hidden="true" />
+                  <span className="font-semibold">{t("caseDetail.editCase")}</span>
+                </a>
+              </Button>
+            )}
+            <ReportCaseDialog caseId={id || ""} caseTitle={caseData.title} />
+          </>
+        }
         shareAction={{
           label: t("caseDetail.shareCase"),
           onClick: handleBannerShare,
@@ -645,10 +674,8 @@ const CaseDetail = () => {
               <CaseContactStrip
                 email={JAWAFDEHI_EMAIL}
                 whatsappNumber={JAWAFDEHI_WHATSAPP_NUMBER}
-                editUrl={`${API_BASE_URL}/admin/cases/case/${id}/change/`}
                 emailLabel={t("caseDetail.emailLabel")}
                 whatsappLabel={t("caseDetail.whatsappLabel")}
-                editLabel={t("caseDetail.editCase")}
                 title={t("caseDetail.contact")}
               />
 


### PR DESCRIPTION
### **User description**
## What

Caseworker issue #1: show the "Edit case" affordance **only when the user is logged in**, and move it from the bottom of the case page up to the **top**.

Before: the "Edit case" link sat in the bottom contact strip and rendered for **everyone** (public visitors included). After: it's in the banner action row (beside Report / Share) at the top of the page, and only appears when there's an active session.

## How

Public pages (`CaseDetail`) render **outside** the admin OIDC / `CaseworkAuth` providers — those are mounted only in `AdminApp` at `/admin/*` — so `useCaseworkAuth()` isn't available here (it would throw). New `useIsLoggedIn` hook reads the persisted session directly instead:
- the dev-auth user (`getStoredDevUser`, localStorage, already SSR-guarded), and
- the OIDC user from the localStorage-backed `UserManager` singleton (`getUserManager().getUser()`, non-expired).

It answers *"is anyone signed in"*, **not** *"may they edit"* — the API and the admin route guards remain the authorization authority, and the link still opens the case admin, so a signed-in non-staff visitor hits the login/permission wall there. **SSR-safe**: starts logged-out and only flips in a client effect, so the pre-rendered/hydrated markup matches (no hydration mismatch).

`CaseContactStrip` loses the edit affordance and its now-unused `editUrl`/`editLabel` props; it keeps its email + WhatsApp buttons.

## Tests

New `useIsLoggedIn` unit test across dev-auth / non-expired OIDC / expired-OIDC / no-session. `eslint` clean; `tsc -b` introduces no new errors (the tree has pre-existing ones, unrelated). Existing `CaseDetail` suite stays green.

## Note

Independent of the `public_notes` byline PR (#236) — both touch `CaseDetail.tsx` but in different regions; they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Move edit action top

- Gate edit by login

- Add session-detection hook tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Persisted auth sessions"]
  B["useIsLoggedIn hook"]
  C["Case detail banner"]
  D["Admin edit link"]
  A -- "checked by" --> B
  B -- "controls" --> C
  C -- "renders" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-contact-strip.tsx</strong><dd><code>Remove edit action from contact strip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/case-detail/case-contact-strip.tsx

<ul><li>Remove edit-link props<br> <li> Drop <code>ExternalLink</code> import<br> <li> Keep email, WhatsApp actions</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/237/files#diff-b22a1eaa5205294836cd5161153b311497921258b2b0d00e72c4c426a756ad96">+1/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-is-logged-in.ts</strong><dd><code>Add persisted login detection hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/use-is-logged-in.ts

<ul><li>Add SSR-safe login hook<br> <li> Read dev-auth session synchronously<br> <li> Check non-expired OIDC user asynchronously<br> <li> Ignore storage/session lookup failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/237/files#diff-7509d208e3d481f7ff5dfc314f8fee43db0ebd6951fef68991db99310f45ea3a">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CaseDetail.tsx</strong><dd><code>Move logged-in edit button to banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/CaseDetail.tsx

<ul><li>Use <code>useIsLoggedIn</code> on public case page<br> <li> Render top banner edit button when logged in<br> <li> Open admin case editor in new tab<br> <li> Remove contact-strip edit props</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/237/files#diff-c20f4e307c43e31e62e4a7ff87948a8716275509e65e80b2fe949f1989070349">+30/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-is-logged-in.test.ts</strong><dd><code>Test persisted login session detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/use-is-logged-in.test.ts

<ul><li>Add <code>useIsLoggedIn</code> hook tests<br> <li> Mock dev-auth, OIDC sources<br> <li> Cover absent, dev, valid, expired sessions</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/237/files#diff-6b9b2c19de22a0b5027a181b2d83bfdc4d8d886c90a0643b5625f70f930591d7">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_reasoning_model: False
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
git_provider: github
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
