### PR TITLE
feat(search): result-click beacon — close the (query → shown → clicked) loop

### DIFF
--- a/src/pages/ArchiveSearch.tsx
+++ b/src/pages/ArchiveSearch.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/utils/archive-search-params";
 import { getFacetItemLabel } from "@/utils/case-entities";
 import { trackEvent } from "@/utils/analytics";
+import { sendSearchClick } from "@/utils/searchClick";
 
 type RefinementName = SidebarFilterName | "type";
 
@@ -532,6 +533,7 @@ function ArchiveSearchResults({
             key={`${result.type}-${result.id}`}
             rank={rankOf(index)}
             result={result}
+            searchId={data.search_id}
             searchTerm={searchTerm}
             viewMode="card"
           >
@@ -549,6 +551,7 @@ function ArchiveSearchResults({
           key={`${result.type}-${result.id}`}
           rank={rankOf(index)}
           result={result}
+          searchId={data.search_id}
           searchTerm={searchTerm}
           viewMode="list"
         >
@@ -560,18 +563,22 @@ function ArchiveSearchResults({
 }
 
 // Wraps a result so a click that navigates to the record (lands on an <a>, not a
-// tag/filter button) emits a GA4 `select_search_result` event carrying the
-// result's 1-based rank. Click-through and rank-of-first-click can only be
-// observed client-side — the server never learns which result was chosen.
+// tag/filter button) reports the selection two ways: the GA4
+// `select_search_result` event (consent-gated) AND a server-side click beacon
+// join-keyed by `searchId` (consent-free, no identity) that lets the backend
+// learn which result was chosen at what rank — the ground truth GA's ~24% sample
+// cannot give.
 function TrackedSearchResult({
   rank,
   result,
+  searchId,
   searchTerm,
   viewMode,
   children,
 }: Readonly<{
   rank: number;
   result: ArchiveSearchResult;
+  searchId?: string;
   searchTerm?: string;
   viewMode: "list" | "card";
   children: ReactNode;
@@ -583,6 +590,7 @@ function TrackedSearchResult({
       rank,
       search_term: searchTerm || undefined,
     });
+    sendSearchClick({ searchId, rank, result });
   };
   // `h-full` keeps card-grid cell heights consistent (inner card stretches to
   // fill); list view needs no wrapper sizing.

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -129,4 +129,8 @@ export interface ArchiveSearchResponse {
   facets: ArchiveSearchFacets;
   results: ArchiveSearchResult[];
   next_cursor: string | null;
+  // Ephemeral per-response id (not a user/session id). Echoed back on a result
+  // click (POST /api/search/click) to join query → clicked result server-side.
+  // Optional: older cached responses / mocks may omit it.
+  search_id?: string;
 }

--- a/src/utils/searchClick.test.ts
+++ b/src/utils/searchClick.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendSearchClick } from "./searchClick";
+import { telemetryAllowedHere } from "@/lib/telemetry";
+
+vi.mock("@/lib/telemetry", () => ({
+  telemetryAllowedHere: vi.fn(() => true),
+}));
+vi.mock("@/services/http", () => ({ API_BASE_URL: "https://api.example.test" }));
+
+const beacon = vi.fn((_url: string, _body?: string) => true);
+const result = {
+  type: "entity" as const,
+  id: "https://jawafdehi.org/entity/person/x",
+  score: 7.5,
+};
+
+beforeEach(() => {
+  vi.mocked(telemetryAllowedHere).mockReturnValue(true);
+  beacon.mockClear();
+  vi.stubGlobal("navigator", { sendBeacon: beacon });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("sendSearchClick", () => {
+  it("beacons the join key + clicked result to /api/search/click", () => {
+    sendSearchClick({ searchId: "sid-9", rank: 3, result });
+    expect(beacon).toHaveBeenCalledTimes(1);
+    const [url, body] = beacon.mock.calls[0];
+    expect(url).toBe("https://api.example.test/api/search/click");
+    expect(JSON.parse(body as string)).toEqual({
+      search_id: "sid-9",
+      rank: 3,
+      result_type: "entity",
+      result_id: "https://jawafdehi.org/entity/person/x",
+      result_score: 7.5,
+    });
+  });
+
+  it("no-ops when search_id is absent (nothing to join to)", () => {
+    sendSearchClick({ searchId: undefined, rank: 1, result });
+    expect(beacon).not.toHaveBeenCalled();
+  });
+
+  it("no-ops on dev/localhost/preview hosts (not consent — host gating)", () => {
+    vi.mocked(telemetryAllowedHere).mockReturnValue(false);
+    sendSearchClick({ searchId: "sid-9", rank: 1, result });
+    expect(beacon).not.toHaveBeenCalled();
+  });
+
+  it("swallows a sendBeacon failure (never affects navigation)", () => {
+    beacon.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    expect(() =>
+      sendSearchClick({ searchId: "sid-9", rank: 1, result }),
+    ).not.toThrow();
+  });
+});

--- a/src/utils/searchClick.ts
+++ b/src/utils/searchClick.ts
@@ -1,0 +1,61 @@
+/**
+ * Search result-click beacon.
+ *
+ * Fire-and-forget POST to /api/search/click recording that a search result was
+ * clicked, join-keyed by the response's `search_id` to the query that produced
+ * it. Together with the server-side `search_query` log this closes the loop into
+ * (query → shown → clicked) judgments for future relevance tuning.
+ *
+ * Deliberately NOT consent-gated — unlike the GA4 `select_search_result` event
+ * (which only fires when gtag is loaded, i.e. after consent). The beacon carries
+ * NO identity, sets no cookies, and is the unbiased ground-truth denominator the
+ * ~24%-consented GA sample cannot provide. It is still suppressed on
+ * dev/localhost/preview hosts (`telemetryAllowedHere`) so throwaway traffic never
+ * pollutes production analytics.
+ *
+ * Transport is `navigator.sendBeacon`: it survives the click-then-navigate unload
+ * and posts `text/plain` (a CORS-safelisted content type → no preflight), which
+ * the endpoint parses from the raw body. Any failure is swallowed — a beacon must
+ * never affect the click or navigation.
+ */
+
+import { telemetryAllowedHere } from "@/lib/telemetry";
+import { API_BASE_URL } from "@/services/http";
+import type { ArchiveSearchResult } from "@/types/search";
+
+export interface SearchClickBeacon {
+  searchId: string | undefined;
+  rank: number;
+  result: Pick<ArchiveSearchResult, "type" | "id" | "score">;
+}
+
+export function sendSearchClick({
+  searchId,
+  rank,
+  result,
+}: SearchClickBeacon): void {
+  // No search_id (older cached response / mock) → nothing to join to.
+  if (!searchId) return;
+  // Dev/localhost/preview: never beacon (mirrors GA/Sentry host gating).
+  if (!telemetryAllowedHere()) return;
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.sendBeacon !== "function"
+  ) {
+    return;
+  }
+
+  const payload = JSON.stringify({
+    search_id: searchId,
+    rank,
+    result_type: result.type,
+    result_id: result.id,
+    result_score: result.score,
+  });
+
+  try {
+    navigator.sendBeacon(`${API_BASE_URL}/api/search/click`, payload);
+  } catch {
+    // Best-effort: a beacon failure must never affect the click/navigation.
+  }
+}


### PR DESCRIPTION
### **User description**
## Why

Final piece of the search-analytics seam. The search response carries an ephemeral `search_id` (API #349) and there's now a `POST /api/search/click` endpoint (API #353). This PR wires the SPA to fire that beacon on a result click — closing the loop into **`(query → shown → clicked)`** judgments joined server-side by `search_id`, the ground-truth signal for the deferred relevance tuning. Still instrumentation only.

## What

On a result click that navigates to the record (lands on an `<a>`, same seam as the GA `select_search_result` event), `TrackedSearchResult` now also calls `sendSearchClick(...)` → `navigator.sendBeacon('/api/search/click', {search_id, rank, result_type, result_id, result_score})`.

- `src/utils/searchClick.ts` — `sendSearchClick` (new).
- `src/types/search.ts` — optional `search_id` on `ArchiveSearchResponse`.
- `src/pages/ArchiveSearch.tsx` — thread `search_id` into `TrackedSearchResult`; fire beacon beside the GA event.

## Design / privacy — please sanity-check

- **Not consent-gated, on purpose.** The GA `select_search_result` event only fires after cookie consent (~24% of humans). The beacon is the *reason* we built the server side: it carries **no identity, sets no cookies**, and gives the unbiased full-traffic denominator. It fires regardless of GA consent. → This is the one privacy posture call worth your eyes; if you'd rather gate it on consent too, it's a one-line change.
- **Still host-gated.** Suppressed on dev/localhost/CF-preview via `telemetryAllowedHere()` (same gate as GA/Sentry) so throwaway traffic never pollutes prod analytics — the GA4 dev-pollution problem we already hit.
- **`sendBeacon`** survives click-then-navigate and posts `text/plain` (CORS-safelisted → no preflight); the endpoint parses the raw body. Best-effort: no-ops without a `search_id`, and any failure is swallowed (never affects the click/navigation).

## Tests / checks

- `src/utils/searchClick.test.ts` (vitest, 4): correct URL + payload; no-op without `search_id`; host-gate suppression; failure swallowed.
- Changed files: **eslint clean, tsc-clean, `vite build` OK**.
- ⚠️ Pre-existing/unrelated: 3 `tests/ssr/worker.*` failures reproduce on pristine `main` (verified with my changes stashed) — not touched by this PR.

## Depends on

API #353 (`POST /api/search/click`). If this ships before that deploys, the beacon just no-ops server-side (best-effort) — no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add search click beacon

- Thread `search_id` into results

- Guard dev hosts, missing IDs

- Cover beacon behavior with tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search response"] -- "provides search_id" --> B["TrackedSearchResult"]
  B -- "clicks link" --> C["sendSearchClick"]
  C -- "beacons payload" --> D["POST /api/search/click"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArchiveSearch.tsx</strong><dd><code>Wire search click beacon into results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/ArchiveSearch.tsx

<ul><li>Import <code>sendSearchClick</code><br> <li> Pass <code>data.search_id</code> into <code>TrackedSearchResult</code><br> <li> Fire click beacon beside GA event<br> <li> Document GA plus server beacon behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/238/files#diff-8f11c86850e392a44e5b229a529863ae6e96f2dc7d2b8ab51bcab1c744d5e282">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search.ts</strong><dd><code>Add search response join key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/search.ts

<ul><li>Add optional <code>search_id</code><br> <li> Document ephemeral join key purpose<br> <li> Preserve compatibility with older mocks</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/238/files#diff-8dd01c30ab5e9d596af32c61f4d72c40a7bba4665d25f25227ed1f26d5acdfc1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>searchClick.ts</strong><dd><code>Implement search click beacon utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/searchClick.ts

<ul><li>Add <code>sendSearchClick</code><br> <li> Build click payload with result metadata<br> <li> Use <code>navigator.sendBeacon</code><br> <li> No-op safely on missing ID, blocked host, unsupported API, failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/238/files#diff-fe36674771fb58130ca41d53e6435e47955036bfdaaf47545664fd647d7d5f6f">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>searchClick.test.ts</strong><dd><code>Cover search click beacon behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/searchClick.test.ts

<ul><li>Test beacon URL and payload<br> <li> Test missing <code>search_id</code> no-op<br> <li> Test host gating no-op<br> <li> Test <code>sendBeacon</code> failure swallowing</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/238/files#diff-b106499ce932c2b93435c218fe624c3a4875a6d106c33e2bef3b04c5271261cc">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
fallback_models: ['openai/cx/gpt-5.4-mini']
custom_reasoning_model: False
custom_model_max_tokens: 200000
output_relevant_configurations: True
model: openai/cx/gpt-5.5
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
