### PR TITLE
feat(case-detail): show the case short description atop the banner (#6)

### DIFF
--- a/src/components/case-detail/case-detail-banner.test.tsx
+++ b/src/components/case-detail/case-detail-banner.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import type { CaseDetail } from "@/types/jds";
+import { CaseDetailBanner } from "@/components/case-detail/case-detail-banner";
+
+// Passthrough translations so assertions don't depend on i18n resources
+// (mirrors case-overview-section.test.tsx). t() returns its fallback or the key.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) =>
+      typeof fallback === "string" ? fallback : key,
+    i18n: { language: "en" },
+  }),
+}));
+
+const SHORT_DESC = "A concise one-line summary of what this case is about.";
+
+const makeCase = (overrides: Partial<CaseDetail> = {}): CaseDetail => ({
+  id: 7,
+  slug: "test-case",
+  case_type: "CORRUPTION",
+  state: "PUBLISHED",
+  title: "Test case title",
+  short_description: SHORT_DESC,
+  case_start_date: null,
+  case_end_date: null,
+  entities: [],
+  tags: [],
+  key_allegations: [],
+  court_cases: [],
+  bigo: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  description: "",
+  timeline: [],
+  evidence: [],
+  notes: "",
+  missing_details: null,
+  ...overrides,
+});
+
+const renderBanner = (caseData: CaseDetail) =>
+  render(
+    <MemoryRouter>
+      <CaseDetailBanner caseData={caseData} resolvedEntities={{}} />
+    </MemoryRouter>,
+  );
+
+describe("CaseDetailBanner short_description deck (#6)", () => {
+  it("renders the short description as a lead at the top of the case", () => {
+    renderBanner(makeCase());
+    expect(screen.getByText(SHORT_DESC)).toBeTruthy();
+    // Still alongside the title.
+    expect(screen.getByText("Test case title")).toBeTruthy();
+  });
+
+  it("omits the deck when short_description is only whitespace", () => {
+    const { container } = renderBanner(makeCase({ short_description: "   " }));
+    expect(container.textContent).not.toContain(SHORT_DESC);
+    expect(screen.getByText("Test case title")).toBeTruthy();
+  });
+
+  it("omits the deck when short_description is null", () => {
+    renderBanner(makeCase({ short_description: null }));
+    expect(screen.getByText("Test case title")).toBeTruthy();
+  });
+});

--- a/src/components/case-detail/case-detail-banner.tsx
+++ b/src/components/case-detail/case-detail-banner.tsx
@@ -241,6 +241,16 @@ export function CaseDetailBanner({
                 ))}
               </div>
 
+              {/* Short description as a lead/deck under the status badge — the
+                  one-line "what is this case" summary at the top of the page.
+                  Authored content, rendered as-is (like the title/description),
+                  not run through the dynamic-text map. */}
+              {caseData.short_description?.trim() ? (
+                <p className="mb-5 max-w-3xl text-base font-medium leading-relaxed text-primary/80 md:text-lg">
+                  {caseData.short_description}
+                </p>
+              ) : null}
+
               <div className="space-y-2">
                 <div>
                   <p className={metaTitleClass}>{t("caseDetail.location")}:</p>


### PR DESCRIPTION
### **User description**
## What

Caseworker issue #6: show the **short description** (+ case status) at the **top** of the case detail page. The status badge was already in the banner; this adds the `short_description` beside it.

Adds `short_description` as a lead / deck paragraph in the banner, directly **under the status / type / tag badges** — the one-line "what is this case about" summary at the top of the page. It was already returned by the API and typed on the case, but never rendered on the detail page (only on cards / search results).

## How

- One conditional `<p>` in `CaseDetailBanner`, styled as an understated deck (`text-base md:text-lg`, `text-primary/80`).
- Rendered **as-is** like the title and description (authored content — not run through the dynamic-text map).
- Hidden when the field is empty / whitespace / null.

## Tests

New `case-detail-banner.test.tsx` (the component had none) covering the present / whitespace / null cases. `eslint` clean; `tsc -b` adds no new errors (the one pre-existing banner error at line 121 is unrelated).

This completes the seven caseworker issues from 2026-07-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Show case short description in banner

- Hide empty or whitespace descriptions

- Add banner rendering tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  caseData["CaseDetail short_description"]
  banner["CaseDetailBanner"]
  deck["Lead paragraph under badges"]
  tests["Vitest coverage"]
  caseData -- "conditional render" --> banner
  banner -- "displays" --> deck
  tests -- "verifies" --> banner
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-detail-banner.tsx</strong><dd><code>Add short description deck to banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/case-detail/case-detail-banner.tsx

<ul><li>Renders <code>caseData.short_description</code> below badges<br> <li> Uses trim check for empty values<br> <li> Keeps authored text unmapped</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/239/files#diff-1d626c0c2e38329e3a988dfcaf66f65800ff76302b670f18b9034e6e1e47be11">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-detail-banner.test.tsx</strong><dd><code>Cover banner short description rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/case-detail/case-detail-banner.test.tsx

<ul><li>Adds <code>CaseDetailBanner</code> test setup<br> <li> Mocks <code>react-i18next</code> translations<br> <li> Covers present, whitespace, null descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/239/files#diff-7efd40fe18403203ad145a8cd6f5c8afa2bfbb299c6dd2c688e3c0960190ab12">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
fallback_models: ['openai/cx/gpt-5.4-mini']
custom_reasoning_model: False
custom_model_max_tokens: 200000
output_relevant_configurations: True
model: openai/cx/gpt-5.5
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
