### PR TITLE
feat(cases): add Banking Offence case type

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -481,6 +481,7 @@
       "illegalProperty": "Illegal Property",
       "examRigging": "Exam Rigging",
       "taxEvasion": "Tax Evasion",
+      "bankingOffence": "Banking Offence",
       "misconduct": "Misconduct",
       "breachOfTrust": "Breach of Trust",
       "mediaTrial": "Media Trial"

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -481,6 +481,7 @@
       "illegalProperty": "गैरकानूनी सम्पत्ति",
       "examRigging": "परीक्षा अनियमितता",
       "taxEvasion": "कर छली",
+      "bankingOffence": "बैंकिङ कसुर",
       "misconduct": "दुर्व्यवहार",
       "breachOfTrust": "विश्वासको उल्लङ्घन",
       "mediaTrial": "मिडिया ट्रायल"

--- a/src/lib/jawafdehi-forms.ts
+++ b/src/lib/jawafdehi-forms.ts
@@ -22,6 +22,7 @@ export const CASE_TYPES: readonly CaseType[] = [
   "ILLEGAL_PROPERTY",
   "EXAM_RIGGING",
   "TAX_EVASION",
+  "BANKING_OFFENCE",
 ];
 
 export const CASE_STATES: readonly CaseState[] = [

--- a/src/types/jds.ts
+++ b/src/types/jds.ts
@@ -20,7 +20,8 @@ export type CaseType =
   | 'MONEY_LAUNDERING'
   | 'ILLEGAL_PROPERTY'
   | 'EXAM_RIGGING'
-  | 'TAX_EVASION';
+  | 'TAX_EVASION'
+  | 'BANKING_OFFENCE';
 
 export type CaseState =
   | 'DRAFT'

--- a/src/utils/case-entities.ts
+++ b/src/utils/case-entities.ts
@@ -43,6 +43,7 @@ const CASE_TYPE_LABEL_KEYS: Record<string, string> = {
   ILLEGAL_PROPERTY: "cases.type.illegalProperty",
   EXAM_RIGGING: "cases.type.examRigging",
   TAX_EVASION: "cases.type.taxEvasion",
+  BANKING_OFFENCE: "cases.type.bankingOffence",
 };
 
 /**

--- a/tests/case-entities.test.ts
+++ b/tests/case-entities.test.ts
@@ -54,6 +54,7 @@ describe('getCaseTypeLabelKey', () => {
   it('maps known case types', () => {
     expect(getCaseTypeLabelKey('CORRUPTION')).toBe('cases.type.corruption');
     expect(getCaseTypeLabelKey('TAX_EVASION')).toBe('cases.type.taxEvasion');
+    expect(getCaseTypeLabelKey('BANKING_OFFENCE')).toBe('cases.type.bankingOffence');
   });
 
   it('is case-insensitive (scraped court types vary in casing)', () => {


### PR DESCRIPTION
### **User description**
Surfaces the new `BANKING_OFFENCE` case type (backend: Jawafdehi/JawafdehiAPI#) in the admin case-type dropdown and the case-detail badge, with localized labels.

## What
- `src/types/jds.ts` — `BANKING_OFFENCE` added to the `CaseType` union.
- `src/utils/case-entities.ts` — label-key map → `cases.type.bankingOffence`.
- `src/lib/jawafdehi-forms.ts` — added to the admin `CASE_TYPES` dropdown list.
- `src/i18n/locales/{en,ne}.json` — EN "Banking Offence" / NE बैंकिङ कसुर.
- `tests/case-entities.test.ts` — spot-check assertion.

Badge styling needs no change: only `CORRUPTION` has a bespoke pill color; every other type (incl. money laundering) uses the default primary style, and banking offence inherits it.

## Checks
- `vitest run` green
- production build (swc) green
- `eslint` clean

Pairs with the backend enum addition — merge after/with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `BANKING_OFFENCE` case type

- Surface option in admin forms

- Map localized display labels

- Cover label-key lookup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  type["CaseType union"] -- "adds" --> form["Admin case types"]
  type -- "maps" --> labels["Label keys"]
  labels -- "localizes" --> i18n["EN/NE labels"]
  labels -- "tests" --> tests["Lookup coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jawafdehi-forms.ts</strong><dd><code>Add banking offence form option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/jawafdehi-forms.ts

<ul><li>Adds <code>BANKING_OFFENCE</code> to <code>CASE_TYPES</code><br> <li> Makes new type selectable in forms</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-1f01ebf1fe1ba10b4d93d24c15b2dbce3b59f131da558e367e066e66b6c8c029">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>jds.ts</strong><dd><code>Extend case type union</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/jds.ts

- Extends `CaseType` union
- Adds `BANKING_OFFENCE` enum value


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-e3fcc474c2b2f1966c105401246cf3e6202a7774cdbcfebe5bdba93243a48bbd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>case-entities.ts</strong><dd><code>Map banking offence label key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/case-entities.ts

- Maps `BANKING_OFFENCE`
- Uses `cases.type.bankingOffence` label key


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-773eb4c04655e84d0acbc816af112bd037e5b7a7fa9a19a9c99e4c9cd78ecf65">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-entities.test.ts</strong><dd><code>Test banking offence mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/case-entities.test.ts

<ul><li>Adds <code>BANKING_OFFENCE</code> mapping assertion<br> <li> Verifies expected i18n key</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-f8c9ad70ac12fe2cfbee46b0ad784c0c3d04975e5b7b25db0bbc8758749a9959">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English banking offence label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en.json

- Adds English `bankingOffence` label
- Displays as `Banking Offence`


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ne.json</strong><dd><code>Add Nepali banking offence label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/ne.json

- Adds Nepali `bankingOffence` label
- Displays as `बैंकिङ कसुर`


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/240/files#diff-e088c4713e8d7635691c3b76d5456c12cfd747832c7dea0a6f5a09ea3672cd53">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
fallback_models: ['openai/cx/gpt-5.4-mini']
custom_reasoning_model: False
custom_model_max_tokens: 200000
output_relevant_configurations: True
model: openai/cx/gpt-5.5
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
