### PR TITLE
fix(cases): render public_notes byline on screen, not only in print

### DIFF
--- a/src/components/case-detail/case-detail-banner.test.tsx
+++ b/src/components/case-detail/case-detail-banner.test.tsx
@@ -68,3 +68,17 @@ describe("CaseDetailBanner short_description deck (#6)", () => {
     expect(screen.getByText("Test case title")).toBeTruthy();
   });
 });
+
+describe("CaseDetailBanner public_notes byline (on-screen)", () => {
+  it("renders the public_notes byline on screen (not just in the print block)", () => {
+    renderBanner(makeCase({ public_notes: "Case drafted by the casework team." }));
+    const byline = screen.getByTestId("case-byline");
+    expect(byline).toBeTruthy();
+    expect(byline.textContent).toContain("Case drafted by the casework team.");
+  });
+
+  it("renders nothing when public_notes is empty", () => {
+    renderBanner(makeCase({ public_notes: "" }));
+    expect(screen.queryByTestId("case-byline")).toBeNull();
+  });
+});

--- a/src/components/case-detail/case-detail-banner.tsx
+++ b/src/components/case-detail/case-detail-banner.tsx
@@ -16,6 +16,7 @@ import { parseCourtCaseRef } from "@/utils/courtCaseRef";
 import { translateDynamicText } from "@/lib/translate-dynamic-content";
 import { formatBigo } from "@/utils/number";
 import { getCaseTypeLabelKey } from "@/utils/case-entities";
+import { CaseByline } from "@/components/case-detail/case-byline";
 
 interface CaseDetailBannerProps {
   caseData: CaseDetail;
@@ -321,6 +322,12 @@ export function CaseDetailBanner({
                     </div>
                   </div>
                 )}
+
+                {/* Public caseworker-authored attribution + edit-history byline
+                    (Case.public_notes). On-screen counterpart to the print-only
+                    block in CaseDetail; the banner is no-print, so it renders on
+                    screen without duplicating in the PDF. Empty = nothing shown. */}
+                <CaseByline markdown={caseData.public_notes} />
               </div>
 
               {actions || shareAction ? (


### PR DESCRIPTION
### **User description**
## Problem

The `CaseByline` (public `Case.public_notes` attribution / edit-history byline, added in #236) was rendered **only** inside `CaseDetail`'s `hidden print:block` metadata block. That block is `display:none` on screen and shows only in the print/PDF view — so the byline never appeared on the live case page.

**Verified against prod with a headless browser:** the `[data-testid="case-byline"]` element was present in the DOM with the correct text (e.g. `Case drafted by …`) but had a `0x0` box and no `offsetParent` — its ancestor `div.mb-8.hidden.print:block` was `display:none`.

## Fix

Also render `<CaseByline markdown={caseData.public_notes} />` in `CaseDetailBanner`'s metadata block (after the court-cases row). The banner is `no-print`, and the print block keeps its own byline, so:

- **screen** → banner byline shows ✓
- **print/PDF** → print-block byline shows, banner (and its byline) hidden ✓
- no duplication — mirroring how location / period / embezzled-amount are already rendered in both the banner (screen) and the print block.

Empty `public_notes` still renders nothing (the component returns `null`).

## Tests

`case-detail-banner.test.tsx`: added two cases — byline renders on screen when `public_notes` is set, and nothing renders when empty. Full banner suite green (5/5). eslint clean; no new type errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Show case byline on screen

- Keep print behavior unchanged

- Add banner byline tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Case public_notes"] -- "passes to" --> B["CaseByline"]
  B -- "renders in" --> C["CaseDetailBanner"]
  C -- "visible on" --> D["Screen"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-detail-banner.tsx</strong><dd><code>Add on-screen case byline rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/case-detail/case-detail-banner.tsx

<ul><li>Imports <code>CaseByline</code><br> <li> Renders <code>CaseByline</code> in banner metadata<br> <li> Mirrors print-only byline for screen display<br> <li> Keeps empty <code>public_notes</code> rendering null</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/242/files#diff-1d626c0c2e38329e3a988dfcaf66f65800ff76302b670f18b9034e6e1e47be11">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case-detail-banner.test.tsx</strong><dd><code>Cover banner public notes byline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/case-detail/case-detail-banner.test.tsx

<ul><li>Tests byline rendering with <code>public_notes</code><br> <li> Tests no byline for empty <code>public_notes</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/242/files#diff-7efd40fe18403203ad145a8cd6f5c8afa2bfbb299c6dd2c688e3c0960190ab12">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
