### PR TITLE
fix(spa): auto-reload stale tabs on chunk-load failure; unblock Sentry/GA4/RUM in CSP

### DIFF
--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -13,6 +13,23 @@ import './i18n/config';
 
 initSentry();
 
+// A Cloudflare Workers Builds deploy swaps every hashed asset atomically, so a
+// tab still running a previous build 404s when it lazy-loads a route chunk whose
+// hash no longer exists — the edge serves index.html in its place, which trips
+// "Failed to fetch dynamically imported module" and drops the user on the error
+// boundary (e.g. opening /data-quality after a deploy). Vite fires
+// `vite:preloadError` for exactly this; reload once to pull the fresh index.html
+// and its current chunk names. The sessionStorage cooldown stops a reload loop
+// when the failure is genuine (offline, real 5xx) rather than a stale build.
+window.addEventListener('vite:preloadError', (event) => {
+  const RELOAD_KEY = 'jds:chunk-reload-at';
+  const lastReload = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0);
+  if (Date.now() - lastReload < 10_000) return;
+  sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+  event.preventDefault();
+  window.location.reload();
+});
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 5 * 60 * 1000, retry: 1 } },
 });

--- a/worker.ts
+++ b/worker.ts
@@ -44,8 +44,15 @@ interface FeedVideo {
 }
 
 function securityHeaders(): Record<string, string> {
+  // Third-party allowances layered onto the same-origin baseline:
+  //   script-src  — googletagmanager (GA4 gtag.js) + cloudflareinsights (RUM beacon.min.js)
+  //   connect-src — *.ingest.de.sentry.io (Sentry envelopes), googletagmanager +
+  //                 *.google-analytics.com / *.analytics.google.com (GA4 collect),
+  //                 cloudflareinsights.com (RUM /cdn-cgi/rum POST)
+  // Without these the SPA loads gtag/Sentry/RUM but the browser blocks every
+  // request, so analytics silently record nothing and prod errors never reach Sentry.
   return {
-    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.jawafdehi.org https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://auth.jawafdehi.org; worker-src 'self' blob:;",
+    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.jawafdehi.org https://portal.jawafdehi.org https://jawafdehi.org https://nes.jawafdehi.org https://auth.jawafdehi.org https://*.ingest.de.sentry.io https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cloudflareinsights.com; worker-src 'self' blob:;",
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
     'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',


### PR DESCRIPTION
### **User description**
## What broke

`https://jawafdehi.org/data-quality` showed **"Something went wrong."** for a user, with:

```
assets/DataQuality-ykUw0Mtk.js  →  MIME "text/html"  (SPA index.html fallback)
TypeError: Failed to fetch dynamically imported module: .../assets/DataQuality-ykUw0Mtk.js
```

## Root cause — stale tab after a deploy

`/data-quality` is a lazy route (`App.tsx`: `lazy(() => import("./pages/DataQuality"))`). A **CF Workers Builds deploy replaces every hashed asset atomically**, so a tab still running the *previous* build 404s when it lazy-loads a route chunk whose hash no longer exists — the edge returns `index.html` in its place (`content-type: text/html`), the module import fails, and it hits the `ErrorBoundary`.

Verified against production:
- old chunk `DataQuality-ykUw0Mtk.js` → now serves `text/html` (purged)
- live `index.html` → `index-DID9wXcZ.js` → `DataQuality-CgA3SbqC.js` → serves `text/javascript` **200**

So **a fresh load already works** — the deploy is fine. The gap is that the SPA had **no chunk-load-error recovery** (`grep` for `vite:preloadError` → nothing), so any tab left open across a deploy hard-fails on its next lazy navigation.

## Fix 1 — auto-reload stale tabs (`entry-client.tsx`)

Add a `vite:preloadError` listener that reloads once, guarded by a `sessionStorage` cooldown so a genuine offline/5xx failure can't loop. Vite dispatches this event from its preload helper on exactly this failure; confirmed wired in the built bundle (`vite:preloadError` appears twice — Vite's dispatcher + this listener).

## Fix 2 — unblock Sentry / GA4 / CF RUM in CSP (`worker.ts`)

The deployed CSP has, since the July-2 v2 cutover, omitted the Sentry ingest host, `googletagmanager`/`google-analytics` hosts, and the Cloudflare Insights beacon — so **client errors never reached Sentry** (which is why this breakage went unnoticed) and the client `gtag` path recorded nothing. Added:
- `script-src`: `www.googletagmanager.com`, `static.cloudflareinsights.com`
- `connect-src`: `*.ingest.de.sentry.io`, `www.googletagmanager.com`, `www.google-analytics.com`, `*.google-analytics.com`, `*.analytics.google.com`, `cloudflareinsights.com`

## Verification
- `tsc -b`: no new errors in changed files (pre-existing main red is unrelated)
- `eslint worker.ts src/entry-client.tsx`: clean
- `vite build`: succeeds; handler present and wired in `index-*.js`

## Not in scope (flagged separately)
`api/cases/080-C4-2408/` 404s — a link to a case slug that doesn't exist (unpublished / slug-changed). `worker.ts` already has a `LEGACY_CASE_MAP` redirect path that could cover it; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Reload stale SPA tabs once

- Restore Sentry, GA4, RUM CSP access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  stale["Stale SPA tab"]
  preload["vite:preloadError"]
  reload["One-time reload"]
  csp["Expanded CSP"]
  telemetry["Sentry GA4 RUM"]
  stale -- "missing chunk" --> preload
  preload -- "cooldown guarded" --> reload
  csp -- "allows requests" --> telemetry
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entry-client.tsx</strong><dd><code>Add guarded stale chunk reload recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/entry-client.tsx

<ul><li>Adds <code>vite:preloadError</code> listener.<br> <li> Reloads once after stale chunk failures.<br> <li> Uses <code>sessionStorage</code> cooldown guard.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/243/files#diff-311f1bfe99dd31d43562780221a057cc4f1e6cdc5725b97144d4aba77c6b6863">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.ts</strong><dd><code>Expand CSP for telemetry endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.ts

<ul><li>Documents third-party CSP requirements.<br> <li> Allows GA4 script and collection endpoints.<br> <li> Allows Sentry ingest and Cloudflare RUM.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/243/files#diff-330a94350ac07edfd25eb4bbe98201b91ce9087fe792dc5c1fa6d2ed215576ce">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically refreshes the page once when a deployment causes a stale or unavailable application resource to load, helping users recover without encountering an error screen.
  * Improved compatibility with analytics, monitoring, and performance tools by updating browser security permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->