### PR TITLE
fix(courtcase): human-readable cause title instead of the raw id

### DIFF
--- a/src/components/CourtCaseCard.test.tsx
+++ b/src/components/CourtCaseCard.test.tsx
@@ -96,4 +96,50 @@ describe("CourtCaseCard", () => {
       container.querySelector('a[href="/courtcase/special/080-cr-0111"]'),
     ).toBeTruthy();
   });
+
+  it("uses the party cause title as the heading, demoting the court/number id", () => {
+    // Core shape (compact registry party strings, no entities) — the "…समेत N"
+    // et-al form a Special Court criminal docket carries.
+    const registryCase = {
+      ...coreCase,
+      case_number: "082-CR-0154",
+      court_identifier: "special",
+      plaintiff: "नेपाल सरकार",
+      defendant: "प्रतिवादी समेत २",
+    } as CourtCase;
+
+    render(
+      <MemoryRouter>
+        <CourtCaseCard
+          courtCaseId="https://jawafdehi.org/courtcase/special/082-cr-0154"
+          courtCase={registryCase}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    // Heading is the human-readable "<plaintiff> <versus> <defendant>" cause
+    // title — never the raw "special:082-cr-0154" identifier.
+    expect(screen.getByText("नेपाल सरकार v. प्रतिवादी समेत २")).toBeTruthy();
+    // The canonical court/number reference is kept as a demoted sub-line.
+    expect(screen.getByText("082-CR-0154 (Special Court)")).toBeTruthy();
+    expect(screen.queryByText(/special:082-cr-0154/i)).toBeNull();
+  });
+
+  it("falls back to the court/number identifier when no parties are known", () => {
+    const bare = { ...coreCase, plaintiff: null, defendant: null } as CourtCase;
+
+    render(
+      <MemoryRouter>
+        <CourtCaseCard
+          courtCaseId="https://jawafdehi.org/courtcase/special/080-cr-0111"
+          courtCase={bare}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    // No parties → the identifier is the heading itself (no duplicate sub-line).
+    expect(screen.getByText("080-CR-0111 (Special Court)")).toBeTruthy();
+  });
 });

--- a/src/components/CourtCaseCard.tsx
+++ b/src/components/CourtCaseCard.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import type { CourtCase, CourtCaseHearing } from "@/types/jds";
 import { parseCourtCaseRef } from "@/utils/courtCaseRef";
+import { getCourtCaseCauseTitle, getPartiesByRole } from "@/utils/courtCase";
 import { formatDateWithBS } from "@/utils/date";
 import { cn } from "@/lib/utils";
 
@@ -47,38 +48,6 @@ function parseCourtIdentifier(
   }
 
   return { courtName, caseNumber };
-}
-
-// ── Defendant/Plaintiff from entities ────────────────────────────────────
-
-function getPartiesByRole(courtCase: CourtCase): {
-  plaintiffs: string[];
-  defendants: string[];
-} {
-  const plaintiffs: string[] = [];
-  const defendants: string[] = [];
-
-  // `entities` is only populated on the assembled "full" court case; the core
-  // shape used on the case-detail page omits it. Default to [] so the string
-  // plaintiff/defendant fallback below still renders instead of crashing.
-  for (const entity of courtCase.entities ?? []) {
-    const side = entity.side?.toLowerCase();
-    if (side === "plaintiff" || side === "वादी") {
-      plaintiffs.push(entity.name);
-    } else if (side === "defendant" || side === "प्रतिवादी") {
-      defendants.push(entity.name);
-    }
-  }
-
-  // Fall back to string fields if entities list is empty
-  if (plaintiffs.length === 0 && courtCase.plaintiff) {
-    plaintiffs.push(courtCase.plaintiff);
-  }
-  if (defendants.length === 0 && courtCase.defendant) {
-    defendants.push(courtCase.defendant);
-  }
-
-  return { plaintiffs, defendants };
 }
 
 function getStatusTone(status: string | null | undefined) {
@@ -167,11 +136,15 @@ export function CourtCaseCard({ courtCaseId, courtCase, isLoading, linkToDetail 
   const detailPath = linkToDetail ? courtCaseDetailPath(courtCaseId) : null;
   const lastUpdate = courtCase ? getLatestCourtUpdate(courtCase) : null;
 
-  const headerText = (
-    <span className="break-words">
-      {caseNumber ? `${caseNumber} (${courtName})` : courtName}
-    </span>
-  );
+  // Heading = the cause title (parties) when known; the court/number identifier
+  // is demoted to a sub-line so the canonical reference is never lost. Without
+  // party data (loading / bare ref) the identifier is the heading itself.
+  const causeTitle = courtCase
+    ? getCourtCaseCauseTitle(courtCase, t("caseDetail.courtVersus", "v."))
+    : null;
+  const identifier = caseNumber ? `${caseNumber} (${courtName})` : courtName;
+
+  const headerText = <span className="break-words">{causeTitle ?? identifier}</span>;
 
   return (
     <div className="rounded-lg border border-border p-4">
@@ -189,6 +162,11 @@ export function CourtCaseCard({ courtCaseId, courtCase, isLoading, linkToDetail 
             <span className="inline-flex min-w-0 flex-wrap items-center gap-1.5 text-base font-semibold leading-6 text-primary md:text-lg">
               {headerText}
             </span>
+          )}
+          {causeTitle && (
+            <p className="mt-0.5 break-words text-xs font-normal text-primary/55">
+              {identifier}
+            </p>
           )}
         </div>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -599,6 +599,7 @@
     "courtHearing": "Hearing",
     "courtPlaintiff": "Plaintiff",
     "courtDefendant": "Defendant",
+    "courtVersus": "v.",
     "courtHearings": "Hearings",
     "courtHearingDate": "Hearing Date",
     "courtHearingStatus": "Status",

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -597,6 +597,7 @@
     "courtHearing": "सुनुवाइ",
     "courtPlaintiff": "वादी",
     "courtDefendant": "प्रतिवादी",
+    "courtVersus": "विरुद्ध",
     "courtHearings": "सुनुवाइहरू",
     "courtHearingDate": "सुनवाइ मिती",
     "courtHearingStatus": "मुद्दाको स्थिती",

--- a/src/pages/CourtCaseProfile.tsx
+++ b/src/pages/CourtCaseProfile.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, ArrowLeft } from "lucide-react";
 
@@ -7,10 +8,12 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { CourtCaseCard } from "@/components/CourtCaseCard";
 import { getCourtCaseFull } from "@/services/datalake-api";
+import { getCourtCaseCauseTitle } from "@/utils/courtCase";
 
 // The /courtcase/* splat tail is the courtcase IRI path component
-// `<court>/<case_number>` (e.g. `special/081-CR-0079`). CourtCaseCard wants the
-// legacy `<court>:<case_number>` id form, so we convert on the way in.
+// `<court>/<case_number>` (e.g. `special/081-CR-0079`); we rebuild the canonical
+// @id IRI from it (see `courtCaseIri`) and pass that to CourtCaseCard, whose
+// parser accepts only the IRI form.
 function parseTail(tail: string): { court: string; caseNumber: string } | null {
   const i = tail.indexOf("/");
   if (i === -1) return null;
@@ -23,10 +26,10 @@ function parseTail(tail: string): { court: string; caseNumber: string } | null {
 }
 
 export default function CourtCaseProfile() {
+  const { t } = useTranslation();
   const params = useParams();
   const tail = params["*"] || "";
   const parsed = parseTail(tail);
-  const courtCaseId = parsed ? `${parsed.court}:${parsed.caseNumber}` : "";
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["datalake-courtcase", parsed?.court, parsed?.caseNumber],
@@ -43,8 +46,15 @@ export default function CourtCaseProfile() {
   const courtCaseIri = parsed
     ? `https://jawafdehi.org/courtcase/${parsed.court.toLowerCase()}/${parsed.caseNumber.toLowerCase()}`
     : "";
+  // Prefer the human-readable cause title ("<plaintiff> विरुद्ध <defendant>") for
+  // the tab title / JSON-LD name; fall back to the bare case number when the
+  // parties are unknown.
+  const causeTitle = data
+    ? getCourtCaseCauseTitle(data, t("caseDetail.courtVersus", "v."))
+    : null;
+  const heading = causeTitle || caseNumber;
   const title = data
-    ? `${caseNumber} — ${data.case_type || "Court case"}`
+    ? `${heading} — ${data.case_type || "Court case"}`
     : caseNumber || "Court case";
 
   // schema.org JSON-LD for crawlers (parity with the retired R2 landing pages). A
@@ -92,7 +102,7 @@ export default function CourtCaseProfile() {
           </Alert>
         ) : (
           <article className="space-y-6">
-            <CourtCaseCard courtCaseId={courtCaseId} courtCase={data} isLoading={isLoading} />
+            <CourtCaseCard courtCaseId={courtCaseIri} courtCase={data} isLoading={isLoading} />
 
             {/* Provenance. */}
             <div className="rounded-xl border bg-muted/30 p-4 text-xs text-muted-foreground">

--- a/src/utils/courtCase.ts
+++ b/src/utils/courtCase.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure derivations over a court-case record (parties, cause title).
+ *
+ * Kept out of the CourtCaseCard component so these can be reused (e.g. the
+ * CourtCaseProfile tab title / JSON-LD) without importing a component module,
+ * and so the component file only exports components (react-refresh clean).
+ */
+
+import type { CourtCase } from "@/types/jds";
+
+// ── Defendant/Plaintiff from entities ────────────────────────────────────
+
+export function getPartiesByRole(courtCase: CourtCase): {
+  plaintiffs: string[];
+  defendants: string[];
+} {
+  const plaintiffs: string[] = [];
+  const defendants: string[] = [];
+
+  // `entities` is only populated on the assembled "full" court case; the core
+  // shape used on the case-detail page omits it. Default to [] so the string
+  // plaintiff/defendant fallback below still renders instead of crashing.
+  for (const entity of courtCase.entities ?? []) {
+    const side = entity.side?.toLowerCase();
+    if (side === "plaintiff" || side === "वादी") {
+      plaintiffs.push(entity.name);
+    } else if (side === "defendant" || side === "प्रतिवादी") {
+      defendants.push(entity.name);
+    }
+  }
+
+  // Fall back to string fields if entities list is empty
+  if (plaintiffs.length === 0 && courtCase.plaintiff) {
+    plaintiffs.push(courtCase.plaintiff);
+  }
+  if (defendants.length === 0 && courtCase.defendant) {
+    defendants.push(courtCase.defendant);
+  }
+
+  return { plaintiffs, defendants };
+}
+
+// The court-case cause title — "<plaintiff> <versus> <defendant>" — the
+// human-readable name for the case (e.g. "नेपाल सरकार विरुद्ध प्रतिवादी समेत २").
+// Prefers the compact registry `plaintiff`/`defendant` strings (which already
+// carry the "…समेत N" et-al form); falls back to the first entity per side, then
+// to whichever single party is known. Returns null when neither party is known
+// (callers fall back to the court/number identifier).
+export function getCourtCaseCauseTitle(
+  courtCase: CourtCase,
+  versus: string,
+): string | null {
+  const { plaintiffs, defendants } = getPartiesByRole(courtCase);
+  const plaintiff = courtCase.plaintiff?.trim() || plaintiffs[0] || "";
+  const defendant = courtCase.defendant?.trim() || defendants[0] || "";
+  if (plaintiff && defendant) return `${plaintiff} ${versus} ${defendant}`;
+  return defendant || plaintiff || null;
+}


### PR DESCRIPTION
### **User description**
## Problem

The court-case detail page (e.g. `/courtcase/special/082-cr-0154`) rendered its heading as the raw machine string **`special:082-cr-0154`**.

Root cause is a stale contract: `CourtCaseProfile` handed `CourtCaseCard` the retired `<court>:<case_number>` colon form, but `parseCourtCaseRef` was since changed to accept **only** the canonical `@id` IRI. The card's parser returned `null` and fell through to printing the identifier verbatim — on *every* court-case page. Even once parsed, the best that logic produced was a bare `082-CR-0154 (Special Court)` number, not a real name.

## Change

| | Before | After |
|---|---|---|
| Heading | `special:082-cr-0154` | **नेपाल सरकार विरुद्ध &lt;defendant&gt;** (NE) / **… v. …** (EN) |
| Sub-line | — | `082-CR-0154 (Special Court)` (muted — canonical ref kept) |
| Tab / JSON-LD `name` | `082-cr-0154 — <case_type>` | cause title `— <case_type>` |

- **Regression fix:** pass the canonical IRI (already computed as `courtCaseIri`) to `CourtCaseCard`, so its parser succeeds.
- **Good name:** derive a cause title `"<plaintiff> <versus> <defendant>"` from the case data and use it as the heading; demote the court/number identifier to a muted sub-line so the canonical reference is never lost. Falls back to the identifier when parties are unknown (loading / bare ref).
- Reuse the cause title for the tab title / JSON-LD `name`.
- Extract pure `getPartiesByRole` / `getCourtCaseCauseTitle` into `src/utils/courtCase.ts` (keeps the component react-refresh clean; reusable by the page).
- New `courtVersus` i18n key (`v.` / `विरुद्ध`).

Data-driven, so it improves every court-case page and the related-case cards on Jawafdehi case pages.

## Verification

- Full FE test suite: **241/241 pass**, including 2 new `CourtCaseCard` tests that render the real docket shape and assert the cause title renders while `special:082-cr-0154` never appears.
- `eslint` clean on changed files; no new `tsc` errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix court-case heading identifier regression

- Show party-based cause titles

- Reuse title in metadata

- Add i18n key, regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CourtCaseProfile"] -- "passes canonical IRI" --> B["CourtCaseCard"]
  B -- "derives heading" --> C["Cause title"]
  C -- "falls back" --> D["Court/number identifier"]
  C -- "updates" --> E["Tab title JSON-LD"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CourtCaseCard.test.tsx</strong><dd><code>Add court-case cause title tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/CourtCaseCard.test.tsx

<ul><li>Adds cause-title heading regression test<br> <li> Verifies identifier sub-line remains visible<br> <li> Verifies fallback without parties</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-c5210a434eb94374b588cada6026dfee53441b5bf5c6fa1194f4ece86713e555">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CourtCaseCard.tsx</strong><dd><code>Render party cause title headings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/CourtCaseCard.tsx

<ul><li>Imports shared court-case utilities<br> <li> Uses <code>getCourtCaseCauseTitle</code> for heading<br> <li> Demotes court/number identifier to sub-line<br> <li> Falls back to identifier without parties</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-a10ee285e17f0cb3b43cb004479002e775315c16614174bb6fd61d06f08c8322">+15/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CourtCaseProfile.tsx</strong><dd><code>Use canonical IRI and cause metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/CourtCaseProfile.tsx

<ul><li>Passes canonical <code>courtCaseIri</code> to card<br> <li> Builds metadata title from cause title<br> <li> Adds translation hook for <code>courtVersus</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-2c8eb34039690b0dbb0930e2110943c9cb0c7c874306777ca183cc29536c616f">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>courtCase.ts</strong><dd><code>Extract court-case party title helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/courtCase.ts

<ul><li>Adds reusable <code>getPartiesByRole</code><br> <li> Adds <code>getCourtCaseCauseTitle</code><br> <li> Supports entity and string-party fallbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-ce690cdd4777cc0aa1c4a1a249760cafe83a7d8aa96dc4bfd2c9d7d57f27f0dd">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English versus translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en.json

- Adds English `caseDetail.courtVersus`


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ne.json</strong><dd><code>Add Nepali versus translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/ne.json

- Adds Nepali `caseDetail.courtVersus`


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/251/files#diff-e088c4713e8d7635691c3b76d5456c12cfd747832c7dea0a6f5a09ea3672cd53">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Court case cards now display a clearer heading using plaintiff and defendant names.
  * Case number and court details appear as a secondary line when party names are available.
  * Added localized “versus” labels in English and Nepali.
  * Court case profiles now use more readable titles and improved fallback headings.

* **Bug Fixes**
  * Removed raw internal identifiers from visible case headings.
  * Prevented duplicate case identifiers when party information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->