### PR TITLE
feat(entities): entity/material images, full record fields, View-JSON popup, and document modal

### DIFF
--- a/src/services/entity-adapters.test.ts
+++ b/src/services/entity-adapters.test.ts
@@ -46,6 +46,40 @@ describe('jsonLdToEntity', () => {
     expect(() => e.pictures?.find(() => true)).not.toThrow();
   });
 
+  describe('image mapping -> pictures[]', () => {
+    const withImage = (image: unknown) =>
+      jsonLdToEntity({ '@id': 'https://jawafdehi.org/entity/organization/sebon', name: { en: 'SEBON' }, image });
+
+    it('maps a schema.org image URL string to a single full picture', () => {
+      const e = withImage('https://s3.jawafdehi.org/entities/sebon.png');
+      expect(e.pictures).toEqual([{ type: 'full', url: 'https://s3.jawafdehi.org/entities/sebon.png' }]);
+    });
+
+    it('reads an ImageObject via url or contentUrl', () => {
+      expect(withImage({ '@type': 'ImageObject', url: 'https://x/u.png' }).pictures).toEqual([
+        { type: 'full', url: 'https://x/u.png' },
+      ]);
+      expect(withImage({ contentUrl: 'https://x/c.png' }).pictures).toEqual([
+        { type: 'full', url: 'https://x/c.png' },
+      ]);
+    });
+
+    it('maps an array of images, skipping blanks', () => {
+      const e = withImage(['https://x/a.png', '  ', { url: 'https://x/b.png' }]);
+      expect(e.pictures).toEqual([
+        { type: 'full', url: 'https://x/a.png' },
+        { type: 'full', url: 'https://x/b.png' },
+      ]);
+    });
+
+    it('is [] for absent, blank, or unusable image so the type-icon fallback stands', () => {
+      expect(withImage(undefined).pictures).toEqual([]);
+      expect(withImage('   ').pictures).toEqual([]);
+      expect(withImage({}).pictures).toEqual([]);
+      expect(withImage(42).pictures).toEqual([]);
+    });
+  });
+
   it('tolerates a missing/empty name and a bare-string name', () => {
     expect(jsonLdToEntity({ '@id': 'https://jawafdehi.org/entity/person/x' }).names).toEqual([]);
     const s = jsonLdToEntity({ '@id': 'https://jawafdehi.org/entity/person/y', name: 'Plain Name' });

--- a/src/services/entity-adapters.ts
+++ b/src/services/entity-adapters.ts
@@ -8,7 +8,7 @@
  * - Backend types: https://github.com/Jawafdehi/NepalEntityService-Tundikhel/blob/main/src/common/nes-types.ts
  */
 
-import type { Entity, Attribution, Name, EntityType } from '@/types/entity';
+import type { Entity, Attribution, Name, EntityType, EntityPicture } from '@/types/entity';
 
 // ============================================================================
 // schema.org JSON-LD -> Entity adapter
@@ -18,9 +18,9 @@ import type { Entity, Attribution, Name, EntityType } from '@/types/entity';
 // but the SPA's Entity model is the NES shape (names: Name[], pictures: [], contacts: [], ...).
 // Without this adaptation, consumers that read entity.names (e.g. getPrimaryName) throw
 // "Cannot read properties of undefined (reading 'find')" and take the whole case page down.
-// Map the fields the UI actually reads (name -> names[], @id/@type -> type, empty arrays for the
-// collections it iterates) and drop the rest of the schema.org payload, which the case/entity
-// views don't consume.
+// Map the fields the UI actually reads (name -> names[], @id/@type -> type, image -> pictures[],
+// empty arrays for the other collections it iterates) and drop the rest of the schema.org payload,
+// which the case/entity views don't consume.
 type JsonLdName = string | { en?: string | null; ne?: string | null } | null | undefined;
 
 interface EntityJsonLd {
@@ -29,6 +29,7 @@ interface EntityJsonLd {
   id?: string;
   name?: JsonLdName;
   description?: unknown;
+  image?: unknown;
   dateCreated?: string;
   [k: string]: unknown;
 }
@@ -64,6 +65,28 @@ function entityTypeFromJsonLd(iri: string, atType: string): EntityType {
   return 'person';
 }
 
+// NES stores an optional schema.org `image` on the entity JSON-LD — a URL string, an ImageObject
+// ({ url } / { contentUrl }), or an array of either. Surface it as the SPA's pictures[] so the avatar
+// consumers render it: CaseEntityChips.getEntityImage and EntityProfileHeader read pictures[].url,
+// preferring type 'thumb' then 'full'. One logical image -> one 'full' entry; absent/blank -> [] so
+// the type-icon fallback stands.
+function toPictures(image: unknown): EntityPicture[] {
+  const urlOf = (v: unknown): string | undefined => {
+    if (typeof v === 'string') return v.trim() || undefined;
+    if (v && typeof v === 'object') {
+      const o = v as { url?: unknown; contentUrl?: unknown };
+      const u = typeof o.url === 'string' ? o.url : typeof o.contentUrl === 'string' ? o.contentUrl : '';
+      return u.trim() || undefined;
+    }
+    return undefined;
+  };
+  const items = Array.isArray(image) ? image : [image];
+  return items
+    .map(urlOf)
+    .filter((u): u is string => !!u)
+    .map((url) => ({ type: 'full' as const, url }));
+}
+
 export function jsonLdToEntity(input: unknown): Entity {
   const raw = (input ?? {}) as EntityJsonLd;
   const iri = raw['@id'] ?? raw.id ?? '';
@@ -81,15 +104,16 @@ export function jsonLdToEntity(input: unknown): Entity {
   const description = toLangText(raw.description);
   const createdAt = typeof raw.dateCreated === 'string' ? raw.dateCreated : '';
 
-  // Empty collections keep the array-iterating consumers (pictures/contacts/...) safe. JSON-LD
-  // carries no version history, so version_summary is a neutral placeholder (version 0, no author)
-  // — filled rather than cast away so the Entity contract stays fully type-checked.
+  // pictures come from the schema.org `image` (toPictures); the remaining empty collections keep the
+  // array-iterating consumers (contacts/identifiers/...) safe. JSON-LD carries no version history, so
+  // version_summary is a neutral placeholder (version 0, no author) — filled rather than cast away so
+  // the Entity contract stays fully type-checked.
   return {
     id: iri,
     slug,
     type,
     names,
-    pictures: [],
+    pictures: toPictures(raw.image),
     contacts: [],
     identifiers: [],
     tags: [],


### PR DESCRIPTION
Renders entity images end-to-end and polishes the entity/material **record pages** (read path). No backend change — NES already stores + serves the schema.org `image`; the API was the only missing link on the adapter, and the record pages render the JSON-LD directly.

## Entity images
- **Adapter** (`entity-adapters.ts`): map the stored schema.org `image` → `pictures[]` (string / ImageObject / array) so the avatar consumers render it (was hardcoded `pictures: []`).
- **Type-aware fit** across `CaseEntityChips`, `EntityCard`, `EntityProfileHeader`, `EntityDetailContainer`: `object-contain` for **org/location logos** (wide marks no longer center-cropped) and `object-cover` for **person portraits**.
- **`EntityRecordProfile`** (`/entity/*`): render the `image`/`logo` as an actual image instead of dumping the URL as a generic text row (which also mangled the URL via the slug-humanizer).

## Show all record fields (entity page)
- Surface previously-hidden fields: **Created** (`dateCreated`), **Also known as** (`alternateName`), and a **Revision** provenance line (`jawafdehi:version`).

## View JSON popup
- New `ViewJsonButton`: a **popup** (`Dialog`) showing the record's raw JSON-LD with **Copy** + **Open raw**, reusing the already-fetched record. On **entity + material** record pages — deliberately **not** on corruption case pages.

## Material document preview
- `MaterialProfile` document sources now open in the shared **`DocumentPreviewDialog`** modal — **View PDF** / **View transcript** (PDFs + markdown/text), instead of a bare "Download document" link. Non-previewable formats (source pages, doc/docx) stay as external links.

## Tests / checks
- `entity-adapters.test.ts`: +4 image-mapping cases (15/15 pass). eslint clean; `bun run build` succeeds. `/document-preview` proxy verified locally (returns the PDF) so the modal works in dev too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)