### PR TITLE
feat(entities): record-page images, full fields, View-JSON popup, and document modal

### DIFF
--- a/src/components/CaseEntityChips.tsx
+++ b/src/components/CaseEntityChips.tsx
@@ -101,7 +101,11 @@ export function CaseEntityChips({
             <>
               <Avatar className="h-16 w-16 border border-border/80 shadow-sm transition-transform group-hover:scale-105">
                 {imageUrl ? (
-                  <AvatarImage src={imageUrl} alt={displayName} className="object-cover" />
+                  <AvatarImage
+                    src={imageUrl}
+                    alt={displayName}
+                    className={entity?.type === "person" ? "object-cover" : "object-contain bg-white"}
+                  />
                 ) : null}
                 <AvatarFallback className="bg-muted text-muted-foreground">
                   {getFallbackIcon(jawafEntity, entity)}

--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -77,7 +77,11 @@ const EntityCard = ({ entity, jawafEntity }: EntityCardProps) => {
           <div className="flex items-start gap-4">
             <Avatar className="w-16 h-16 flex-shrink-0">
               {profilePicUrl ? (
-                <AvatarImage src={profilePicUrl} alt={primaryName} className="object-cover" />
+                <AvatarImage
+                  src={profilePicUrl}
+                  alt={primaryName}
+                  className={entity?.type === "person" ? "object-cover" : "object-contain bg-white"}
+                />
               ) : null}
               <AvatarFallback className="bg-muted">
                 {isOrganization ? (

--- a/src/components/EntityDetailContainer.tsx
+++ b/src/components/EntityDetailContainer.tsx
@@ -155,7 +155,11 @@ export function EntityDetailContainer({
           <div className="flex flex-col md:flex-row gap-6">
             {/* Photo/Avatar */}
             <Avatar className="w-32 h-32 rounded-lg flex-shrink-0">
-              <AvatarImage src={photoUrl} alt={primaryName} className="object-cover" />
+              <AvatarImage
+                src={photoUrl}
+                alt={primaryName}
+                className={entity?.type === "person" ? "object-cover" : "object-contain bg-white"}
+              />
               <AvatarFallback className="rounded-lg bg-muted">
                 {isOrganization ? (
                   <Building2 className="w-16 h-16 text-muted-foreground" />

--- a/src/components/EntityProfileHeader.tsx
+++ b/src/components/EntityProfileHeader.tsx
@@ -47,7 +47,11 @@ const EntityProfileHeader = ({
         <div className="flex flex-col md:flex-row gap-6">
           {/* Photo/Avatar */}
           <Avatar className="w-32 h-32 rounded-lg flex-shrink-0">
-            <AvatarImage src={photoUrl} alt={primaryName} className="object-cover" />
+            <AvatarImage
+              src={photoUrl}
+              alt={primaryName}
+              className={entity.type === "person" ? "object-cover" : "object-contain bg-white"}
+            />
             <AvatarFallback className="rounded-lg bg-muted">
               {isOrganization ? (
                 <Building2 className="w-16 h-16 text-muted-foreground" />

--- a/src/components/ViewJsonButton.tsx
+++ b/src/components/ViewJsonButton.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from "react";
+import { Braces, Check, Copy, ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ViewJsonButtonProps {
+  data: unknown;
+  title?: string;
+  rawUrl?: string;
+  disabled?: boolean;
+}
+
+// A small "View JSON" affordance for record pages (entities, materials): opens a popup
+// showing the record's raw JSON-LD, pretty-printed — mirroring the document-source preview
+// dialog. Copy-to-clipboard + an "open raw" link to the API endpoint are included. It reuses
+// the already-fetched record, so opening the popup makes no extra request.
+export function ViewJsonButton({ data, title = "Raw JSON", rawUrl, disabled }: Readonly<ViewJsonButtonProps>) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const json = useMemo(() => (data == null ? "" : JSON.stringify(data, null, 2)), [data]);
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(json).then(
+      () => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      },
+      () => undefined,
+    );
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground"
+        disabled={disabled || data == null}
+        onClick={() => setOpen(true)}
+      >
+        <Braces className="mr-1 h-4 w-4" aria-hidden="true" />
+        View JSON
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="w-[min(96vw,880px)] max-w-none gap-0 overflow-hidden p-0">
+          <DialogHeader className="border-b px-4 py-3 text-left">
+            <DialogTitle className="flex items-center gap-2 pr-8 text-base">
+              <Braces className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span className="truncate">{title}</span>
+            </DialogTitle>
+            <DialogDescription className="sr-only">Raw JSON-LD record</DialogDescription>
+          </DialogHeader>
+
+          <div className="p-4">
+            <div className="mb-2 flex items-center gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={copy}>
+                {copied ? (
+                  <Check className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                ) : (
+                  <Copy className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+              {rawUrl ? (
+                <Button asChild size="sm" variant="outline">
+                  <a href={rawUrl} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                    Open raw
+                  </a>
+                </Button>
+              ) : null}
+            </div>
+            <pre className="max-h-[68vh] overflow-auto rounded-lg bg-[#0b0b0c] p-4 text-xs leading-relaxed text-slate-100">
+              {json}
+            </pre>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/ViewJsonButton.tsx
+++ b/src/components/ViewJsonButton.tsx
@@ -27,7 +27,7 @@ export function ViewJsonButton({ data, title = "Raw JSON", rawUrl, disabled }: R
   const json = useMemo(() => (data == null ? "" : JSON.stringify(data, null, 2)), [data]);
 
   const copy = () => {
-    void navigator.clipboard?.writeText(json).then(
+    void navigator.clipboard?.writeText(json)?.then(
       () => {
         setCopied(true);
         window.setTimeout(() => setCopied(false), 1500);
@@ -79,7 +79,10 @@ export function ViewJsonButton({ data, title = "Raw JSON", rawUrl, disabled }: R
                 </Button>
               ) : null}
             </div>
-            <pre className="max-h-[68vh] overflow-auto rounded-lg bg-[#0b0b0c] p-4 text-xs leading-relaxed text-slate-100">
+            <pre
+              tabIndex={0}
+              className="max-h-[68vh] overflow-auto rounded-lg bg-[#0b0b0c] p-4 text-xs leading-relaxed text-slate-100"
+            >
               {json}
             </pre>
           </div>

--- a/src/pages/EntityRecordProfile.tsx
+++ b/src/pages/EntityRecordProfile.tsx
@@ -1,10 +1,12 @@
+import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, AlertTriangle, ArrowLeft, ExternalLink } from "lucide-react";
 
-import { http } from "@/services/http";
+import { http, API_BASE_URL } from "@/services/http";
 import { entityPath } from "@/lib/entity-links";
+import { ViewJsonButton } from "@/components/ViewJsonButton";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -43,6 +45,8 @@ interface EntityRecord {
   dateCreated?: string;
   foundingDate?: string;
   leader?: string;
+  image?: unknown;
+  logo?: unknown;
   containedInPlace?: JsonLdRef;
   parentOrganization?: JsonLdRef;
   "jawafdehi:version"?: VersionInfo;
@@ -111,12 +115,12 @@ const FIELD_LABELS: Record<string, string> = {
   "jawafdehi:registrationDateBS": "Registered (BS)",
 };
 
-// Keys handled explicitly elsewhere (header/relations/links/identifiers/provenance)
+// Keys handled explicitly elsewhere (header/image/relations/links/identifiers/provenance)
 // or that are pure plumbing — never shown in the generic Details list.
 const HANDLED_KEYS = new Set([
   "@id", "@type", "@context", "additionalType", "name", "alternateName",
   "description", "address", "url", "sameAs", "identifier", "dateCreated",
-  "containedInPlace", "parentOrganization", "jawafdehi:version",
+  "containedInPlace", "parentOrganization", "jawafdehi:version", "image", "logo",
 ]);
 
 function labelFor(key: string): string {
@@ -134,6 +138,28 @@ function scalar(v: unknown): string | null {
     return [b.en, b.ne].filter(Boolean).join(" · ") || null;
   }
   return null;
+}
+
+// schema.org image/logo -> a single URL (a plain string, an ImageObject via url/contentUrl,
+// or an array of either). Returns undefined when there's nothing usable.
+function imageUrlOf(rec: EntityRecord | undefined): string | undefined {
+  const pick = (v: unknown): string | undefined => {
+    if (typeof v === "string") return v.trim() || undefined;
+    if (Array.isArray(v)) {
+      for (const x of v) {
+        const u = pick(x);
+        if (u) return u;
+      }
+      return undefined;
+    }
+    if (v && typeof v === "object") {
+      const o = v as { url?: unknown; contentUrl?: unknown };
+      if (typeof o.url === "string" && o.url.trim()) return o.url.trim();
+      if (typeof o.contentUrl === "string" && o.contentUrl.trim()) return o.contentUrl.trim();
+    }
+    return undefined;
+  };
+  return pick(rec?.image) ?? pick(rec?.logo);
 }
 
 function RelationLink({ label, refObj }: { label: string; refObj?: JsonLdRef }) {
@@ -159,6 +185,7 @@ function RelationLink({ label, refObj }: { label: string; refObj?: JsonLdRef }) 
 export default function EntityRecordProfile() {
   const params = useParams();
   const tail = params["*"] || "";
+  const [imgOk, setImgOk] = useState(true);
   const { data, isLoading, isError } = useQuery({
     queryKey: ["entity-record", tail],
     queryFn: async () => {
@@ -181,6 +208,12 @@ export default function EntityRecordProfile() {
       : data?.address?.description || data?.address?.streetAddress || "";
   const identifiers = Array.isArray(data?.identifier) ? data!.identifier! : [];
   const blacklisted = data?.["jawafdehi:blacklisted"] === true;
+  const imageUrl = imageUrlOf(data);
+  const aliases = Array.isArray(data?.alternateName)
+    ? data!.alternateName!.map((a) => bilingual(a)).map((b) => b.en || b.ne).filter(Boolean)
+    : [];
+  const created = data?.dateCreated ? String(data.dateCreated).slice(0, 10) : "";
+  const version = data?.["jawafdehi:version"];
 
   // Generic details: any presentable scalar field not handled elsewhere.
   const detailRows: Array<{ label: string; value: string }> = [];
@@ -204,12 +237,22 @@ export default function EntityRecordProfile() {
       </Helmet>
 
       <div className="container mx-auto max-w-3xl px-4">
-        <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
-          <Link to="/search?type=entity">
-            <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
-            Back to search
-          </Link>
-        </Button>
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <Button asChild variant="ghost" size="sm" className="-ml-2">
+            <Link to="/search?type=entity">
+              <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+              Back to search
+            </Link>
+          </Button>
+          {tail ? (
+            <ViewJsonButton
+              data={data}
+              title={`${displayName} — JSON-LD`}
+              rawUrl={`${API_BASE_URL}/api/entities/${tail}`}
+              disabled={!data}
+            />
+          ) : null}
+        </div>
 
         {isError ? (
           <Alert variant="destructive">
@@ -228,6 +271,17 @@ export default function EntityRecordProfile() {
         ) : data ? (
           <article className="space-y-6">
             <header className="space-y-2">
+              {imageUrl && imgOk ? (
+                <div className="mb-1 flex h-24 w-fit items-center justify-center overflow-hidden rounded-xl border bg-white p-3">
+                  <img
+                    src={imageUrl}
+                    alt={displayName}
+                    loading="lazy"
+                    className="max-h-full max-w-[16rem] object-contain"
+                    onError={() => setImgOk(false)}
+                  />
+                </div>
+              ) : null}
               <Badge variant="outline" className="capitalize">{typeLabel}</Badge>
               <h1 className="text-3xl font-extrabold text-primary md:text-4xl">{displayName}</h1>
               {name.ne && name.ne !== displayName ? (
@@ -302,6 +356,12 @@ export default function EntityRecordProfile() {
                   <dd className="mt-1 text-sm text-foreground">{id.value}</dd>
                 </div>
               ))}
+              {aliases.length > 0 ? (
+                <div className="sm:col-span-2">
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Also known as</dt>
+                  <dd className="mt-1 text-sm text-foreground">{aliases.join(" · ")}</dd>
+                </div>
+              ) : null}
               <div className="sm:col-span-2">
                 <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Canonical ID</dt>
                 <dd className="mt-1 break-all font-mono text-xs text-muted-foreground">{data["@id"]}</dd>
@@ -309,11 +369,19 @@ export default function EntityRecordProfile() {
             </dl>
 
             {/* Provenance. */}
-            <div className="rounded-xl border bg-muted/30 p-4 text-xs text-muted-foreground">
+            <div className="space-y-1 rounded-xl border bg-muted/30 p-4 text-xs text-muted-foreground">
               <p>
                 <strong>Source:</strong> Jawafdehi entity registry — a public registry of Nepal&apos;s
                 people, organizations, and places.
               </p>
+              {created ? <p>Created {created}.</p> : null}
+              {version ? (
+                <p>
+                  Revision {version.version_number ?? "?"}
+                  {version.created_at ? ` · updated ${String(version.created_at).slice(0, 10)}` : ""}
+                  {version.change_description ? ` · ${version.change_description}` : ""}
+                </p>
+              ) : null}
             </div>
           </article>
         ) : null}

--- a/src/pages/EntityRecordProfile.tsx
+++ b/src/pages/EntityRecordProfile.tsx
@@ -185,7 +185,7 @@ function RelationLink({ label, refObj }: { label: string; refObj?: JsonLdRef }) 
 export default function EntityRecordProfile() {
   const params = useParams();
   const tail = params["*"] || "";
-  const [imgOk, setImgOk] = useState(true);
+  const [failedImgUrl, setFailedImgUrl] = useState<string | null>(null);
   const { data, isLoading, isError } = useQuery({
     queryKey: ["entity-record", tail],
     queryFn: async () => {
@@ -271,14 +271,14 @@ export default function EntityRecordProfile() {
         ) : data ? (
           <article className="space-y-6">
             <header className="space-y-2">
-              {imageUrl && imgOk ? (
+              {imageUrl && imageUrl !== failedImgUrl ? (
                 <div className="mb-1 flex h-24 w-fit items-center justify-center overflow-hidden rounded-xl border bg-white p-3">
                   <img
                     src={imageUrl}
                     alt={displayName}
                     loading="lazy"
                     className="max-h-full max-w-[16rem] object-contain"
-                    onError={() => setImgOk(false)}
+                    onError={() => setFailedImgUrl(imageUrl)}
                   />
                 </div>
               ) : null}

--- a/src/pages/MaterialProfile.tsx
+++ b/src/pages/MaterialProfile.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
@@ -9,6 +10,9 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { humanizeEntityType } from "@/utils/entity-helpers";
 import { getMaterial, type Material, type MaterialBilingual } from "@/services/datalake-api";
+import { API_BASE_URL } from "@/services/http";
+import { ViewJsonButton } from "@/components/ViewJsonButton";
+import { DocumentPreviewDialog, type PreviewDocument } from "@/components/DocumentPreviewDialog";
 
 // ─── value helpers (a material is schema.org JSON-LD, same family as entities) ──
 
@@ -91,21 +95,42 @@ const ROLE_LABELS: Record<string, string> = {
 interface MediaLink {
   contentUrl?: string;
   url?: string;
+  encodingFormat?: string;
+  "jawafdehi:linkRole"?: string;
   "jawafdehi:role"?: string;
   role?: string;
   name?: string;
 }
 
-function sourceLinks(data: Material | undefined): Array<{ href: string; label: string }> {
+// PDFs and markdown/text transcripts open in the shared document modal; source
+// pages and other formats (doc/docx) stay as external links.
+function previewTypeOf(m: MediaLink, href: string, role: string): PreviewDocument["type"] | undefined {
+  const fmt = (m.encodingFormat || "").toLowerCase();
+  const ext = (href.split("?")[0].split(".").pop() || "").toLowerCase();
+  if (fmt.includes("pdf") || ext === "pdf") return "pdf";
+  if (role === "MARKDOWN" || fmt.includes("markdown") || ext === "md" || ext === "markdown") return "markdown";
+  return undefined;
+}
+
+type MaterialSourceLink = { href: string; label: string; previewType?: PreviewDocument["type"] };
+
+function sourceLinks(data: Material | undefined): MaterialSourceLink[] {
   if (!data) return [];
   const media = data.associatedMedia;
   const arr: MediaLink[] = Array.isArray(media) ? media : media ? [media as MediaLink] : [];
-  const links: Array<{ href: string; label: string }> = [];
+  const links: MaterialSourceLink[] = [];
   for (const m of arr) {
     const href = m.contentUrl || m.url;
     if (!href) continue;
-    const role = m["jawafdehi:role"] || m.role || "";
-    links.push({ href, label: ROLE_LABELS[role] || m.name || ROLE_LABELS.RAW });
+    const role = (m["jawafdehi:linkRole"] || m["jawafdehi:role"] || m.role || "").toUpperCase();
+    const previewType = previewTypeOf(m, href, role);
+    const label =
+      previewType === "pdf"
+        ? "View PDF"
+        : previewType === "markdown"
+          ? "View transcript"
+          : ROLE_LABELS[role] || m.name || ROLE_LABELS.RAW;
+    links.push({ href, label, previewType });
   }
   return links;
 }
@@ -131,6 +156,7 @@ export default function MaterialProfile() {
   const fullText = data ? bilingual((data.text as MaterialBilingual | string | undefined)) : { en: "", ne: "" };
   const fullTextStr = fullText.en || fullText.ne;
   const links = sourceLinks(data);
+  const [previewDocument, setPreviewDocument] = useState<PreviewDocument | null>(null);
 
   // Generic details: any presentable scalar field not handled elsewhere.
   const detailRows: Array<{ label: string; value: string }> = [];
@@ -170,12 +196,22 @@ export default function MaterialProfile() {
       </Helmet>
 
       <div className="container mx-auto max-w-3xl px-4">
-        <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
-          <Link to="/search?type=material">
-            <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
-            Back to search
-          </Link>
-        </Button>
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <Button asChild variant="ghost" size="sm" className="-ml-2">
+            <Link to="/search?type=material">
+              <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+              Back to search
+            </Link>
+          </Button>
+          {tail ? (
+            <ViewJsonButton
+              data={data}
+              title={`${displayName} — JSON-LD`}
+              rawUrl={`${API_BASE_URL}/api/materials/${tail}`}
+              disabled={!data}
+            />
+          ) : null}
+        </div>
 
         {isError ? (
           <Alert variant="destructive">
@@ -206,13 +242,28 @@ export default function MaterialProfile() {
             {/* Source documents + external links. */}
             {links.length > 0 || data.url ? (
               <div className="flex flex-wrap gap-2">
-                {links.map((l) => (
-                  <Button asChild key={l.href} variant="outline" size="sm">
-                    <a href={l.href} target="_blank" rel="noopener noreferrer">
-                      {l.label} <ExternalLink className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
-                    </a>
-                  </Button>
-                ))}
+                {links.map((l) =>
+                  l.previewType ? (
+                    <Button
+                      key={l.href}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        setPreviewDocument({ title: displayName, type: l.previewType!, url: l.href })
+                      }
+                    >
+                      <FileText className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                      {l.label}
+                    </Button>
+                  ) : (
+                    <Button asChild key={l.href} variant="outline" size="sm">
+                      <a href={l.href} target="_blank" rel="noopener noreferrer">
+                        {l.label} <ExternalLink className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
+                      </a>
+                    </Button>
+                  ),
+                )}
                 {data.url && links.length === 0 ? (
                   <Button asChild variant="outline" size="sm">
                     <a href={data.url} target="_blank" rel="noopener noreferrer">
@@ -265,6 +316,14 @@ export default function MaterialProfile() {
           </article>
         ) : null}
       </div>
+
+      <DocumentPreviewDialog
+        document={previewDocument}
+        open={Boolean(previewDocument)}
+        onOpenChange={(open) => {
+          if (!open) setPreviewDocument(null);
+        }}
+      />
     </main>
   );
 }


### PR DESCRIPTION
### **User description**
Follow-on to #253 (which shipped the `image`→`pictures[]` adapter). This polishes the entity/material **record pages** (read path). No backend change — the record pages render the JSON-LD the API already serves.

## Entity images on the record page
- **`EntityRecordProfile`** (`/entity/*`): render the schema.org `image`/`logo` as an actual image instead of dumping the URL as a generic text row (which also mangled the URL via the slug-humanizer, e.g. `bhrikuti stock broking.png`).
- **Type-aware avatar fit** across `CaseEntityChips`, `EntityCard`, `EntityProfileHeader`, `EntityDetailContainer`: `object-contain` for **org/location logos** (wide marks no longer center-cropped) + `object-cover` for **person portraits**.

## Show all record fields
- Surface previously-hidden entity fields: **Created** (`dateCreated`), **Also known as** (`alternateName`), and a **Revision** provenance line (`jawafdehi:version`).

## View JSON popup
- New `ViewJsonButton`: a **popup** (`Dialog`) showing the record's raw JSON-LD with **Copy** + **Open raw**, reusing the already-fetched record. On **entity + material** record pages — deliberately **not** on corruption case pages.

## Material document preview
- `MaterialProfile` document sources now open in the shared **`DocumentPreviewDialog`** modal — **View PDF** / **View transcript** (PDF + markdown/text) — instead of a bare "Download document" link. Non-previewable formats (source pages, doc/docx) stay as external links.

## Checks
- eslint clean; `bun run build` succeeds; adapter tests 15/15. `/document-preview` proxy verified in dev (returns the PDF), so the modal works locally too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add record JSON popup

- Render entity images/logos

- Preserve logo aspect fit

- Preview material PDFs/transcripts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  records["Record pages"]
  json["ViewJsonButton dialog"]
  images["Entity image/logo rendering"]
  previews["DocumentPreviewDialog previews"]
  records -- "show raw data" --> json
  records -- "display media" --> images
  records -- "open sources" --> previews
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>CaseEntityChips.tsx</strong><dd><code>Type-aware entity avatar image fitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-0ae084ded28435b931b84a6c4002283c27bc26dd54e36073357d25fd07f47364">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EntityCard.tsx</strong><dd><code>Type-aware card avatar image fitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-a6385310fb787a40497dfb1ab6cb590041eb0f8c693b58cad5e60c5e2a4955f0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EntityDetailContainer.tsx</strong><dd><code>Type-aware detail avatar image fitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-6f6ea26fb0a0d6e868eee2914ed1d044b7d72815559ecdca4d718520320e78ae">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EntityProfileHeader.tsx</strong><dd><code>Type-aware profile avatar image fitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-0eb179dd3fa70a2554d537884dcd7be714a7e9e53072600cfdf2e787702c78b8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ViewJsonButton.tsx</strong><dd><code>Add reusable raw JSON dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-7a10f88daf6801091eef232979a99d6ed1ab4658f71a9400d65e148613e97085">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EntityRecordProfile.tsx</strong><dd><code>Render images, metadata, JSON viewer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-1bf2059e444c1e66abf63e5f86e0aea250be717cfb064ebe4d54ed66f9c89823">+78/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MaterialProfile.tsx</strong><dd><code>Add JSON viewer and document previews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/254/files#diff-6e765d4a0406a7768c25dad6190c6f91413f89c323eefcace88c55db273b97c8">+76/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “View JSON” dialog with pretty-printed output, copy-to-clipboard, and an optional “Open raw” link.
  * Added in-app previews for supported documents (PDFs and markdown/transcripts).
  * Enhanced entity profile pages with JSON-LD viewing when available, plus richer metadata (e.g., aliases and revision details).
* **Bug Fixes**
  * Improved entity avatar rendering by using better image-fit behavior for persons vs non-person entities (including consistent white background for non-person images).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->