### PR TITLE
fix(admin): land on the dashboard after login, not /admin/reviews

### DIFF
--- a/src/context/CaseworkAuthContext.tsx
+++ b/src/context/CaseworkAuthContext.tsx
@@ -14,7 +14,11 @@ interface AuthContextValue {
   user: CaseworkUser | null;
   loading: boolean;
   error: string | null;
-  login: () => void;
+  // `returnTo` is the in-app path to land on after the OIDC round-trip. Pass
+  // the page the user actually asked for (the login page captures it from the
+  // router `from` state) — omitting it falls back to the current pathname,
+  // which is the login page itself and would be discarded by the callback.
+  login: (returnTo?: string) => void;
   logout: () => void;
   isAdmin: boolean;
   // True when the user holds admin OR moderator — the UI gate for privileged
@@ -78,9 +82,9 @@ export function CaseworkAuthProvider({ children }: { children: React.ReactNode }
 
   const user = devUser ?? oidcUser;
 
-  const login = () => {
+  const login = (returnTo?: string) => {
     auth.signinRedirect({
-      state: window.location.pathname + window.location.search,
+      state: returnTo ?? window.location.pathname + window.location.search,
     });
   };
 

--- a/src/pages/CaseworkCallback.tsx
+++ b/src/pages/CaseworkCallback.tsx
@@ -15,14 +15,14 @@ const CaseworkCallback = () => {
     if (auth.isLoading) return;
     if (auth.isAuthenticated) {
       // Return to the pre-login path saved in the OIDC `state`, but never back to
-      // the login/callback pages themselves — fall back to the portal home.
+      // the login/callback pages themselves — fall back to the admin dashboard.
       const saved = typeof auth.user?.state === "string" ? auth.user.state : "";
       const dest =
         saved &&
         !saved.startsWith("/admin/login") &&
         !saved.startsWith("/admin/callback")
           ? saved
-          : "/admin/reviews";
+          : "/admin";
       navigate(dest, { replace: true });
     } else if (auth.error || !hadAuthParams) {
       // A real sign-in failure, or a stray visit with no pending sign-in. Don't

--- a/src/pages/CaseworkLogin.tsx
+++ b/src/pages/CaseworkLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useCaseworkAuth } from "@/context/CaseworkAuthContext";
 import { FormError } from "@/components/admin/FormError";
@@ -13,6 +13,18 @@ const CaseworkLogin = () => {
     useCaseworkAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
+  // The page the user tried to reach before the auth gate bounced them here
+  // (AdminShell sets `state.from`). Default to the dashboard, never back to a
+  // login/callback page. This becomes the OIDC `state` so the callback can
+  // return the user to where they started.
+  const rawFrom = (location.state as { from?: string } | null)?.from;
+  const returnTo =
+    rawFrom &&
+    !rawFrom.startsWith("/admin/login") &&
+    !rawFrom.startsWith("/admin/callback")
+      ? rawFrom
+      : "/admin";
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -21,11 +33,11 @@ const CaseworkLogin = () => {
 
   // Already signed in (e.g. landed here after the OIDC round-trip) — go inside.
   useEffect(() => {
-    if (user) navigate("/admin", { replace: true });
-  }, [user, navigate]);
+    if (user) navigate(returnTo, { replace: true });
+  }, [user, navigate, returnTo]);
 
   const handleSignIn = () => {
-    login();
+    login(returnTo);
   };
 
   const handleDevLogin = async (e: React.FormEvent) => {
@@ -34,7 +46,7 @@ const CaseworkLogin = () => {
     setDevBusy(true);
     try {
       await devLogin(username.trim(), password);
-      navigate("/admin", { replace: true });
+      navigate(returnTo, { replace: true });
     } catch (err) {
       const status = (err as { response?: { status?: number } })?.response
         ?.status;

--- a/tests/e2e/admin-login-redirect.mjs
+++ b/tests/e2e/admin-login-redirect.mjs
@@ -1,0 +1,129 @@
+// Headless verify driver for the /admin post-login redirect fix.
+//
+// Bug: logging in from /admin dropped the user on /admin/reviews (a /portal
+// leftover) instead of the dashboard, and deep-link return was dead — the login
+// page never read the `from` router state AdminShell hands it, so the OIDC
+// `state` was always the login page's own path and got discarded by the
+// callback, hitting the hardcoded fallback every time.
+//
+// This drives the DEV_AUTH login flow (no Zitadel) so the shared returnTo logic
+// and the landing page can be asserted in a real browser. Case 3 additionally
+// exercises the real OIDC callback's fallback by injecting a stored oidc user.
+//
+// Requires: mock API on :48000 (bun tests/e2e/mock-api.ts) and the dev server
+// started with VITE_DEV_AUTH=true (port via E2E_BASE_URL, default :40115).
+//   node tests/e2e/admin-login-redirect.mjs
+import { chromium } from "playwright";
+
+const BASE = process.env.E2E_BASE_URL || "http://127.0.0.1:40115";
+const IGNORE = /Hydration failed|error while hydrating/; // known dev-SSR artifact
+
+const browser = await chromium.launch();
+
+let failures = 0;
+const check = (label, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"}: ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+// A fresh context per case → isolated localStorage (no leaked dev session).
+async function freshPage() {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.on("pageerror", (e) => {
+    const line = String(e).split("\n")[0];
+    if (!IGNORE.test(line)) {
+      console.log("  pageerror:", line);
+      failures += 1;
+    }
+  });
+  // Pre-answer the cookie banner only; do NOT seed a dev user — we want the
+  // actual login flow, which is exactly what the fix changes.
+  await page.addInitScript(() => {
+    localStorage.setItem("jawafdehi_analytics_consent", "denied");
+  });
+  return page;
+}
+
+// Fill + submit the DEV_AUTH username/password form (opens a Django session via
+// the mock). Targets stable ids / the form's submit button, never the SSO
+// button (which would kick off a real Zitadel redirect).
+async function devSignIn(page) {
+  await page.locator("#dev-username").waitFor({ timeout: 30000 });
+  await page.locator("#dev-username").fill("admin");
+  await page.locator("#dev-password").fill("devpass");
+  await page.locator('form button[type="submit"]').click();
+}
+
+const pathOf = (u) => new URL(u).pathname;
+
+// === Case 1: login from /admin lands on the dashboard, not /admin/reviews ====
+console.log("\n== Case 1: default landing after login ==");
+{
+  const page = await freshPage();
+  await page.goto(BASE + "/admin", { waitUntil: "networkidle" });
+  await page.waitForURL(/\/admin\/login/, { timeout: 20000 });
+  check("unauthenticated /admin bounces to /admin/login", /\/admin\/login/.test(page.url()), page.url());
+
+  await devSignIn(page);
+  await page.waitForURL((u) => !/\/admin\/login/.test(u.href), { timeout: 20000 }).catch(() => {});
+  const p = pathOf(page.url());
+  check("login from /admin lands on the dashboard (/admin)", p === "/admin", page.url());
+  check("login from /admin does NOT land on /admin/reviews", p !== "/admin/reviews", page.url());
+  await page.context().close();
+}
+
+// === Case 2: deep-link return — bounce to login then back to the target ======
+console.log("\n== Case 2: deep-link return ==");
+{
+  const page = await freshPage();
+  await page.goto(BASE + "/admin/entities", { waitUntil: "networkidle" });
+  await page.waitForURL(/\/admin\/login/, { timeout: 20000 });
+  check("unauthenticated /admin/entities bounces to /admin/login", /\/admin\/login/.test(page.url()), page.url());
+
+  await devSignIn(page);
+  await page.waitForURL((u) => pathOf(u.href) === "/admin/entities", { timeout: 20000 }).catch(() => {});
+  const p = pathOf(page.url());
+  check("login returns to the originally requested /admin/entities", p === "/admin/entities", page.url());
+  await page.context().close();
+}
+
+// === Case 3: real OIDC callback fallback (no Zitadel — inject a stored user) ==
+// The production path can't complete a live Zitadel round-trip here, but the
+// callback's fallback is the piece that regressed. Seed an already-authenticated
+// oidc user (so react-oidc-context reports isAuthenticated with NO `state`) and
+// hit /admin/callback: with no saved state it must fall back to /admin.
+console.log("\n== Case 3: OIDC callback fallback (best-effort) ==");
+{
+  const page = await freshPage();
+  await page.addInitScript(() => {
+    // Storage key + shape used by oidc-client-ts (defaults from services/oidc.ts).
+    const authority = "https://auth.jawafdehi.org";
+    const clientId = "377887299569975664";
+    const user = {
+      id_token: "e2e.fake.idtoken",
+      access_token: "e2e-fake-access-token",
+      token_type: "Bearer",
+      scope: "openid profile email",
+      profile: { sub: "e2e-oidc", email: "e2e-oidc@example.test", roles: ["admin"] },
+      expires_at: 4102444800, // year 2100 — never expired
+    };
+    localStorage.setItem(`oidc.user:${authority}:${clientId}`, JSON.stringify(user));
+  });
+  await page.goto(BASE + "/admin/callback", { waitUntil: "networkidle" });
+  // Give the callback effect a beat to route.
+  await page.waitForURL((u) => !/\/admin\/callback/.test(u.href), { timeout: 15000 }).catch(() => {});
+  const p = pathOf(page.url());
+  if (p === "/admin") {
+    check("OIDC callback with no saved state falls back to /admin", true, page.url());
+  } else if (p === "/admin/reviews") {
+    check("OIDC callback fallback is NOT /admin/reviews (regression)", false, page.url());
+  } else {
+    console.log(`SKIP: OIDC callback fallback inconclusive — landed on ${page.url()} (injection did not authenticate)`);
+  }
+  await page.context().close();
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+await browser.close();
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
### **User description**
## Problem

Logging into the `/admin` panel dropped every user on **`/admin/reviews`** instead of the dashboard. Two compounding causes:

1. **The saved return-path was the login page itself.** When the auth gate bounces an anonymous visitor from `/admin` to `/admin/login`, `AdminShell` passes the intended page as router state (`state.from`) — but `CaseworkLogin` never read it. `login()` instead captured `window.location.pathname`, which at that point is `/admin/login`, so the OIDC `state` was always the login path.
2. **The fallback destination was `/admin/reviews`.** `CaseworkCallback` correctly discards login/callback paths, then fell through to a hardcoded `/admin/reviews` — a leftover from when the panel lived at `/portal`. Since the saved state was *always* the (rejected) login path, **every** login hit that fallback.

Net effect: the deep-link-return machinery (the `from` state + the `saved`-state guard) was dead, and everyone landed on `/reviews`. The `/admin/reviews` fallback predates the current admin panel (it dates to the v2→main cutover, #170).

## Fix

- **`CaseworkAuthContext`** — `login(returnTo?)` takes an explicit destination instead of inferring it from the current URL.
- **`CaseworkLogin`** — reads `AdminShell`'s `from` state, sanitizes it (never a login/callback loop), defaults to `/admin`, and passes it to `login()` and the dev-login path.
- **`CaseworkCallback`** — post-login fallback `/admin/reviews` → `/admin`.

Bonus: this restores deep-link return — a bookmark to e.g. `/admin/entities/edit/…` now sends you back there after login instead of a default page.

## Verification

Added a headless e2e driver, `tests/e2e/admin-login-redirect.mjs`, that drives the **dev-auth** login flow (no Zitadel) in headless Chromium against the mock API:

| Case | With fix | Pre-fix |
|---|---|---|
| Login from `/admin` lands on the dashboard (`/admin`, not `/admin/reviews`) | PASS | PASS¹ |
| Deep-link `/admin/entities` → login → returns to `/admin/entities` | PASS | **FAIL** (lands on `/admin`) |
| OIDC callback with no saved state falls back to `/admin` | PASS | **FAIL** (lands on `/admin/reviews`) |

¹ the old dev-login hardcoded `/admin`; only the OIDC path regressed, which case 3 reproduces.

Also: `npm run build` succeeds; eslint clean on the changed files. (`tsc -b` was not run as a gate — the repo has pre-existing tree-wide type errors and CI doesn't run it.)

Run locally:
```bash
MOCK_API_PORT=48222 bun tests/e2e/mock-api.ts &
VITE_DEV_AUTH=true VITE_API_PROXY_TARGET=http://127.0.0.1:48222 bunx vite --port 40222 --strictPort &
E2E_BASE_URL=http://127.0.0.1:40222 node tests/e2e/admin-login-redirect.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix admin post-login landing

- Restore deep-link return paths

- Sanitize login/callback redirect targets

- Add headless redirect e2e checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gate["Admin auth gate"] 
  login["Login page reads from state"]
  oidc["OIDC state stores returnTo"]
  callback["Callback validates destination"]
  admin["Admin dashboard or deep link"]
  gate -- "passes from" --> login
  login -- "calls login(returnTo)" --> oidc
  oidc -- "returns saved state" --> callback
  callback -- "navigates" --> admin
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaseworkAuthContext.tsx</strong><dd><code>Add explicit login return destination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/context/CaseworkAuthContext.tsx

<ul><li>Change <code>login</code> signature to accept optional <code>returnTo</code><br> <li> Store explicit return path in OIDC <code>state</code><br> <li> Keep pathname fallback for omitted destinations</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/256/files#diff-fe685ff5e7a6b3fbcbc812260a0ae632c21a4d3662fa0846bb8747638bd6a73d">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CaseworkCallback.tsx</strong><dd><code>Default callback redirect to dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/CaseworkCallback.tsx

<ul><li>Update callback fallback destination to <code>/admin</code><br> <li> Keep login/callback loop prevention<br> <li> Adjust comments to dashboard behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/256/files#diff-2a77bd907e033e600e393261d377a9e0057ad2ee4493840c2faae2860e7a723d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CaseworkLogin.tsx</strong><dd><code>Preserve requested admin return path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/CaseworkLogin.tsx

<ul><li>Read router <code>state.from</code> via <code>useLocation</code><br> <li> Sanitize login/callback return targets<br> <li> Pass <code>returnTo</code> into OIDC login<br> <li> Navigate dev login and existing user to <code>returnTo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/256/files#diff-f5efd817b9f91ea98a6d0692e8392589ac1341a9ea8730ecc060dbb228ef0766">+17/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-login-redirect.mjs</strong><dd><code>Cover admin login redirect behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/admin-login-redirect.mjs

<ul><li>Add Playwright DEV_AUTH redirect driver<br> <li> Verify <code>/admin</code> login lands on dashboard<br> <li> Verify <code>/admin/entities</code> deep-link return<br> <li> Check OIDC callback fallback avoids <code>/admin/reviews</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/256/files#diff-510103644602bd096469d32ca49ee8566b6d0d34e27e54c8da777df1829be356">+129/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
