### PR TITLE
feat(entities): show related cases on the entity record page

### DIFF
--- a/src/components/EntityRelatedCases.tsx
+++ b/src/components/EntityRelatedCases.tsx
@@ -1,0 +1,182 @@
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { ArrowRight } from "lucide-react";
+
+import { getCasesCitingEntity } from "@/services/jds-api";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { formatDate } from "@/utils/date";
+import { getCaseTypeLabelKey } from "@/utils/case-entities";
+import {
+  outcomeBadgeClass,
+  outcomeLabel,
+  shouldShowOutcome,
+} from "@/utils/case-outcome";
+import type { Case } from "@/types/jds";
+
+// Relationship role -> i18n label key. Mirrors the case-side relation labels so
+// the reverse view reads the same as the forward (case detail) view.
+const ROLE_LABEL_KEY: Record<string, string> = {
+  accused: "entityDetail.relationTypeAccused",
+  alleged: "entityDetail.relationTypeAlleged",
+  related: "entityDetail.relationTypeRelated",
+  witness: "entityDetail.relationTypeWitness",
+  opposition: "entityDetail.relationTypeOpposition",
+  victim: "entityDetail.relationTypeVictim",
+  respondent: "entityDetail.relationTypeRespondent",
+  petitioner: "entityDetail.relationTypePetitioner",
+  location: "entityDetail.relationTypeLocation",
+};
+
+// First page only — the corpus is small and an entity rarely spans many cases.
+const PAGE_SIZE = 20;
+
+// accused + alleged form the emphasized top tier (matches the server ordering).
+function isAccusedTier(role: string): boolean {
+  return role === "accused" || role === "alleged";
+}
+
+// This entity's role/verdict on a given case, read from the case's own entity
+// binds (the list serializer resolves every bind's nes_id/type/outcome). When a
+// case cites the entity in more than one role, prefer the accused/alleged bind
+// so the badge matches why the card floated to the top.
+function roleFor(caseItem: Case, entityIri: string) {
+  const binds = (caseItem.entities ?? []).filter((e) => e.nes_id === entityIri);
+  const bind = binds.find((b) => isAccusedTier(b.type ?? "")) ?? binds[0];
+  return { role: bind?.type ?? "related", outcome: bind?.outcome ?? null };
+}
+
+/**
+ * "Related cases" section for an entity record page: the published cases that
+ * cite this entity, accused/alleged floated to the top and visually emphasized,
+ * everything else reverse-chronologically below. Renders nothing when the entity
+ * has no published citations (or on error), so it can be dropped in unconditionally.
+ */
+export function EntityRelatedCases({ entityIri }: { entityIri: string }) {
+  const { t, i18n } = useTranslation();
+  const language = i18n.language === "ne" ? "ne" : "en";
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["entity-related-cases", entityIri],
+    queryFn: () => getCasesCitingEntity(entityIri, { page_size: PAGE_SIZE }),
+    enabled: entityIri.length > 0,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isLoading) {
+    return (
+      <section aria-busy="true" className="space-y-3">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-[4.5rem] w-full rounded-xl" />
+        <Skeleton className="h-[4.5rem] w-full rounded-xl" />
+      </section>
+    );
+  }
+
+  // Hide the whole section when there are no published citations (or on error).
+  if (isError || !data || data.count === 0) return null;
+
+  // Defensive re-sort (the server already orders this way): accused/alleged
+  // first, reverse-chron within each tier.
+  const cases = [...data.results].sort((a, b) => {
+    const ra = isAccusedTier(roleFor(a, entityIri).role) ? 0 : 1;
+    const rb = isAccusedTier(roleFor(b, entityIri).role) ? 0 : 1;
+    if (ra !== rb) return ra - rb;
+    return (b.created_at ?? "").localeCompare(a.created_at ?? "");
+  });
+
+  const remaining = data.count - cases.length;
+
+  return (
+    <section aria-labelledby="related-cases-heading" className="space-y-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2
+          id="related-cases-heading"
+          className="text-xl font-semibold tracking-tight text-primary"
+        >
+          {t("entityDetail.relatedCases")}
+        </h2>
+        <span className="text-sm font-medium text-muted-foreground">{data.count}</span>
+      </div>
+
+      <ul className="space-y-3">
+        {cases.map((c) => {
+          const { role, outcome } = roleFor(c, entityIri);
+          const accused = isAccusedTier(role);
+          const roleLabel = t(
+            ROLE_LABEL_KEY[role] ?? "entityDetail.relationTypeUnknown",
+          );
+          const date = formatDate(c.case_start_date || c.created_at);
+          const typeKey = getCaseTypeLabelKey(c.case_type);
+          const typeLabel = typeKey ? t(typeKey) : c.case_type;
+          const href = c.slug ? `/case/${c.slug}` : undefined;
+
+          const row = (
+            <div
+              className={cn(
+                "group flex items-start gap-3 rounded-xl border bg-card p-4 transition-colors hover:bg-muted/40",
+                accused && "border-l-4 border-l-accent",
+              )}
+            >
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant={accused ? undefined : "secondary"}
+                    className={cn(
+                      "shrink-0",
+                      accused && "border-transparent bg-accent text-accent-foreground",
+                    )}
+                  >
+                    {roleLabel}
+                  </Badge>
+                  {accused && shouldShowOutcome(outcome) ? (
+                    <Badge variant="outline" className={outcomeBadgeClass(outcome)}>
+                      {outcomeLabel(outcome, language)}
+                    </Badge>
+                  ) : null}
+                </div>
+                <h3 className="line-clamp-2 text-base font-medium leading-snug text-primary group-hover:underline">
+                  {c.title}
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  {typeLabel}
+                  {date ? ` · ${date}` : ""}
+                </p>
+              </div>
+              {href ? (
+                <ArrowRight
+                  className="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
+              ) : null}
+            </div>
+          );
+
+          return (
+            <li key={c.id}>
+              {href ? (
+                <Link
+                  to={href}
+                  className="block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {row}
+                </Link>
+              ) : (
+                row
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {remaining > 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t("entityDetail.moreCases", { count: remaining })}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -989,6 +989,7 @@
     "relatedCases": "Related Cases",
     "noAllegedCases": "No accused cases found.",
     "noRelatedCases": "No related cases found.",
+    "moreCases": "+{{count}} more",
     "loading": "Loading entity details...",
     "activeCases": "Active Cases",
     "unknown": "Unknown",

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -989,6 +989,7 @@
     "relatedCases": "सम्बन्धित मुद्दाहरू",
     "noAllegedCases": "कुनै अभियुक्त मुद्दा फेला परेन।",
     "noRelatedCases": "कुनै सम्बन्धित मुद्दा फेला परेन।",
+    "moreCases": "+{{count}} थप",
     "loading": "संस्था विवरण लोड हुँदैछ...",
     "activeCases": "सक्रिय मुद्दाहरू",
     "unknown": "अज्ञात",

--- a/src/pages/EntityRecordProfile.tsx
+++ b/src/pages/EntityRecordProfile.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, AlertTriangle, ArrowLeft, ExternalLink } from "lucide-reac
 
 import { http } from "@/services/http";
 import { entityPath } from "@/lib/entity-links";
+import { EntityRelatedCases } from "@/components/EntityRelatedCases";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -307,6 +308,10 @@ export default function EntityRecordProfile() {
                 <dd className="mt-1 break-all font-mono text-xs text-muted-foreground">{data["@id"]}</dd>
               </div>
             </dl>
+
+            {/* Published cases citing this entity (accused/alleged floated to
+                the top). Renders nothing when there are none. */}
+            {data["@id"] ? <EntityRelatedCases entityIri={data["@id"]} /> : null}
 
             {/* Provenance. */}
             <div className="rounded-xl border bg-muted/30 p-4 text-xs text-muted-foreground">

--- a/src/services/jds-api.ts
+++ b/src/services/jds-api.ts
@@ -210,11 +210,33 @@ export async function getCasesByEntity(entityId: string, params?: CaseSearchPara
     });
 
     // Filter cases that include the entity in the unified entities array
-    const filteredCases = response.data.results.filter(caseItem => 
+    const filteredCases = response.data.results.filter(caseItem =>
       caseItem.entities?.some(e => e.nes_id === entityId)
     );
-    
+
     return filteredCases;
+  } catch (error) {
+    handleApiError(error, '/cases/');
+  }
+}
+
+/**
+ * Fetch the published cases that CITE a given entity, by its canonical NES
+ * `@id` IRI, using the server-side `?entity=` reverse-lookup filter on
+ * /api/cases/. The backend scopes to PUBLISHED for anonymous callers and orders
+ * accused/alleged citations first, then reverse-chronologically. Returns the
+ * paginated envelope so callers can surface `count` and know if more exist.
+ */
+export async function getCasesCitingEntity(
+  entityIri: string,
+  params?: { page_size?: number },
+): Promise<PaginatedCaseList> {
+  try {
+    const response = await http.get<PaginatedCaseList>('/api/cases/', {
+      params: { entity: entityIri, ...params },
+      timeout: 10000,
+    });
+    return response.data;
   } catch (error) {
     handleApiError(error, '/cases/');
   }


### PR DESCRIPTION
### **User description**
## What

Adds a "Related cases" section to the entity record page (`EntityRecordProfile`): the published cases that cite this entity, fetched via the new backend `?entity=` filter (API PR: Jawafdehi/JawafdehiAPI#366).

## Behavior

- Single list with a count; **accused/alleged citations float to the top** and are emphasized (solid crimson badge + crimson left-accent) with verdict pills (Convicted / Acquitted / Abated; the undecided `charged` default is suppressed). Reverse-chron within each tier.
- Other roles (related / witness / …) render below with a muted badge.
- Each card links to `/case/<slug>`; a case with no slug renders unlinked.
- The section **renders nothing** when the entity has no published citations or on fetch error (no empty box).
- Fully localized (EN / NE) — reuses the existing `entityDetail.relationType*` and `cases.type.*` label keys; one new key `entityDetail.moreCases`.

## Implementation

- New `src/components/EntityRelatedCases.tsx`.
- New `getCasesCitingEntity()` in `src/services/jds-api.ts` (server `?entity=` filter; the paginated envelope surfaces `count`).
- `roleFor()` prefers the accused/alleged bind when a case cites the entity in multiple roles, so the badge matches why the card floated up.

## Testing

Verified locally against a seeded backend with a headless browser: ordering (accused/alleged first; a newer `related` case correctly sits below), all four outcome pills, `IN_REVIEW` hidden from anon, empty-state hidden, EN/NE labels, and pagination (>20 citations → 20 cards + "+N more"). eslint clean; no new `tsc` errors.

## Follow-up (not in this PR)

- "+N more" is plain text (first page only) — fine for the current corpus; could become a link to a filtered listing if any entity exceeds 20 citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add entity related cases section

- Fetch citations via `?entity=` API

- Prioritize accused/alleged case roles

- Add localized overflow count


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Entity profile"] -- "passes `@id`" --> B["EntityRelatedCases"]
  B -- "calls" --> C["getCasesCitingEntity"]
  C -- "queries `?entity=`" --> D["Cases API"]
  D -- "renders" --> E["Prioritized related cases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EntityRelatedCases.tsx</strong><dd><code>New related cases entity component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/EntityRelatedCases.tsx

<ul><li>Adds <code>EntityRelatedCases</code> component.<br> <li> Fetches citing cases with React Query.<br> <li> Sorts accused/alleged roles first.<br> <li> Renders badges, outcomes, links, overflow count.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/257/files#diff-68336e8906ef715cbf33125b75656099aa039f26fb74fa58820f3139b3c5277c">+182/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EntityRecordProfile.tsx</strong><dd><code>Embed related cases in profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/EntityRecordProfile.tsx

<ul><li>Imports <code>EntityRelatedCases</code>.<br> <li> Inserts section after entity metadata.<br> <li> Passes canonical <code>data["@id"]</code>.<br> <li> Hides section when no entity IRI.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/257/files#diff-1bf2059e444c1e66abf63e5f86e0aea250be717cfb064ebe4d54ed66f9c89823">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>jds-api.ts</strong><dd><code>Add citing cases API helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/jds-api.ts

<ul><li>Adds <code>getCasesCitingEntity</code>.<br> <li> Calls <code>/api/cases/</code> with <code>entity</code> filter.<br> <li> Returns paginated case envelope.<br> <li> Preserves count for overflow display.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/257/files#diff-6174036bdd94a7acb372f99361573d0ee20465951137f640ddbb55be5e2fdf70">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add English more cases label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/en.json

<ul><li>Adds <code>entityDetail.moreCases</code>.<br> <li> Enables English overflow count text.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/257/files#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ne.json</strong><dd><code>Add Nepali more cases label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n/locales/ne.json

<ul><li>Adds <code>entityDetail.moreCases</code>.<br> <li> Enables Nepali overflow count text.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/Jawafdehi/pull/257/files#diff-e088c4713e8d7635691c3b76d5456c12cfd747832c7dea0a6f5a09ea3672cd53">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
