### PR TITLE
fix(material): contain overflowing source URL and document text

### DIFF
--- a/src/pages/MaterialProfile.test.tsx
+++ b/src/pages/MaterialProfile.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Material } from "@/services/datalake-api";
+
+const getMaterial = vi.fn();
+vi.mock("@/services/datalake-api", () => ({
+  getMaterial: (...args: unknown[]) => getMaterial(...args),
+}));
+
+// Isolate MaterialProfile's own rendering from the shared dialog/button widgets.
+vi.mock("@/components/ViewJsonButton", () => ({ ViewJsonButton: () => null }));
+vi.mock("@/components/DocumentPreviewDialog", () => ({ DocumentPreviewDialog: () => null }));
+
+import MaterialProfile from "@/pages/MaterialProfile";
+
+// A real AG source URL: one long, unbroken, percent-encoded string — the shape
+// that overflows its grid cell and overlaps the neighbouring field.
+const LONG_URL =
+  "https://ag.gov.np/storage/abhiyogPatra/" +
+  "%E0%A5%A6%E0%A5%AE%E0%A5%A8-FT-%E0%A5%A6%E0%A5%AA%E0%A5%AB%E0%A5%AF_1782114350.pdf";
+
+const material = (extra: Record<string, unknown>): Material =>
+  ({
+    "@id": "https://jawafdehi.org/material/ag/116707",
+    "@type": "CreativeWork",
+    name: { en: "Abhiyog patra", ne: "" },
+    ...extra,
+  }) as Material;
+
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/material/ag/116707"]}>
+          <Routes>
+            <Route path="/material/*" element={<MaterialProfile />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+};
+
+beforeEach(() => getMaterial.mockReset());
+
+describe("MaterialProfile — overflow-safe rendering", () => {
+  it("renders a long source URL as a compact host link, not raw percent-encoded text", async () => {
+    getMaterial.mockResolvedValue(material({ "jawafdehi:sourceUrl": LONG_URL }));
+    renderPage();
+
+    const link = await screen.findByRole("link", { name: /ag\.gov\.np/i });
+    expect(link.getAttribute("href")).toBe(LONG_URL);
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel") || "").toContain("noopener");
+    expect(screen.queryByText(/%E0%A5/)).toBeNull();
+  });
+
+  it("wraps the document-text transcript so long unbroken runs stay inside the card on mobile", async () => {
+    // Nepali transcripts carry dotted leaders (……………फरार) and long unbroken runs
+    // that whitespace-pre-wrap alone will not break, overflowing the card on a
+    // narrow (mobile) viewport. The paragraph must allow breaking inside a run.
+    const longRun = "…".repeat(150) + "फरार";
+    getMaterial.mockResolvedValue(material({ text: { ne: `TRANSCRIPT_MARKER ${longRun}` } }));
+    renderPage();
+
+    const para = await screen.findByText(/TRANSCRIPT_MARKER/);
+    expect(para.className).toMatch(/\bwhitespace-pre-wrap\b/); // keep formatting
+    expect(para.className).toMatch(/\bbreak-words\b/); // but break over-long runs
+  });
+
+  it("leaves a non-URL detail field as plain text", async () => {
+    getMaterial.mockResolvedValue(material({ "jawafdehi:recordId": "116707" }));
+    renderPage();
+    expect(await screen.findByText("116707")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /116707/ })).toBeNull();
+  });
+});

--- a/src/pages/MaterialProfile.tsx
+++ b/src/pages/MaterialProfile.tsx
@@ -73,6 +73,34 @@ function scalar(v: unknown): string | null {
   return null;
 }
 
+// A stored value like jawafdehi:sourceUrl is a full http(s) URL — often a long,
+// unbroken, percent-encoded path (…/%E0%A5%A6…pdf). Printed verbatim it overflows
+// its grid cell and overlaps the neighbouring field, and reads as noise. Detect
+// it so the Details grid can render it as a compact host link instead.
+function isHttpUrl(s: string): boolean {
+  return /^https?:\/\//i.test(s);
+}
+
+// Short, human label for a URL: its host (sans leading `www.`). Falls back to the
+// raw string if the URL can't be parsed, so we never show nothing.
+function hostLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+// Decoded URL for the hover tooltip — turns %E0%A5%A6… back into readable
+// Devanagari. Falls back to the raw URL on a malformed escape sequence.
+function decodedUrl(url: string): string {
+  try {
+    return decodeURIComponent(url);
+  } catch {
+    return url;
+  }
+}
+
 // Keys handled explicitly in the header/links/full-text/provenance, never in Details.
 // The jawafdehi:visibility[Policy] pair is a caseworker-only annotation the API
 // adds on authed reads; it is an editor concern (see MaterialVisibilityControl),
@@ -278,15 +306,33 @@ export default function MaterialProfile() {
             {detailRows.length > 0 || data.identifier ? (
               <dl className="grid gap-4 rounded-xl bg-card p-5 sm:grid-cols-2">
                 {detailRows.map((r) => (
-                  <div key={r.label}>
+                  // min-w-0: a grid item defaults to min-width:auto, which lets a
+                  // long unbroken value push past its column and overlap the next
+                  // one; allow it to shrink so break-words can actually wrap.
+                  <div key={r.label} className="min-w-0">
                     <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{r.label}</dt>
-                    <dd className="mt-1 text-sm text-foreground">{r.value}</dd>
+                    <dd className="mt-1 text-sm text-foreground break-words">
+                      {isHttpUrl(r.value) ? (
+                        <a
+                          href={r.value}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={decodedUrl(r.value)}
+                          className="inline-flex max-w-full items-center gap-1 text-primary underline underline-offset-2 hover:no-underline"
+                        >
+                          <span className="truncate">{hostLabel(r.value)}</span>
+                          <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />
+                        </a>
+                      ) : (
+                        r.value
+                      )}
+                    </dd>
                   </div>
                 ))}
                 {data.identifier ? (
-                  <div>
+                  <div className="min-w-0">
                     <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Identifier</dt>
-                    <dd className="mt-1 text-sm text-foreground">{data.identifier}</dd>
+                    <dd className="mt-1 text-sm text-foreground break-words">{data.identifier}</dd>
                   </div>
                 ) : null}
                 <div className="sm:col-span-2">
@@ -302,7 +348,10 @@ export default function MaterialProfile() {
                 <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-foreground">
                   <FileText className="h-4 w-4" aria-hidden="true" /> Document text
                 </h2>
-                <p className="whitespace-pre-wrap text-sm leading-7 text-foreground">{fullTextStr}</p>
+                {/* break-words: transcripts carry dotted leaders (……………फरार) and
+                    other long unbroken runs that whitespace-pre-wrap will not
+                    break, overflowing the card on a narrow (mobile) viewport. */}
+                <p className="whitespace-pre-wrap break-words text-sm leading-7 text-foreground">{fullTextStr}</p>
               </section>
             ) : null}
 

--- a/src/pages/MaterialProfile.tsx
+++ b/src/pages/MaterialProfile.tsx
@@ -318,9 +318,9 @@ export default function MaterialProfile() {
                           target="_blank"
                           rel="noopener noreferrer"
                           title={decodedUrl(r.value)}
-                          className="inline-flex max-w-full items-center gap-1 text-primary underline underline-offset-2 hover:no-underline"
+                          className="inline-flex items-center gap-1 text-primary underline underline-offset-2 hover:no-underline"
                         >
-                          <span className="truncate">{hostLabel(r.value)}</span>
+                          {hostLabel(r.value)}
                           <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />
                         </a>
                       ) : (


### PR DESCRIPTION
## Problem

Two overflow bugs on the material detail page (`/material/*`):

1. **Source URL overflow.** A long, percent-encoded `jawafdehi:sourceUrl` (e.g. an AG indictment link like `…/storage/abhiyogPatra/%E0%A5%A6…pdf`) was rendered verbatim in the Details grid. As one unbroken string it pushed past its column and overlapped the neighbouring **CASE NUMBER** field.

2. **Document-text overflow on mobile.** The "Document text" transcript overflowed its card horizontally on narrow viewports. Nepali transcripts carry dotted leaders (`……………फरार`) and other long unbroken runs that `whitespace-pre-wrap` alone will not break.

## Fix

- Render `http(s)` detail values as a **compact host link** (`ag.gov.np ↗`) rather than raw text — the full URL stays in `href`, the decoded path shows in the hover tooltip.
- Add `min-w-0` + `break-words` across the Details grid so no long value can push past its column. (Grid/flex items default to `min-width: auto`, which is what allowed the overlap.)
- Add `break-words` to the transcript paragraph so long unbroken runs wrap inside the card.

## Testing

- **Unit / component** (`src/pages/MaterialProfile.test.tsx`): long URL renders as a host link carrying the full `href`, the raw percent-encoded string never appears as text, the transcript paragraph wraps, and non-URL detail fields stay plain text.
- **Real browser @ 430px (mobile):** page-body and transcript horizontal overflow both measure **0px**; source URL renders as the host link.
- Full suite **248 passing**; `tsc --noEmit` and `eslint` clean.

## Notes
- **Follow-up (not in this PR):** the same Details grid exists in `EntityRecordProfile`; extracting a shared `DetailGrid` + URL helper would DRY the two and prevent future drift.

## How to verify

Open a material with a long source URL and a transcript, e.g. `/material/ag/116707`, and view it at a mobile width — the source URL is a tidy link and the document text stays inside its card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long source URLs in material details now display compactly by showing the website host while preserving the full destination link.
  - URL tooltips are easier to understand with decoded text.
  - Long identifiers and transcript text now wrap correctly on narrow screens, preventing layout overflow.
  - Non-URL detail values continue to appear as plain text.

- **Tests**
  - Added coverage for URL rendering, transcript wrapping, and plain-text detail values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->