### PR TITLE
Research: honest funnel, charge-mix-by-year & monthly-filing charts, single methodology

### DIFF
--- a/src/components/data-quality/AccountabilityFunnel.tsx
+++ b/src/components/data-quality/AccountabilityFunnel.tsx
@@ -6,6 +6,13 @@ export interface FunnelStage {
   count: number;
   /** CSS color for the bar fill (a theme token via `hsl(var(--…))`). */
   color: string;
+  /**
+   * Optional drop indicator rendered ABOVE this stage (a ↓ chip between it and
+   * the previous stage), e.g. "≈1 in 7 investigated are prosecuted". Expresses
+   * this stage's share of the *previous* stage — the funnel retention a single
+   * "% of total" denominator can't show. Omitted → no indicator rendered.
+   */
+  note?: string;
 }
 
 /**
@@ -62,6 +69,14 @@ export function AccountabilityFunnel({
 
         return (
           <li key={stage.key}>
+            {stage.note ? (
+              <div className="mb-1.5 flex items-center gap-1.5 pl-1 text-xs text-muted-foreground">
+                <svg viewBox="0 0 12 14" className="h-3.5 w-3 shrink-0 text-accent" aria-hidden="true">
+                  <path d="M6 0v10M2.5 7L6 11l3.5-4" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <span className="rounded-full bg-muted px-2 py-0.5">{stage.note}</span>
+              </div>
+            ) : null}
             <div className="mb-1 flex items-baseline justify-between gap-3">
               <span className="text-sm font-medium text-foreground">{stage.label}</span>
               <span className="font-mono text-lg font-bold tabular-nums text-foreground">

--- a/src/components/research/ChargeMixByYear.tsx
+++ b/src/components/research/ChargeMixByYear.tsx
@@ -1,0 +1,132 @@
+import { useId, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { ChargeMixYear } from "@/data/research-corruption";
+import { useMounted } from "@/hooks/useMounted";
+import { MONO_STACK } from "@/lib/data-quality";
+import { Switch } from "@/components/ui/switch";
+
+type MixKey = "bribery" | "fake" | "embezzlement" | "benefit" | "loss" | "other";
+
+// Fixed categorical order + colours (validated CVD-safe set; `other` is neutral).
+// Fake-credential is crimson so the eye tracks the family whose share collapses.
+const SERIES: readonly { key: MixKey; color: string }[] = [
+  { key: "bribery", color: "#2a78d6" },
+  { key: "fake", color: "#B5242C" },
+  { key: "embezzlement", color: "#1baf7a" },
+  { key: "benefit", color: "#4a3aa7" },
+  { key: "loss", color: "#eda100" },
+  { key: "other", color: "hsl(var(--muted-foreground))" },
+];
+
+const rowTotal = (d: ChargeMixYear) =>
+  d.bribery + d.fake + d.embezzlement + d.benefit + d.loss + d.other;
+
+/**
+ * Charge mix by Bikram Sambat filing year — a stacked bar per year over the
+ * substantive prosecution corpus. Reads as both volume (bar height) and
+ * composition (segments): the crimson fake-credential band dominates the early
+ * years and thins sharply after BS 2077 (with a one-year rebound in 2081). A
+ * toggle switches to a 100%-share view
+ * (equal-height bars) to isolate the composition shift from the volume swings;
+ * it is off by default, so absolute case counts show first.
+ */
+export function ChargeMixByYear({
+  data,
+  labels,
+  percentLabel,
+}: {
+  data: readonly ChargeMixYear[];
+  labels: Record<MixKey, string>;
+  percentLabel: string;
+}) {
+  const mounted = useMounted();
+  const [percent, setPercent] = useState(false);
+  const toggleId = useId();
+  const height = 300;
+
+  const ariaLabel = `Charge mix by filing year: ${data
+    .map((d) => `BS ${d.bs} — ${SERIES.map((s) => `${labels[s.key]} ${d[s.key]}`).join(", ")}`)
+    .join("; ")}`;
+
+  return (
+    <div className="w-full">
+      <div className="mb-2 flex items-center justify-end gap-2">
+        <label htmlFor={toggleId} className="text-xs font-medium text-muted-foreground">
+          {percentLabel}
+        </label>
+        <Switch id={toggleId} checked={percent} onCheckedChange={setPercent} />
+      </div>
+
+      <div role="img" aria-label={ariaLabel} style={{ height }}>
+        {mounted ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data as ChargeMixYear[]}
+            stackOffset={percent ? "expand" : "none"}
+            margin={{ top: 8, right: 12, bottom: 4, left: 4 }}
+          >
+            <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="bs"
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(y: number) => String(y).slice(2)}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+            />
+            <YAxis
+              width={36}
+              tickLine={false}
+              axisLine={false}
+              domain={percent ? [0, 1] : undefined}
+              tickFormatter={percent ? (v: number) => `${Math.round(v * 100)}%` : undefined}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+            />
+            <Tooltip
+              labelFormatter={(y) => `BS ${y}`}
+              contentStyle={{ borderRadius: 8, border: "1px solid hsl(var(--border))", fontSize: 13 }}
+              itemStyle={{ fontFamily: MONO_STACK }}
+              formatter={(value: number, name: string, entry: { payload?: ChargeMixYear }) => {
+                if (!percent) return [value, name];
+                const total = entry?.payload ? rowTotal(entry.payload) : 0;
+                const pct = total ? Math.round((value / total) * 100) : 0;
+                return [`${value} (${pct}%)`, name];
+              }}
+            />
+            {SERIES.map((s, i) => (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={labels[s.key]}
+                stackId="mix"
+                fill={s.color}
+                stroke="hsl(var(--background))"
+                strokeWidth={1}
+                radius={!percent && i === SERIES.length - 1 ? [3, 3, 0, 0] : 0}
+                isAnimationActive={false}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+        ) : null}
+      </div>
+
+      <ul className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+        {SERIES.map((s) => (
+          <li key={s.key} className="inline-flex items-center gap-1.5">
+            <span className="h-2.5 w-4 rounded-sm" style={{ backgroundColor: s.color }} aria-hidden="true" />
+            {labels[s.key]}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/research/FiledByMonth.tsx
+++ b/src/components/research/FiledByMonth.tsx
@@ -1,0 +1,100 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ErrorBar,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { MonthFiling } from "@/data/research-corruption";
+import { useMounted } from "@/hooks/useMounted";
+import { MONO_STACK } from "@/lib/data-quality";
+
+/**
+ * Cases filed per Nepali month — mean bar with ±1 SD error bars across complete
+ * Bikram Sambat years. Surfaces the filing seasonality: a peak in Ashadh (the
+ * fiscal year-end) and a trough in Kartik (the Dashain/Tihar festival month).
+ * The tall error bars are themselves the point — filing volume swings widely
+ * year to year.
+ */
+export function FiledByMonth({
+  data,
+  peakMonth,
+  meanLabel,
+  sdLabel,
+}: {
+  data: readonly MonthFiling[];
+  /** Month index (1–12) to accent; e.g. the fiscal year-end peak. */
+  peakMonth?: number;
+  meanLabel: string;
+  sdLabel: string;
+}) {
+  const mounted = useMounted();
+  const height = 300;
+  // Pin the axis to [0, nice-max]: filings can't be negative, so a large SD
+  // (e.g. Kartik mean 11.2 ± 11.3) must not push the auto-domain below zero;
+  // the max still clears every upper whisker (mean + sd).
+  const maxY = Math.ceil(Math.max(...data.map((d) => d.mean + d.sd)) / 10) * 10;
+
+  if (!mounted) return <div className="w-full" style={{ height }} />;
+
+  const ariaLabel = `${meanLabel} by Nepali month, with ${sdLabel}: ${data
+    .map((d) => `${d.name} ${d.mean} ±${d.sd}`)
+    .join(", ")}`;
+
+  return (
+    <div className="w-full" role="img" aria-label={ariaLabel}>
+      <div style={{ height }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data as MonthFiling[]} margin={{ top: 8, right: 12, bottom: 22, left: 4 }}>
+            <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="name"
+              interval={0}
+              tickLine={false}
+              axisLine={false}
+              angle={-35}
+              textAnchor="end"
+              height={44}
+              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+            />
+            <YAxis
+              width={36}
+              domain={[0, maxY]}
+              tickLine={false}
+              axisLine={false}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+            />
+            <Tooltip
+              cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+              contentStyle={{ borderRadius: 8, border: "1px solid hsl(var(--border))", fontSize: 13 }}
+              itemStyle={{ fontFamily: MONO_STACK }}
+              formatter={(value: number, _n, entry: { payload?: MonthFiling }) => [
+                `${value} ± ${entry?.payload?.sd ?? 0}`,
+                meanLabel,
+              ]}
+            />
+            <Bar dataKey="mean" name={meanLabel} radius={[3, 3, 0, 0]} isAnimationActive={false}>
+              {data.map((d) => (
+                // Lighter blue than navy so the dark error whiskers stay legible
+                // against the fill; the fiscal year-end peak is accented in crimson.
+                <Cell key={d.month} fill={peakMonth === d.month ? "hsl(var(--accent))" : "#2a78d6"} />
+              ))}
+              <ErrorBar
+                dataKey="sd"
+                width={7}
+                strokeWidth={2}
+                stroke="hsl(var(--foreground))"
+                direction="y"
+              />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/data/research-corruption.ts
+++ b/src/data/research-corruption.ts
@@ -65,6 +65,28 @@ export type CohortRow = {
   medianMonths: number;
 };
 
+export type ChargeMixYear = {
+  /** Bikram Sambat filing (registration) year. */
+  bs: number;
+  bribery: number;
+  fake: number;
+  embezzlement: number;
+  benefit: number;
+  loss: number;
+  /** Smaller families folded together (illicit enrichment, irregularity, etc.). */
+  other: number;
+};
+
+export type MonthFiling = {
+  /** Nepali month index: 1 = Baisakh … 12 = Chaitra. */
+  month: number;
+  name: string;
+  /** Mean cases filed in this month across complete BS years. */
+  mean: number;
+  /** ±1 sample standard deviation across those years. */
+  sd: number;
+};
+
 // In-platform citation targets. Each is a real public page on jawafdehi.org.
 export const CITATIONS = {
   ciaa35: "https://jawafdehi.org/material/ciaa_annual_report/ee0b4f80b24b8665",
@@ -73,11 +95,11 @@ export const CITATIONS = {
   ciaa32:
     "https://jawafdehi.org/material/ciaa_annual_report/4._32nd_annual_report_2078_079_fek7bv_ba92e14e",
   /** The whole CIAA annual-report series (41 materials). */
-  ciaaReports: "https://jawafdehi.org/materials?source=ciaa_annual_report",
+  ciaaReports: "https://jawafdehi.org/search?type=material&q=CIAA%20annual%20report",
   /** CIAA charge-sheet-filing announcements (3,438 press releases). */
-  ciaaPressReleases: "https://jawafdehi.org/materials?material_type=press_release",
+  ciaaPressReleases: "https://jawafdehi.org/search?type=material&q=CIAA%20press%20release",
   /** AG abhiyog-patra (charge sheets, 99,783). */
-  chargeSheets: "https://jawafdehi.org/materials?material_type=charge_sheet",
+  chargeSheets: "https://jawafdehi.org/search?type=material&q=charge%20sheet",
   /** The Special Court record base. */
   courtRecords: "https://jawafdehi.org/courtcases",
   /** Representative decided cases (verify each resolves logged-out). */
@@ -176,11 +198,60 @@ export const REPORT = {
     decided: [86, 126, 138, 251, 150, 180, 275, 251, 147, 116, 438, 529, 279, 92, 11],
   },
 
+  // --- Charge mix by filing year (BS registration year), substantive prosecutions ---
+  // Bucketed from raw case_type over plaintiff = Government of Nepal, Special Court,
+  // petitions & money-laundering excluded. `other` folds the smaller families
+  // (illicit enrichment, irregularity, false statement, land, revenue, forgery, exam).
+  // The story: fake-credential's share falls from ~75% (BS 2069) to single digits
+  // by BS 2078–2080 (with a one-year rebound in 2081), while the newer illegal-
+  // benefit charge (absent before BS 2078) and loss to government grow.
+  // BS 2083 (partial year) omitted.
+  chargeMixByYear: [
+    { bs: 2069, bribery: 7, fake: 116, embezzlement: 6, benefit: 1, loss: 0, other: 24 },
+    { bs: 2070, bribery: 17, fake: 70, embezzlement: 6, benefit: 0, loss: 0, other: 37 },
+    { bs: 2071, bribery: 62, fake: 117, embezzlement: 98, benefit: 0, loss: 11, other: 58 },
+    { bs: 2072, bribery: 43, fake: 27, embezzlement: 21, benefit: 0, loss: 3, other: 22 },
+    { bs: 2073, bribery: 53, fake: 54, embezzlement: 29, benefit: 0, loss: 0, other: 24 },
+    { bs: 2074, bribery: 89, fake: 19, embezzlement: 21, benefit: 0, loss: 1, other: 17 },
+    { bs: 2075, bribery: 130, fake: 117, embezzlement: 34, benefit: 0, loss: 1, other: 45 },
+    { bs: 2076, bribery: 244, fake: 81, embezzlement: 64, benefit: 0, loss: 11, other: 63 },
+    { bs: 2077, bribery: 93, fake: 23, embezzlement: 23, benefit: 0, loss: 24, other: 33 },
+    { bs: 2078, bribery: 28, fake: 4, embezzlement: 22, benefit: 3, loss: 13, other: 17 },
+    { bs: 2079, bribery: 24, fake: 10, embezzlement: 30, benefit: 39, loss: 30, other: 38 },
+    { bs: 2080, bribery: 55, fake: 16, embezzlement: 8, benefit: 30, loss: 36, other: 46 },
+    { bs: 2081, bribery: 37, fake: 37, embezzlement: 4, benefit: 29, loss: 8, other: 19 },
+    { bs: 2082, bribery: 34, fake: 12, embezzlement: 23, benefit: 36, loss: 36, other: 40 },
+  ] satisfies ChargeMixYear[],
+
+  // --- Cases filed per Nepali month — mean ± sample SD across complete years ---
+  // Mean and standard deviation of monthly filings across BS 2069–2082 (14 years);
+  // error bars are ±1 SD, showing year-to-year variability. Filings peak in Ashadh
+  // (fiscal year-end) and trough in Kartik (Dashain/Tihar festival month).
+  filedByMonth: [
+    { month: 1, name: "Baisakh", mean: 13.9, sd: 7.3 },
+    { month: 2, name: "Jestha", mean: 21.4, sd: 13.3 },
+    { month: 3, name: "Ashadh", mean: 27.9, sd: 15.7 },
+    { month: 4, name: "Shrawan", mean: 15.3, sd: 8.8 },
+    { month: 5, name: "Bhadra", mean: 19.6, sd: 12.9 },
+    { month: 6, name: "Ashwin", mean: 15.9, sd: 12.4 },
+    { month: 7, name: "Kartik", mean: 11.2, sd: 11.3 },
+    { month: 8, name: "Mangsir", mean: 15.2, sd: 11.1 },
+    { month: 9, name: "Poush", mean: 16.8, sd: 11.3 },
+    { month: 10, name: "Magh", mean: 15.4, sd: 8.3 },
+    { month: 11, name: "Falgun", mean: 17.9, sd: 14.9 },
+    { month: 12, name: "Chaitra", mean: 16.5, sd: 7.0 },
+  ] satisfies MonthFiling[],
+
   // --- Funnel (CIAA annual report + our court records) ---
-  // Complaint + prosecution counts from the CIAA 35th annual report (FY 2081/82);
-  // the conviction stage applies our measured 46% full-conviction rate to the filed count.
+  // Complaint, investigation + prosecution counts from the CIAA 35th annual report
+  // (FY 2081/82): 37,026 complaints, of which 947 completed a full investigation
+  // (Table 2.15) and 137 were prosecuted; the conviction stage applies our measured
+  // 46% full-conviction rate to the filed count. The `investigated` stage keeps the
+  // funnel honest — the steep drop is at intake screening, not the courtroom, and the
+  // CIAA prosecutes ~1 in 7 of the complaints it actually investigates.
   funnel: [
     { key: "complaints", count: 37026, source: "ciaa35" },
+    { key: "investigated", count: 947, source: "ciaa35" },
     { key: "filed", count: 137, source: "ciaa35" },
     { key: "convicted", count: 63, source: "courtRecords" },
   ] satisfies FunnelStageData[],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1138,19 +1138,24 @@
         "eyebrow": "Research · Corruption Accountability",
         "title": "Where Nepal's corruption accountability actually leaks",
         "lead": "How many complaints become cases, how those cases resolve, and which charges the system convicts — drawn from court records ingested from Nepal's judiciary and the CIAA's own annual reports. Every figure links to the record behind it.",
-        "snapshot": "Snapshot as of BS {{bs}}. Court records collected from Nepal's Special Court and wider judiciary.",
+        "snapshot": "Snapshot as of BS {{bs}}.",
+        "methodologyLink": "How we built and cross-checked these numbers →",
         "englishOnlyNotice": "This report is currently available in English only."
       },
       "funnel": {
         "eyebrow": "The funnel",
         "heading": "About 0.2% of complaints end in a full conviction",
-        "lead": "In a single year the CIAA received roughly 37,000 complaints and filed about 137 prosecutions. Apply the measured full-conviction rate and only a few dozen end in a full conviction.",
+        "lead": "In a single year the CIAA received about 37,026 complaints. Most were screened out at intake — only 947 (2.6%) went to a full investigation — and of those it prosecuted 137, roughly one in seven. Apply the measured full-conviction rate and only a few dozen end in a full conviction.",
         "ofComplaints": "{{pct}}% of complaints",
-        "caption": "Complaint and prosecution counts: CIAA 35th annual report (FY 2081/82). The conviction stage applies this archive's measured 46% full-conviction rate to the filed count.",
+        "caption": "Complaint, investigation and prosecution counts: CIAA 35th annual report (FY 2081/82), cross-checked against the court records. The steep drop is at intake screening, not the courtroom — most complaints never warrant a full investigation (many are outside the CIAA's jurisdiction or evidence-free); of those it does investigate, it prosecutes about 1 in 7. The conviction stage applies this archive's measured 46% full-conviction rate to the filed count.",
         "stage": {
           "complaints": "Complaints to the CIAA",
+          "investigated": "Complaints fully investigated",
           "filed": "Prosecutions filed",
-          "convicted": "Full convictions (est.)"
+          "convicted": "Full convictions (est.)",
+          "investigatedNote": "only 2.6% go to a full investigation",
+          "filedNote": "≈1 in 7 investigated are prosecuted",
+          "convictedNote": "≈46% of prosecutions convict"
         }
       },
       "cite": {
@@ -1213,27 +1218,50 @@
         "provisional": "Provisional (cohort still open)",
         "mixTitle": "The charge mix",
         "mixSub": "Substantive prosecutions by offense family (petitions excluded).",
-        "mixTooltip": "Prosecutions"
+        "mixTooltip": "Prosecutions",
+        "mixByYearTitle": "How the charge mix shifted, by year",
+        "mixPercentToggle": "Show as 100%",
+        "mixByYearSub": "Substantive prosecutions by Bikram Sambat filing year. Fake-credential cases (crimson) dominated the early docket — about 75% in BS 2069 — then fell to single digits by BS 2078–2080 (with a one-year rebound in 2081), while the newer illegal-benefit charge (absent before BS 2078) and loss to government grew. BS 2083 (partial year) omitted.",
+        "mixLabels": {
+          "bribery": "Bribery",
+          "fake": "Fake credential",
+          "embezzlement": "Embezzlement",
+          "benefit": "Illegal benefit",
+          "loss": "Loss to government",
+          "other": "Other"
+        },
+        "monthTitle": "When cases are filed, by Nepali month",
+        "monthSub": "Mean cases filed per Nepali month across BS 2069–2082; error bars show ±1 standard deviation. Filings peak in Ashadh — the fiscal year-end — and trough in Kartik, the Dashain/Tihar festival month.",
+        "monthMean": "Mean cases filed",
+        "monthSd": "±1 SD",
+        "monthCaption": "Bars are the mean across 14 complete Bikram Sambat years (BS 2069–2082); whiskers are ±1 standard deviation — how much each month swings from year to year. Registration date from Special Court records."
       },
       "gaps": {
         "eyebrow": "Where the gap is",
         "heading": "Attrition concentrates at the CIAA stage — then goes dark",
-        "intake": { "title": "Intake & screening (CIAA)", "body": "~37,000 complaints a year produce ~137 prosecutions (≈0.4%); most complaints are shelved internally with no public verdict. The single biggest, least-visible leak." },
+        "intake": { "title": "Intake & screening (CIAA)", "body": "~37,000 complaints a year produce ~137 prosecutions (≈0.4% of all complaints); most are screened out at intake — only ~1 in 7 of those the CIAA fully investigates is prosecuted — and the rest are shelved with no public verdict. The single biggest, least-visible leak." },
         "charging": { "title": "Charging strategy (CIAA)", "body": "49% of convictions are easy documentary fake-certificate cases; core financial corruption converts at ~31%, with the signature charges collapsing. The system convicts paperwork, not plunder." },
         "adjudication": { "title": "Adjudication (Special Court)", "body": "38% outright acquittal, 54% less-than-full-conviction, and a threefold spread across benches. Year-to-year the rate swung 88% → 33%, partly on one 2078 apex-court ruling." },
         "appeal": { "title": "Appeal (Supreme Court) — dark", "body": "The CIAA appeals many losses and defendants appeal convictions, but appellate outcomes carry no decision data in the record. How often a verdict is overturned is currently unmeasurable." },
         "recovery": { "title": "Recovery & sanction — dark", "body": "Billions in damages are claimed each year, but no source tracks how much is ever recovered, or whether the convicted serve meaningful sanction." }
       },
       "appendix": {
-        "summary": "Methodology, discrepancies & sources",
+        "eyebrow": "Methodology",
+        "heading": "How this report was built and cross-checked",
+        "summary": "Full methodology, discrepancies & limits",
+        "sourcesLead": "Two independent public records, cross-checked against each other — and both browsable on Jawafdehi. Complaint, investigation and prosecution counts come from the CIAA's own annual reports; conviction outcomes come from our mirror of Nepal's Special Court and wider judiciary. Where the two overlap — the cases filed each year — they agree. Every figure on this page links to the record behind it.",
         "corpus": "Corpus. Of ~12,600 Special Court records, most are procedural petitions. We isolate CIAA prosecutions as cases filed in the name of the Government of Nepal (~3,278), of which ~2,850 are substantive corruption charges after removing petitions, money-laundering (a separate agency), and unclassified matters.",
+        "funnel": "The funnel. Of 37,026 complaints in the year, only 947 (2.6%) went to a full investigation; most of the rest were screened out at intake — shelved or referred — much of it legitimate (outside the CIAA's jurisdiction, no supporting evidence, or duplicates). Of the complaints it fully investigated, the CIAA filed charges in 137 — about 1 in 7 (the CIAA reports this as 13% of its investigation decisions). So “0.4% of all complaints reach court” and “~1 in 7 of the complaints it investigates is prosecuted” are both true and measure different stages; the steep drop is concentrated at screening, not the courtroom.",
         "outcomes": "Outcomes. Verdicts are coded per hearing as convicted / acquitted / partial; each case is taken at its terminal deciding hearing. The conviction rate is over the ~92% of decided cases carrying an unambiguous disposition (2,835 of 3,069).",
         "dates": "Dates. Verdict dates are parsed from the case status text; filings from the registration date. Bikram Sambat throughout.",
         "overTime": "Over time. Yearly rates are grouped by verdict year; the sharp rise in acquittals from BS 2079 is a genuine surge in the record, not a coding artifact. Time-to-verdict is measured by filing cohort: cohorts through BS 2079 are essentially fully decided, but recent cohorts are still open, so their apparent speed reflects only the cases already resolved (survivorship) and is drawn as provisional.",
         "justice": "Per-justice. Attribution is bench-grain: every member of a panel is credited with the panel's outcome, so this describes the benches a justice sat on, not that justice's individual effect. It is descriptive, and small differences are noise.",
         "discrepancy": "Discrepancy with CIAA figures. The CIAA reports a ~53% “success” rate; that counts full + partial convictions together, and is fiscal-year, whereas our full-conviction rate (46%) is cumulative and separates the two. CIAA's “cases filed” per fiscal year also differ from our Bikram-Sambat-year filing counts because of year binning, case-versus-defendant counting, and record timing. Never compare the two without aligning definition and period.",
         "entity": "Identity. Only ~3% of listed defendants (607 of 19,222) are resolved to a canonical, cross-referenced identity, so office-level and repeat-offender cuts are deferred as low-confidence.",
-        "limits": "Limits. These are the records in the archive as of the snapshot date; appellate outcomes are largely absent, and amount-recovered is untracked anywhere."
+        "likhitPre": "Reading the source PDFs. The CIAA reports are Nepali-language PDFs set in legacy Devanagari fonts that ordinary tools garble. We convert them to clean, checkable Markdown with ",
+        "likhitName": "likhit",
+        "likhitPost": " — Jawafdehi's open-source universal Nepali document-to-markdown converter — then verify every figure by eye against the original page.",
+        "limits": "Limits. These are the records in the archive as of the snapshot date (BS {{bs}}); figures update as new records are mirrored. Appellate outcomes are largely absent, and amount-recovered is untracked anywhere."
       },
       "sources": {
         "heading": "Sources — all in-platform",

--- a/src/pages/ResearchCorruption.tsx
+++ b/src/pages/ResearchCorruption.tsx
@@ -13,6 +13,8 @@ import { JusticeSpread } from "@/components/research/JusticeSpread";
 import { FiledDecidedTrend } from "@/components/research/FiledDecidedTrend";
 import { RateTrend } from "@/components/research/RateTrend";
 import { PipelineHealth } from "@/components/research/PipelineHealth";
+import { ChargeMixByYear } from "@/components/research/ChargeMixByYear";
+import { FiledByMonth } from "@/components/research/FiledByMonth";
 
 const CANONICAL = "https://jawafdehi.org/research/corruption-accountability";
 
@@ -46,6 +48,13 @@ const ResearchCorruption = () => {
   const courtAvgConv = (o.convicted / decidedClean) * 100;
 
   // Funnel — uniform accent hue; the shrinking widths + "% of complaints" tell it.
+  // Notes carry the "share of the previous stage" story the single denominator can't:
+  // the big drop is intake screening, and the CIAA prosecutes ~1 in 7 of what it investigates.
+  const funnelStageNote: Record<string, string> = {
+    investigated: t("research.corruption.funnel.stage.investigatedNote", "only 2.6% go to a full investigation"),
+    filed: t("research.corruption.funnel.stage.filedNote", "≈1 in 7 investigated are prosecuted"),
+    convicted: t("research.corruption.funnel.stage.convictedNote", "≈46% of prosecutions convict"),
+  };
   const funnelStages: FunnelStage[] = REPORT.funnel.map((s) => ({
     key: s.key,
     label: t(
@@ -53,6 +62,7 @@ const ResearchCorruption = () => {
       (
         {
           complaints: "Complaints to the CIAA",
+          investigated: "Complaints fully investigated",
           filed: "Prosecutions filed",
           convicted: "Full convictions (est.)",
         } as Record<string, string>
@@ -60,6 +70,7 @@ const ResearchCorruption = () => {
     ),
     count: s.count,
     color: "hsl(var(--accent))",
+    note: funnelStageNote[s.key],
   }));
 
   const outcomeSegments: DonutSegment[] = [
@@ -143,7 +154,19 @@ const ResearchCorruption = () => {
               {t("research.corruption.hero.lead", "How many complaints become cases, how those cases resolve, and which charges the system convicts — drawn from court records ingested from Nepal's judiciary and the CIAA's own annual reports. Every figure links to the record behind it.")}
             </p>
             <p className="mt-4 text-sm italic text-muted-foreground/80">
-              {t("research.corruption.hero.snapshot", "Snapshot as of BS {{bs}}. Court records collected from Nepal's Special Court and wider judiciary.", { bs: REPORT.snapshotBs })}
+              {t("research.corruption.hero.snapshot", "Snapshot as of BS {{bs}}.", { bs: REPORT.snapshotBs })}{" "}
+              <a
+                href="#methodology"
+                onClick={(e) => {
+                  // <base href="/"> makes a bare "#methodology" resolve to the site
+                  // root, so scroll in-page ourselves instead of letting it navigate.
+                  e.preventDefault();
+                  document.getElementById("methodology")?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }}
+                className="font-medium not-italic text-accent hover:underline"
+              >
+                {t("research.corruption.hero.methodologyLink", "How we built and cross-checked these numbers →")}
+              </a>
             </p>
             <p className="mt-4 inline-flex items-center gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground">
               <Info className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -158,7 +181,7 @@ const ResearchCorruption = () => {
             <Eyebrow>{t("research.corruption.funnel.eyebrow", "The funnel")}</Eyebrow>
             <SectionHeading>{t("research.corruption.funnel.heading", "About 0.2% of complaints end in a full conviction")}</SectionHeading>
             <p className="mt-4 max-w-2xl text-lg leading-8 text-foreground/70">
-              {t("research.corruption.funnel.lead", "In a single year the CIAA received roughly 37,000 complaints and filed about 137 prosecutions. Apply the measured full-conviction rate and only a few dozen end in a full conviction.")}
+              {t("research.corruption.funnel.lead", "In a single year the CIAA received about 37,026 complaints. Most were screened out at intake — only 947 (2.6%) went to a full investigation — and of those it prosecuted 137, roughly one in seven. Apply the measured full-conviction rate and only a few dozen end in a full conviction.")}
             </p>
             <div className="mt-8">
               <AccountabilityFunnel
@@ -169,7 +192,7 @@ const ResearchCorruption = () => {
               />
             </div>
             <p className="mt-4 text-xs leading-5 text-muted-foreground">
-              {t("research.corruption.funnel.caption", "Complaint and prosecution counts: CIAA 35th annual report (FY 2081/82). The conviction stage applies this archive's measured 46% full-conviction rate to the filed count.")}{" "}
+              {t("research.corruption.funnel.caption", "Complaint, investigation and prosecution counts: CIAA 35th annual report (FY 2081/82), cross-checked against the court records. The steep drop is at intake screening, not the courtroom — most complaints never warrant a full investigation (many are outside the CIAA's jurisdiction or evidence-free); of those it does investigate, it prosecutes about 1 in 7. The conviction stage applies this archive's measured 46% full-conviction rate to the filed count.")}{" "}
               <a href={CITATIONS.ciaa35} className="text-accent hover:underline">{t("research.corruption.cite.ciaa35", "CIAA 35th annual report")}</a>
             </p>
           </section>
@@ -317,6 +340,35 @@ const ResearchCorruption = () => {
               <p className="mb-4 mt-1 text-sm text-muted-foreground">{t("research.corruption.volume.mixSub", "Substantive prosecutions by offense family (petitions excluded).")}</p>
               <BreakdownBar items={mixItems} tooltipLabel={t("research.corruption.volume.mixTooltip", "Prosecutions")} labelWidth={150} />
             </div>
+
+            <div className="mt-10">
+              <h3 className="text-base font-semibold text-foreground">{t("research.corruption.volume.mixByYearTitle", "How the charge mix shifted, by year")}</h3>
+              <p className="mb-4 mt-1 text-sm text-muted-foreground">{t("research.corruption.volume.mixByYearSub", "Substantive prosecutions by Bikram Sambat filing year. Fake-credential cases (crimson) dominated the early docket — about 75% in BS 2069 — then fell to single digits by BS 2078–2080 (with a one-year rebound in 2081), while the newer illegal-benefit charge (absent before BS 2078) and loss to government grew. BS 2083 (partial year) omitted.")}</p>
+              <ChargeMixByYear
+                data={REPORT.chargeMixByYear}
+                percentLabel={t("research.corruption.volume.mixPercentToggle", "Show as 100%")}
+                labels={{
+                  bribery: t("research.corruption.volume.mixLabels.bribery", "Bribery"),
+                  fake: t("research.corruption.volume.mixLabels.fake", "Fake credential"),
+                  embezzlement: t("research.corruption.volume.mixLabels.embezzlement", "Embezzlement"),
+                  benefit: t("research.corruption.volume.mixLabels.benefit", "Illegal benefit"),
+                  loss: t("research.corruption.volume.mixLabels.loss", "Loss to government"),
+                  other: t("research.corruption.volume.mixLabels.other", "Other"),
+                }}
+              />
+            </div>
+
+            <div className="mt-10">
+              <h3 className="text-base font-semibold text-foreground">{t("research.corruption.volume.monthTitle", "When cases are filed, by Nepali month")}</h3>
+              <p className="mb-4 mt-1 text-sm text-muted-foreground">{t("research.corruption.volume.monthSub", "Mean cases filed per Nepali month across BS 2069–2082; error bars show ±1 standard deviation. Filings peak in Ashadh — the fiscal year-end — and trough in Kartik, the Dashain/Tihar festival month.")}</p>
+              <FiledByMonth
+                data={REPORT.filedByMonth}
+                peakMonth={3}
+                meanLabel={t("research.corruption.volume.monthMean", "Mean cases filed")}
+                sdLabel={t("research.corruption.volume.monthSd", "±1 SD")}
+              />
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">{t("research.corruption.volume.monthCaption", "Bars are the mean across 14 complete Bikram Sambat years (BS 2069–2082); whiskers are ±1 standard deviation — how much each month swings from year to year. Registration date from Special Court records.")}</p>
+            </div>
           </section>
 
           {/* 7 · Gaps */}
@@ -340,7 +392,7 @@ const ResearchCorruption = () => {
                   </h3>
                   <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
                     {t(`research.corruption.gaps.${k}.body`, {
-                      intake: "~37,000 complaints a year produce ~137 prosecutions (≈0.4%); most complaints are shelved internally with no public verdict. The single biggest, least-visible leak.",
+                      intake: "~37,000 complaints a year produce ~137 prosecutions (≈0.4% of all complaints); most are screened out at intake — only ~1 in 7 of those the CIAA fully investigates is prosecuted — and the rest are shelved with no public verdict. The single biggest, least-visible leak.",
                       charging: "49% of convictions are easy documentary fake-certificate cases; core financial corruption converts at ~31%, with the signature charges collapsing. The system convicts paperwork, not plunder.",
                       adjudication: "38% outright acquittal, 54% less-than-full-conviction, and a threefold spread across benches. Year-to-year the rate swung 88% → 33%, partly on one 2078 apex-court ruling.",
                       appeal: "The CIAA appeals many losses and defendants appeal convictions, but appellate outcomes carry no decision data in the record. How often a verdict is overturned is currently unmeasurable.",
@@ -352,21 +404,32 @@ const ResearchCorruption = () => {
             </div>
           </section>
 
-          {/* 8 · Appendix */}
-          <section>
-            <details className="rounded-xl border border-border bg-muted/20 p-5">
+          {/* 8 · Methodology — the single, global methodology for the whole report */}
+          <section id="methodology" className="scroll-mt-24">
+            <Eyebrow>{t("research.corruption.appendix.eyebrow", "Methodology")}</Eyebrow>
+            <SectionHeading>{t("research.corruption.appendix.heading", "How this report was built and cross-checked")}</SectionHeading>
+            <p className="mt-4 max-w-2xl text-lg leading-8 text-foreground/70">
+              {t("research.corruption.appendix.sourcesLead", "Two independent public records, cross-checked against each other — and both browsable on Jawafdehi. Complaint, investigation and prosecution counts come from the CIAA's own annual reports; conviction outcomes come from our mirror of Nepal's Special Court and wider judiciary. Where the two overlap — the cases filed each year — they agree. Every figure on this page links to the record behind it.")}
+            </p>
+            <details className="mt-6 rounded-xl border border-border bg-muted/20 p-5">
               <summary className="cursor-pointer text-sm font-semibold text-foreground">
-                {t("research.corruption.appendix.summary", "Methodology, discrepancies & sources")}
+                {t("research.corruption.appendix.summary", "Full methodology, discrepancies & limits")}
               </summary>
               <div className="mt-4 space-y-3 text-xs leading-5 text-muted-foreground">
                 <p>{t("research.corruption.appendix.corpus", "Corpus. Of ~12,600 Special Court records, most are procedural petitions. We isolate CIAA prosecutions as cases filed in the name of the Government of Nepal (~3,278), of which ~2,850 are substantive corruption charges after removing petitions, money-laundering (a separate agency), and unclassified matters.")}</p>
+                <p>{t("research.corruption.appendix.funnel", "The funnel. Of 37,026 complaints in the year, only 947 (2.6%) went to a full investigation; most of the rest were screened out at intake — shelved or referred — much of it legitimate (outside the CIAA's jurisdiction, no supporting evidence, or duplicates). Of the complaints it fully investigated, the CIAA filed charges in 137 — about 1 in 7 (the CIAA reports this as 13% of its investigation decisions). So “0.4% of all complaints reach court” and “~1 in 7 of the complaints it investigates is prosecuted” are both true and measure different stages; the steep drop is concentrated at screening, not the courtroom.")}</p>
                 <p>{t("research.corruption.appendix.outcomes", "Outcomes. Verdicts are coded per hearing as convicted / acquitted / partial; each case is taken at its terminal deciding hearing. The conviction rate is over the ~92% of decided cases carrying an unambiguous disposition (2,835 of 3,069).")}</p>
                 <p>{t("research.corruption.appendix.dates", "Dates. Verdict dates are parsed from the case status text; filings from the registration date. Bikram Sambat throughout.")}</p>
                 <p>{t("research.corruption.appendix.overTime", "Over time. Yearly rates are grouped by verdict year; the sharp rise in acquittals from BS 2079 is a genuine surge in the record, not a coding artifact. Time-to-verdict is measured by filing cohort: cohorts through BS 2079 are essentially fully decided, but recent cohorts are still open, so their apparent speed reflects only the cases already resolved (survivorship) and is drawn as provisional.")}</p>
                 <p>{t("research.corruption.appendix.justice", "Per-justice. Attribution is bench-grain: every member of a panel is credited with the panel's outcome, so this describes the benches a justice sat on, not that justice's individual effect. It is descriptive, and small differences are noise.")}</p>
                 <p>{t("research.corruption.appendix.discrepancy", "Discrepancy with CIAA figures. The CIAA reports a ~53% “success” rate; that counts full + partial convictions together, and is fiscal-year, whereas our full-conviction rate (46%) is cumulative and separates the two. CIAA's “cases filed” per fiscal year also differ from our Bikram-Sambat-year filing counts because of year binning, case-versus-defendant counting, and record timing. Never compare the two without aligning definition and period.")}</p>
                 <p>{t("research.corruption.appendix.entity", "Identity. Only ~3% of listed defendants (607 of 19,222) are resolved to a canonical, cross-referenced identity, so office-level and repeat-offender cuts are deferred as low-confidence.")}</p>
-                <p>{t("research.corruption.appendix.limits", "Limits. These are the records in the archive as of the snapshot date; appellate outcomes are largely absent, and amount-recovered is untracked anywhere.")}</p>
+                <p>
+                  {t("research.corruption.appendix.likhitPre", "Reading the source PDFs. The CIAA reports are Nepali-language PDFs set in legacy Devanagari fonts that ordinary tools garble. We convert them to clean, checkable Markdown with ")}
+                  <a href="https://github.com/Jawafdehi/likhit" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">{t("research.corruption.appendix.likhitName", "likhit")}</a>
+                  {t("research.corruption.appendix.likhitPost", " — Jawafdehi's open-source universal Nepali document-to-markdown converter — then verify every figure by eye against the original page.")}
+                </p>
+                <p>{t("research.corruption.appendix.limits", "Limits. These are the records in the archive as of the snapshot date (BS {{bs}}); figures update as new records are mirrored. Appellate outcomes are largely absent, and amount-recovered is untracked anywhere.", { bs: REPORT.snapshotBs })}</p>
               </div>
             </details>
 


### PR DESCRIPTION
## What & why
Reviewer feedback on `/research/corruption-accountability` prompted a cross-check of the court-record mirror against the **CIAA 35th Annual Report (FY 2081/82)**. Every published figure verified against source; this PR adds two improvements and two new charts.

### Funnel — honest intake framing
Adds the intermediate **"947 complaints fully investigated"** stage (CIAA Table 2.15) with per-stage drop indicators. Makes explicit that the steep drop is at **intake screening, not the courtroom**: 0.4% of all complaints reach court, but the CIAA prosecutes **~1 in 7** of the complaints it actually investigates (its own reported ~13% of investigation decisions).

### New chart — charge mix by filing year
Stacked bar per BS filing year with a **counts / 100%-share toggle (off by default)**. Fake-credential's share falls from ~75% (BS 2069) to single digits (2078–80, with a one-year rebound in 2081); the newer **illegal-benefit** charge (absent before BS 2078) and loss-to-government rise.

### New chart — cases filed per Nepali month
Mean **± 1 SD** error bars across BS 2069–2082. Filings peak in **Ashadh** (fiscal year-end) and trough in **Kartik** (Dashain/Tihar festival month).

### Single, report-wide Methodology
Consolidated into one prominent section: two independent public records cross-checked (**court records + CIAA annual reports, both browsable on Jawafdehi**); source PDFs converted with **likhit**, the universal Nepali document-to-markdown converter.

### Fixes
- Repointed broken `/materials?...` citation links to `/search?type=material` (the search page has no `material_type` facet).

## Data provenance
Charts computed from the NGM Special Court mirror (plaintiff = Government of Nepal; procedural petitions excluded). Monthly SD is the **sample** standard deviation across complete years.

## Testing
- `tsc --noEmit` clean; existing component/data tests pass; `eslint --fix` clean.
- Verified live on the dev server (funnel indicators, toggle, error-bar legibility).

## Review
Ran an xhigh-recall code review (correctness/Recharts, cross-file/i18n, data-accuracy/conventions). No crash/correctness defects; 4 minor findings fixed (caption vs BS 2081 rebound, mount CLS, month whisker underflow, hardcoded toggle id).

## Follow-up
- `ne.json` not updated for the new strings — the report is English-only via `getFixedT("en")`, so no runtime impact; mirror when Nepali is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)