### PR TITLE
feat(updates): show featured image + caption on the article detail page

### DIFF
--- a/src/components/ArticleView.test.tsx
+++ b/src/components/ArticleView.test.tsx
@@ -59,4 +59,35 @@ describe("ArticleView", () => {
     );
     expect(screen.queryByText("Related cases")).toBeNull();
   });
+
+  it("renders the featured image when a thumbnail is set", () => {
+    render(
+      <MemoryRouter>
+        <ArticleView
+          article={{
+            ...article,
+            thumbnail: {
+              url: "https://s3.example.org/thumb.png",
+              width: 800,
+              height: 450,
+              alt: "Summit stage",
+            },
+          }}
+        />
+      </MemoryRouter>,
+    );
+    const img = screen.getByRole("img", { name: "Summit stage" });
+    expect(img.getAttribute("src")).toBe("https://s3.example.org/thumb.png");
+    // The image description doubles as the visible caption.
+    expect(screen.getByText("Summit stage").tagName).toBe("FIGCAPTION");
+  });
+
+  it("renders no featured image when the thumbnail is null", () => {
+    render(
+      <MemoryRouter>
+        <ArticleView article={{ ...article, thumbnail: null }} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("img")).toBeNull();
+  });
 });

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -42,6 +42,23 @@ export const ArticleView = ({ article }: { article: Article }) => {
                                 </div>
                             </div>
 
+                            {article.thumbnail?.url && (
+                                <figure className="mb-8">
+                                    <img
+                                        src={article.thumbnail.url}
+                                        alt={article.thumbnail.alt || article.title}
+                                        width={article.thumbnail.width}
+                                        height={article.thumbnail.height}
+                                        className="w-full rounded-lg"
+                                    />
+                                    {article.thumbnail.alt ? (
+                                        <figcaption className="font-caption mt-2 text-muted-foreground">
+                                            {article.thumbnail.alt}
+                                        </figcaption>
+                                    ) : null}
+                                </figure>
+                            )}
+
                             <div className="font-paragraph content-prose markdown-content">
                                 <StreamField blocks={article.body} />
                             </div>


### PR DESCRIPTION
## Problem
The article detail page (e.g. [/updates/jawafdehi-presents-at-the-nepals-digital-democracy-summit](https://jawafdehi.org/updates/jawafdehi-presents-at-the-nepals-digital-democracy-summit)) never showed the page's **featured image**. `ArticleView` rendered only title, date, body (`StreamField`) and related cases. The thumbnail data was fully present (API returns an 800×450 rendition + alt; R2 serves 200), but there was no `<img>` to display it — so the image only appeared on the `/updates` listing cards and in the `og:image` social meta.

## Change
Render the thumbnail in `ArticleView` **below the header, before the body**, as a `<figure>` with the image's description as a `<figcaption>` (styled with the app's `font-caption`). Matches the existing StreamField image pattern (`rounded-lg` image + `<figcaption>`). Because `ArticleView` is shared with the Wagtail **headless preview**, editors see it in preview too.

- No backend change — uses the existing `thumbnail` API field (`url`/`alt`/`width`/`height`). Caption reuses the image `description` (same text as `alt`, per product decision).
- Renders nothing when a page has no thumbnail.

## Tests
`ArticleView.test.tsx`: added cases for (a) image + figcaption render when a thumbnail is set, (b) no image when thumbnail is null. All 4 pass; eslint clean.

## Verified
Ran locally against the **prod API** (dev server proxied to `api.jawafdehi.org`) and rendered the real article headless: featured image loads (`naturalWidth: 800`), caption present in a `<figcaption>`, single added figure (no duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Articles now display a featured image when one is available.
  * Images include accessible alternative text and an optional visible caption.

* **Bug Fixes**
  * Articles without a featured image no longer render an empty image area.

* **Tests**
  * Added coverage for featured image display, captions, and missing-image behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->