### PR TITLE
feat(analytics): exclude /admin routes from Google Analytics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import ResearchCorruption from "./pages/ResearchCorruption";
 import DocumentPreviewPage from "./pages/DocumentPreviewPage";
 import NotFound from "./pages/NotFound";
 import { ScrollToTop } from "@/components/ScrollToTop";
+import { AnalyticsRouteGate } from "@/components/AnalyticsRouteGate";
 
 // Lazily imported pages. These routes are not pre-rendered, so client-side code
 // splitting costs nothing at SEO/first-paint time and shrinks the entry chunk.
@@ -93,6 +94,7 @@ const App = () => (
       </ClientOnly>
       <Suspense fallback={<RouteLoadingFallback />}>
         <ScrollToTop />
+        <AnalyticsRouteGate />
         <Routes>
           {/* Embed route for oEmbed iframe */}
           <Route path="/embed/case/:id" element={<EmbedCaseCard />} />

--- a/src/components/AnalyticsRouteGate.test.tsx
+++ b/src/components/AnalyticsRouteGate.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, Link } from "react-router-dom";
+import { AnalyticsRouteGate } from "./AnalyticsRouteGate";
+import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
+
+const DISABLE_KEY = `ga-disable-${JAWAFDEHI_GA_MEASUREMENT_ID}`;
+const gaDisabled = () =>
+  (window as unknown as Record<string, unknown>)[DISABLE_KEY];
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>)[DISABLE_KEY];
+});
+
+describe("AnalyticsRouteGate", () => {
+  it("mutes analytics when the entry route is under /admin", () => {
+    render(
+      <MemoryRouter initialEntries={["/admin/cases"]}>
+        <AnalyticsRouteGate />
+      </MemoryRouter>,
+    );
+    expect(gaDisabled()).toBe(true);
+  });
+
+  it("leaves analytics active on public routes", () => {
+    render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <AnalyticsRouteGate />
+      </MemoryRouter>,
+    );
+    expect(gaDisabled()).toBe(false);
+  });
+
+  it("mutes on navigation into /admin and un-mutes on the way back out", () => {
+    render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <AnalyticsRouteGate />
+        <Routes>
+          <Route
+            path="/cases"
+            element={<Link to="/admin/entities">to-admin</Link>}
+          />
+          <Route
+            path="/admin/entities"
+            element={<Link to="/cases">to-public</Link>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(gaDisabled()).toBe(false);
+    fireEvent.click(screen.getByRole("link", { name: "to-admin" }));
+    expect(gaDisabled()).toBe(true);
+    fireEvent.click(screen.getByRole("link", { name: "to-public" }));
+    expect(gaDisabled()).toBe(false);
+  });
+});

--- a/src/components/AnalyticsRouteGate.test.tsx
+++ b/src/components/AnalyticsRouteGate.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { MemoryRouter, Routes, Route, Link } from "react-router-dom";
+import {
+  MemoryRouter,
+  BrowserRouter,
+  Routes,
+  Route,
+  Link,
+} from "react-router-dom";
 import { AnalyticsRouteGate } from "./AnalyticsRouteGate";
 import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
 
@@ -53,5 +59,59 @@ describe("AnalyticsRouteGate", () => {
     expect(gaDisabled()).toBe(true);
     fireEvent.click(screen.getByRole("link", { name: "to-public" }));
     expect(gaDisabled()).toBe(false);
+  });
+
+  // Deterministic guard against the GA4 Enhanced Measurement race: EM wraps
+  // history.pushState and fires a page_view synchronously on SPA navigation.
+  // This test installs a faithful EM emulation (wrapping pushState AFTER our
+  // guard, as a later-loading gtag.js would) that records a page_view for the
+  // new path UNLESS the property is opted out — and asserts the /admin hop
+  // leaks nothing while the public hop is still tracked.
+  it("emits no GA history page_view when navigating public -> /admin (real window.history)", () => {
+    window.history.replaceState({}, "", "/cases");
+
+    render(
+      <BrowserRouter>
+        <AnalyticsRouteGate />
+        <Routes>
+          <Route
+            path="/cases"
+            element={<Link to="/admin/entities">to-admin</Link>}
+          />
+          <Route
+            path="/admin/entities"
+            element={<Link to="/cases">to-public</Link>}
+          />
+        </Routes>
+      </BrowserRouter>,
+    );
+
+    const gaHits: string[] = [];
+    // At this point window.history.pushState is our guard's wrapper (installed
+    // on mount). Emulate EM stacking on top of it.
+    const guarded = window.history.pushState;
+    const emPushState = function (
+      this: History,
+      ...args: Parameters<History["pushState"]>
+    ): void {
+      guarded.apply(this, args); // guard sets ga-disable, then commits the URL
+      if (!gaDisabled()) gaHits.push(window.location.pathname);
+    } as typeof window.history.pushState;
+    window.history.pushState = emPushState;
+
+    try {
+      fireEvent.click(screen.getByRole("link", { name: "to-admin" }));
+      expect(window.location.pathname).toBe("/admin/entities");
+      expect(gaDisabled()).toBe(true);
+      expect(gaHits).not.toContain("/admin/entities");
+
+      fireEvent.click(screen.getByRole("link", { name: "to-public" }));
+      expect(window.location.pathname).toBe("/cases");
+      expect(gaDisabled()).toBe(false);
+      expect(gaHits).toContain("/cases");
+    } finally {
+      window.history.pushState = guarded;
+      window.history.replaceState({}, "", "/");
+    }
   });
 });

--- a/src/components/AnalyticsRouteGate.tsx
+++ b/src/components/AnalyticsRouteGate.tsx
@@ -1,18 +1,31 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { applyAnalyticsPathSuppression } from "@/lib/ga";
+import {
+  applyAnalyticsPathSuppression,
+  installAnalyticsNavigationSuppression,
+} from "@/lib/ga";
 
 /**
  * Keeps Google Analytics muted on admin/casework routes across client-side
  * navigation. `loadGoogleAnalytics` already refuses to load gtag.js while the
  * entry route is excluded; this covers the other direction — a visitor who
- * accepted analytics on a public page and then navigates into `/admin` — by
- * toggling gtag's `ga-disable-<id>` opt-out flag on every route change.
+ * accepted analytics on a public page and then navigates into `/admin`.
+ *
+ * The synchronous history guard (installed once on mount) sets gtag's
+ * `ga-disable-<id>` opt-out flag for the target path *during* the navigation
+ * call, so it beats GA4 Enhanced Measurement's own history-change page_view even
+ * on the first hop into an admin route. The per-route effect is a belt-and-
+ * suspenders reconcile for the initial paint and any navigation the history
+ * guard didn't originate (e.g. a direct `history` API call).
  *
  * Renders nothing. Effect-only, so it is inert during SSR/pre-render.
  */
 export function AnalyticsRouteGate() {
   const { pathname } = useLocation();
+
+  useEffect(() => {
+    installAnalyticsNavigationSuppression();
+  }, []);
 
   useEffect(() => {
     applyAnalyticsPathSuppression(pathname);

--- a/src/components/AnalyticsRouteGate.tsx
+++ b/src/components/AnalyticsRouteGate.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { applyAnalyticsPathSuppression } from "@/lib/ga";
+
+/**
+ * Keeps Google Analytics muted on admin/casework routes across client-side
+ * navigation. `loadGoogleAnalytics` already refuses to load gtag.js while the
+ * entry route is excluded; this covers the other direction — a visitor who
+ * accepted analytics on a public page and then navigates into `/admin` — by
+ * toggling gtag's `ga-disable-<id>` opt-out flag on every route change.
+ *
+ * Renders nothing. Effect-only, so it is inert during SSR/pre-render.
+ */
+export function AnalyticsRouteGate() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    applyAnalyticsPathSuppression(pathname);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/config/analytics-config.test.ts
+++ b/src/config/analytics-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { isAnalyticsExcludedPath } from "./analytics-config";
+
+describe("isAnalyticsExcludedPath", () => {
+  it("excludes the admin panel and its OIDC auth flows", () => {
+    for (const p of [
+      "/admin",
+      "/admin/",
+      "/admin/entities",
+      "/admin/jawafdehi/cases",
+      "/admin/login",
+      "/admin/callback",
+      "/admin/moderation",
+    ]) {
+      expect(isAnalyticsExcludedPath(p)).toBe(true);
+    }
+  });
+
+  it("excludes the legacy paths that redirect into admin", () => {
+    expect(isAnalyticsExcludedPath("/portal")).toBe(true);
+    expect(isAnalyticsExcludedPath("/portal/reviews")).toBe(true);
+    expect(isAnalyticsExcludedPath("/moderation")).toBe(true);
+  });
+
+  it("keeps public routes tracked", () => {
+    for (const p of [
+      "/",
+      "/cases",
+      "/case/some-slug",
+      "/search",
+      "/donate",
+      "/donate/success",
+      "/updates/a-post",
+    ]) {
+      expect(isAnalyticsExcludedPath(p)).toBe(false);
+    }
+  });
+
+  it("does not treat a longer look-alike path as excluded", () => {
+    // Prefix match must respect the segment boundary.
+    expect(isAnalyticsExcludedPath("/administration")).toBe(false);
+    expect(isAnalyticsExcludedPath("/portals")).toBe(false);
+    expect(isAnalyticsExcludedPath("/moderation-guidelines")).toBe(false);
+  });
+});

--- a/src/config/analytics-config.ts
+++ b/src/config/analytics-config.ts
@@ -1,1 +1,26 @@
 export const JAWAFDEHI_GA_MEASUREMENT_ID = "G-ZDV84KYJDJ";
+
+/**
+ * Route prefixes whose page views must NEVER reach Google Analytics: the
+ * auth-gated admin panel (`/admin/*`, which also holds the OIDC `/admin/login`
+ * and `/admin/callback` flows) plus the two legacy paths that redirect into it
+ * (`/portal/*` → `/admin/*`, and `/moderation` → `/admin/moderation`). This is
+ * staff casework traffic; counting it would pollute the public-usage picture the
+ * GA property exists to measure.
+ *
+ * GA4 has no server-side path-exclusion data filter (only Internal-Traffic-by-IP
+ * and Developer-Traffic filters), so the exclusion is enforced client-side — see
+ * `applyAnalyticsPathSuppression` and `loadGoogleAnalytics` in `@/lib/ga`.
+ */
+const ANALYTICS_EXCLUDED_PREFIXES = ["/admin", "/portal", "/moderation"];
+
+/**
+ * Whether analytics must be suppressed for `pathname`. Matches a prefix exactly
+ * (`/moderation`) or on a path-segment boundary (`/admin/...`), so unrelated
+ * paths like `/administration` are NOT caught.
+ */
+export function isAnalyticsExcludedPath(pathname: string): boolean {
+  return ANALYTICS_EXCLUDED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}

--- a/src/lib/ga.test.ts
+++ b/src/lib/ga.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { applyAnalyticsPathSuppression } from "./ga";
+import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
+
+const DISABLE_KEY = `ga-disable-${JAWAFDEHI_GA_MEASUREMENT_ID}`;
+
+function gaDisabled(): unknown {
+  return (window as unknown as Record<string, unknown>)[DISABLE_KEY];
+}
+
+describe("applyAnalyticsPathSuppression", () => {
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>)[DISABLE_KEY];
+  });
+
+  it("sets gtag's opt-out flag on excluded (admin) routes", () => {
+    applyAnalyticsPathSuppression("/admin/jawafdehi/cases");
+    expect(gaDisabled()).toBe(true);
+  });
+
+  it("clears the opt-out flag on public routes", () => {
+    applyAnalyticsPathSuppression("/admin/cases");
+    expect(gaDisabled()).toBe(true);
+    applyAnalyticsPathSuppression("/cases");
+    expect(gaDisabled()).toBe(false);
+  });
+});

--- a/src/lib/ga.test.ts
+++ b/src/lib/ga.test.ts
@@ -1,18 +1,33 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { applyAnalyticsPathSuppression } from "./ga";
 import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
 
-const DISABLE_KEY = `ga-disable-${JAWAFDEHI_GA_MEASUREMENT_ID}`;
+// Force the host/env gate open so loadGoogleAnalytics reaches its path check
+// (jsdom would otherwise look like an allowed prod host, but be explicit).
+vi.mock("./telemetry", () => ({
+  telemetryAllowedHere: () => true,
+  isCloudflarePreviewHost: () => false,
+}));
 
-function gaDisabled(): unknown {
-  return (window as unknown as Record<string, unknown>)[DISABLE_KEY];
-}
+const DISABLE_KEY = `ga-disable-${JAWAFDEHI_GA_MEASUREMENT_ID}`;
+const win = () => window as unknown as Record<string, unknown>;
+const gaDisabled = () => win()[DISABLE_KEY];
+
+const gaScripts = () =>
+  Array.from(document.querySelectorAll("script")).filter((s) =>
+    s.src.includes("googletagmanager.com/gtag/js"),
+  );
+
+afterEach(() => {
+  gaScripts().forEach((s) => s.remove());
+  delete win().gtag;
+  delete win().dataLayer;
+  delete win()[DISABLE_KEY];
+  window.history.replaceState({}, "", "/");
+  vi.resetModules();
+});
 
 describe("applyAnalyticsPathSuppression", () => {
-  afterEach(() => {
-    delete (window as unknown as Record<string, unknown>)[DISABLE_KEY];
-  });
-
   it("sets gtag's opt-out flag on excluded (admin) routes", () => {
     applyAnalyticsPathSuppression("/admin/jawafdehi/cases");
     expect(gaDisabled()).toBe(true);
@@ -22,6 +37,29 @@ describe("applyAnalyticsPathSuppression", () => {
     applyAnalyticsPathSuppression("/admin/cases");
     expect(gaDisabled()).toBe(true);
     applyAnalyticsPathSuppression("/cases");
+    expect(gaDisabled()).toBe(false);
+  });
+});
+
+describe("loadGoogleAnalytics (entry-route gate)", () => {
+  it("does NOT fetch gtag.js when the entry route is under /admin", async () => {
+    window.history.replaceState({}, "", "/admin/entities");
+    const { loadGoogleAnalytics } = await import("./ga");
+
+    loadGoogleAnalytics();
+
+    expect(gaScripts()).toHaveLength(0);
+    expect(win().gtag).toBeUndefined();
+  });
+
+  it("fetches gtag.js on a public route and leaves analytics active", async () => {
+    window.history.replaceState({}, "", "/cases");
+    const { loadGoogleAnalytics } = await import("./ga");
+
+    loadGoogleAnalytics();
+
+    expect(gaScripts()).toHaveLength(1);
+    expect(typeof win().gtag).toBe("function");
     expect(gaDisabled()).toBe(false);
   });
 });

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -2,11 +2,44 @@
  * Google Analytics 4 loader — only invoked after the visitor opts in via the
  * cookie consent banner. IP anonymization is enabled. Until this runs,
  * gtag.js is never fetched and no GA cookies are set.
+ *
+ * Admin/casework routes are excluded from analytics (see
+ * `isAnalyticsExcludedPath`): gtag.js is not loaded while the visitor is on one
+ * of those paths, and if the tag is already live (visitor navigated in from a
+ * public page) it is muted via gtag's `ga-disable-<id>` opt-out flag — which
+ * suppresses ALL hits for the property, including Enhanced Measurement's
+ * history-change page_views, not just the ones this app fires explicitly.
  */
-import { JAWAFDEHI_GA_MEASUREMENT_ID } from "@/config/analytics-config";
+import {
+  JAWAFDEHI_GA_MEASUREMENT_ID,
+  isAnalyticsExcludedPath,
+} from "@/config/analytics-config";
 import { telemetryAllowedHere } from "./telemetry";
 
 let loaded = false;
+
+/**
+ * gtag's documented per-property opt-out global (`window['ga-disable-G-XXXX']`).
+ * When truthy, gtag.js drops every hit for that measurement id before it is
+ * sent — the same switch the "opt out" links in privacy policies use.
+ */
+function setGaDisabled(disabled: boolean): void {
+  (window as unknown as Record<string, boolean>)[
+    `ga-disable-${JAWAFDEHI_GA_MEASUREMENT_ID}`
+  ] = disabled;
+}
+
+/**
+ * Mute or un-mute analytics for the current route. Safe to call before gtag has
+ * loaded (it just sets the global that a later-loading tag will honour) and on
+ * every SPA navigation. Call this on route changes so an already-live tag stops
+ * reporting the moment the visitor enters an excluded (admin) path and resumes
+ * when they leave it.
+ */
+export function applyAnalyticsPathSuppression(pathname: string): void {
+  if (typeof window === "undefined") return;
+  setGaDisabled(isAnalyticsExcludedPath(pathname));
+}
 
 export function loadGoogleAnalytics(): void {
   if (typeof window === "undefined" || loaded || window.gtag) return;
@@ -14,6 +47,11 @@ export function loadGoogleAnalytics(): void {
   // Cloudflare `*.workers.dev` preview — otherwise their page views pollute
   // prod analytics.
   if (!telemetryAllowedHere()) return;
+  // Don't fetch gtag.js while on an admin/casework route: staff landing
+  // directly on /admin (bookmark, or the OIDC /admin/callback fresh load) would
+  // otherwise fire an initial page_view for that path. The consent banner
+  // re-checks on later navigations, so a public route can still load it.
+  if (isAnalyticsExcludedPath(window.location.pathname)) return;
   loaded = true;
 
   const script = document.createElement("script");
@@ -28,6 +66,9 @@ export function loadGoogleAnalytics(): void {
     window.dataLayer!.push(arguments);
   } as Window["gtag"];
 
+  // Set the opt-out flag for the current path before the config page_view fires,
+  // so a tag that loads on an excluded path can never emit even its first hit.
+  applyAnalyticsPathSuppression(window.location.pathname);
   window.gtag("js", new Date());
   window.gtag("config", JAWAFDEHI_GA_MEASUREMENT_ID, { anonymize_ip: true });
 }

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -8,7 +8,10 @@
  * of those paths, and if the tag is already live (visitor navigated in from a
  * public page) it is muted via gtag's `ga-disable-<id>` opt-out flag — which
  * suppresses ALL hits for the property, including Enhanced Measurement's
- * history-change page_views, not just the ones this app fires explicitly.
+ * history-change page_views, not just the ones this app fires explicitly. The
+ * flag is set synchronously inside the history navigation itself (see
+ * `installAnalyticsNavigationSuppression`) so it wins the race against Enhanced
+ * Measurement's own history listener, even on the first hop into an admin route.
  */
 import {
   JAWAFDEHI_GA_MEASUREMENT_ID,
@@ -39,6 +42,59 @@ function setGaDisabled(disabled: boolean): void {
 export function applyAnalyticsPathSuppression(pathname: string): void {
   if (typeof window === "undefined") return;
   setGaDisabled(isAnalyticsExcludedPath(pathname));
+}
+
+/** Set the opt-out flag for a history entry's target URL (the 3rd pushState arg). */
+function suppressForHistoryUrl(url: string | URL | null | undefined): void {
+  if (url == null) {
+    // Same-URL state replacement: reconcile against the current location.
+    applyAnalyticsPathSuppression(window.location.pathname);
+    return;
+  }
+  try {
+    setGaDisabled(
+      isAnalyticsExcludedPath(new URL(String(url), window.location.href).pathname),
+    );
+  } catch {
+    // Malformed URL: leave the flag as-is rather than guess.
+  }
+}
+
+let navigationSuppressionInstalled = false;
+
+/**
+ * Close the SPA race against GA4 Enhanced Measurement. GA auto-collects a
+ * `page_view` on `history.pushState`/`replaceState`/`popstate`; on a
+ * client-side navigation INTO an admin route that fires synchronously, before a
+ * React route effect could set the opt-out flag — so a `useEffect` alone can
+ * leak the first admin hit.
+ *
+ * Wrapping the history methods ourselves sets `ga-disable` for the TARGET path
+ * as part of the same synchronous navigation call, before the URL commits.
+ * Enhanced Measurement wraps these same methods and reads `location` only after
+ * the original runs, so the flag is already set when it decides whether to send
+ * — regardless of which wrapper loaded first. Idempotent; call once on the
+ * client, as early as possible (ideally before gtag.js loads).
+ */
+export function installAnalyticsNavigationSuppression(): void {
+  if (typeof window === "undefined" || navigationSuppressionInstalled) return;
+  navigationSuppressionInstalled = true;
+
+  for (const method of ["pushState", "replaceState"] as const) {
+    const original = window.history[method];
+    window.history[method] = function patchedHistoryMethod(
+      this: History,
+      ...args: Parameters<History["pushState"]>
+    ): void {
+      suppressForHistoryUrl(args[2]);
+      return original.apply(this, args);
+    } as History[typeof method];
+  }
+
+  // Back/forward: the URL is already current by the time popstate fires.
+  window.addEventListener("popstate", () => {
+    applyAnalyticsPathSuppression(window.location.pathname);
+  });
 }
 
 export function loadGoogleAnalytics(): void {


### PR DESCRIPTION
## Problem

Staff casework traffic on the auth-gated admin panel (`/admin/*`) was being counted by the production GA4 property (`G-ZDV84KYJDJ`), polluting the public-usage picture the property exists to measure. Once gtag.js loads (after cookie consent), the initial `gtag("config")` page_view plus GA4 **Enhanced Measurement** (history-change page_views) report every `/admin/…` path a signed-in staffer visits.

GA4 has **no** server-side path-exclusion data filter (only Internal-Traffic-by-IP and Developer-Traffic filters), so the exclusion has to be enforced client-side.

## What this does

- **Don't load gtag.js on admin routes.** `loadGoogleAnalytics()` now returns early when the entry route is under an excluded prefix — `/admin` (which also holds the OIDC `/admin/login` and `/admin/callback` flows) plus the legacy `/portal/*` → `/admin/*` and `/moderation` → `/admin/moderation` redirects. Staff who land directly on `/admin` (bookmark, or the OIDC callback fresh page load) — the overwhelming majority of admin traffic — get zero GA.
- **Mute an already-live tag on in-session navigation.** For the rarer case where a visitor accepted analytics on a public page and then client-navigates into `/admin`, the new `AnalyticsRouteGate` toggles gtag's documented `ga-disable-<id>` opt-out flag on every route change. That flag suppresses **all** hits for the property — including Enhanced Measurement history page_views, not just the events this app fires — and un-mutes on the way back out to public routes.

## Deliberately GA-only

The path gate is kept **out** of `telemetryAllowedHere()` (which also gates Sentry) so **Sentry error monitoring keeps running inside the admin panel** — we still want crash reports from casework flows. The cookie consent banner and host/env gates are untouched.

## The pushState race (closed in 6342f97)

GA4 Enhanced Measurement wraps `history.pushState`/`replaceState` and emits a history-change `page_view` *synchronously* on SPA navigation, so a route `useEffect` can't reliably set the opt-out flag before the first `public → /admin` hop leaks. `installAnalyticsNavigationSuppression()` closes this by wrapping the history methods itself and setting `ga-disable` for the **target** path as part of the navigation call, before the URL commits — Enhanced Measurement reads `location` only after the original runs, so the flag is already set when it decides whether to send, regardless of which wrapper loaded first. This makes the exclusion independent of the GA4 property's Enhanced Measurement console setting. The per-route effect remains as a reconcile fallback.

## Tests

- `src/config/analytics-config.test.ts` — `isAnalyticsExcludedPath` (admin, auth flows, legacy redirects, public routes, and look-alike paths like `/administration` that must NOT match).
- `src/lib/ga.test.ts` — `applyAnalyticsPathSuppression` sets/clears the `ga-disable` flag; `loadGoogleAnalytics()` appends **no** `gtag.js` on `/admin` and **does** on a public route.
- `src/components/AnalyticsRouteGate.test.tsx` — drives real navigation (`/cases → /admin → /cases`) asserting mute/un-mute, plus a deterministic race test over real `window.history` that emulates Enhanced Measurement and verifies the `public → /admin` hop emits **no** `page_view` while the return hop stays tracked.

`bun run lint` clean (0 errors); the 3 failing tests in the full suite are pre-existing `tests/ssr/worker.*` failures (a local Node `AbortSignal` realm quirk) that reproduce without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Analytics is now automatically disabled on administrative and casework routes, including during in-app navigation.
  * Analytics tracking resumes when navigating back to public routes.
  * Route matching avoids incorrectly excluding similarly named public paths.

* **Tests**
  * Added coverage for route-based analytics suppression, restoration, and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
