### PR TITLE
feat(proposals): edit a pending change; drop superseded and set_status

### DIFF
--- a/src/components/casework/ProposalQueue.tsx
+++ b/src/components/casework/ProposalQueue.tsx
@@ -31,8 +31,8 @@ import {
   FileJson,
   Hash,
   Inbox,
-  Layers,
   Loader2,
+  Pencil,
   Search,
   X,
 } from "lucide-react";
@@ -44,9 +44,12 @@ export interface ProposalQueueProps {
   // May return a promise: approve/reject are non-idempotent writes, so the pane
   // awaits it to keep the buttons disabled until the request settles.
   onDecision?: (id: string, decision: Decision, notes: string) => void | Promise<void>;
+  // Correct a pending proposal's change before approving. Omit to hide the editor
+  // (e.g. for a read-only viewer). Should REJECT on failure so the pane can show why.
+  onEditIntent?: (id: string, intent: Intent) => void | Promise<void>;
 }
 
-const STATUS_FILTERS: (ProposalStatus | "all")[] = ["all", "pending", "approved", "rejected", "superseded"];
+const STATUS_FILTERS: (ProposalStatus | "all")[] = ["all", "pending", "approved", "rejected"];
 
 const SOURCE_OPTIONS: SignalSource[] = ["ngm_docket", "court_order", "ciaa_press", "news", "caseworker"];
 
@@ -58,7 +61,7 @@ function Pill({ className, children }: { className?: string; children: React.Rea
   );
 }
 
-export default function ProposalQueue({ proposals, onDecision }: ProposalQueueProps) {
+export default function ProposalQueue({ proposals, onDecision, onEditIntent }: ProposalQueueProps) {
   const { t } = useTranslation();
   const [status, setStatus] = useState<ProposalStatus | "all">("pending");
   const [source, setSource] = useState<SignalSource | "all">("all");
@@ -166,7 +169,7 @@ export default function ProposalQueue({ proposals, onDecision }: ProposalQueuePr
         </div>
 
         <div className="lg:sticky lg:top-20 lg:self-start">
-          {selected ? <DetailPane key={selected.id} p={selected} onDecision={onDecision} /> : (
+          {selected ? <DetailPane key={selected.id} p={selected} onDecision={onDecision} onEditIntent={onEditIntent} /> : (
             <p className="rounded-xl border border-dashed bg-white px-4 py-12 text-center text-sm text-muted-foreground">
               {t("admin.proposals.selectPrompt", "Select a proposal to review.")}
             </p>
@@ -188,7 +191,6 @@ function ProposalRow({ p, active, onClick }: { p: CaseUpdateProposal; active: bo
       className={cn(
         "w-full rounded-xl border bg-white px-3 py-3 text-left transition-colors",
         active ? "border-primary/40 ring-1 ring-primary/20" : "hover:bg-slate-50",
-        p.status === "superseded" && "opacity-60",
       )}
     >
       <div className="flex items-center gap-2">
@@ -204,11 +206,6 @@ function ProposalRow({ p, active, onClick }: { p: CaseUpdateProposal; active: bo
       <div className="mt-2 flex items-center gap-1.5">
         <Pill className={band.pill}>{band.label} · {pct(p.confidence)}</Pill>
         {p.status !== "pending" && <Pill className={statusPill(p.status)}>{statusLabel(p.status, t)}</Pill>}
-        {p.provenance.supersedes && (
-          <Pill className="bg-slate-100 text-slate-500 border-slate-200">
-            <Layers className="h-3 w-3" /> {t("admin.proposals.supersedesShort", "supersedes")}
-          </Pill>
-        )}
       </div>
     </button>
   );
@@ -220,6 +217,7 @@ function DetailPane({
 }: {
   p: CaseUpdateProposal;
   onDecision?: (id: string, d: Decision, notes: string) => void | Promise<void>;
+  onEditIntent?: (id: string, intent: Intent) => void | Promise<void>;
 }) {
   const { t } = useTranslation();
   const [notes, setNotes] = useState("");
@@ -227,6 +225,10 @@ function DetailPane({
   // onto the case), so a double-click must not fire two requests. The pane is
   // remounted per proposal via `key`, so this resets on selection change.
   const [submitting, setSubmitting] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [editError, setEditError] = useState("");
+  const [saving, setSaving] = useState(false);
   const band = confidenceBand(p.confidence, t);
   const src = sourceMeta(p.source_kind, t);
   const SrcIcon = src.icon;
@@ -239,6 +241,45 @@ function DetailPane({
       await onDecision?.(p.id, decision, notes);
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const startEditing = () => {
+    setDraft(JSON.stringify(p.intent, null, 2));
+    setEditError("");
+    setEditing(true);
+  };
+
+  const saveEdit = async () => {
+    if (saving) return;
+    // Parse locally first so a typo is a caught mistake rather than a 400 round-trip.
+    // The backend re-validates the shape regardless — this only catches the obvious.
+    let parsed: Intent;
+    try {
+      parsed = JSON.parse(draft) as Intent;
+    } catch (e) {
+      setEditError(
+        t("admin.proposals.invalidJson", {
+          defaultValue: "That isn't valid JSON: {{message}}",
+          message: e instanceof Error ? e.message : String(e),
+        }),
+      );
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !("type" in parsed)) {
+      setEditError(t("admin.proposals.intentNeedsType", "The change must be an object with a `type`."));
+      return;
+    }
+    setEditError("");
+    setSaving(true);
+    try {
+      await onEditIntent?.(p.id, parsed);
+      setEditing(false);
+    } catch (e) {
+      // Server-side rejection (unknown type, missing entry.date, decided proposal).
+      setEditError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -278,13 +319,54 @@ function DetailPane({
         </div>
       </div>
 
-      {/* The proposed change */}
+      {/* The proposed change — correctable while pending */}
       <div className="rounded-xl border bg-slate-50/60 p-3">
-        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-400">{t("admin.proposals.proposedChange", "Proposed change")}</div>
-        <IntentBody intent={p.intent} />
-        <p className="mt-2 flex items-start gap-1.5 text-xs text-slate-500">
-          <ArrowRight className="mt-0.5 h-3.5 w-3.5 shrink-0" /> {applyEffect(p.intent, t)}
-        </p>
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">{t("admin.proposals.proposedChange", "Proposed change")}</div>
+          {isPending && onEditIntent && !editing && (
+            <button
+              onClick={startEditing}
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/10"
+            >
+              <Pencil className="h-3 w-3" /> {t("admin.proposals.edit", "Edit")}
+            </button>
+          )}
+        </div>
+
+        {editing ? (
+          <div className="space-y-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              spellCheck={false}
+              aria-label={t("admin.proposals.editIntentLabel", "Proposed change as JSON")}
+              className="min-h-[180px] w-full rounded-lg border bg-white p-2 font-mono text-[11px] leading-relaxed text-slate-800"
+            />
+            <p className="text-[11px] text-slate-500">
+              {t(
+                "admin.proposals.editHint",
+                "Only the proposed change is editable — provenance and confidence record where the fact came from and stay as filed.",
+              )}
+            </p>
+            {editError && <p className="text-[11px] font-medium text-red-600">{editError}</p>}
+            <div className="flex items-center gap-2">
+              <Button size="sm" disabled={saving} onClick={saveEdit}>
+                {saving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Check className="mr-1 h-3.5 w-3.5" />}
+                {t("admin.proposals.saveEdit", "Save change")}
+              </Button>
+              <Button size="sm" variant="ghost" disabled={saving} onClick={() => setEditing(false)}>
+                {t("admin.proposals.cancelEdit", "Cancel")}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <IntentBody intent={p.intent} />
+            <p className="mt-2 flex items-start gap-1.5 text-xs text-slate-500">
+              <ArrowRight className="mt-0.5 h-3.5 w-3.5 shrink-0" /> {applyEffect(p.intent, t)}
+            </p>
+          </>
+        )}
       </div>
 
       {/* Provenance */}
@@ -302,11 +384,6 @@ function DetailPane({
         <Field label={t("admin.proposals.dedupKey", "Dedup key")} full>
           <code className="break-all font-mono text-[11px] text-slate-600">{p.provenance.dedup_key}</code>
         </Field>
-        {p.provenance.supersedes && (
-          <Field label={t("admin.proposals.supersedes", "Supersedes")} full>
-            <code className="font-mono text-[11px] text-slate-600">{p.provenance.supersedes}</code>
-          </Field>
-        )}
       </dl>
 
       {/* Linked records (subject_refs) */}
@@ -333,13 +410,15 @@ function DetailPane({
             className="min-h-[64px] text-sm"
           />
           <div className="flex items-center gap-2">
-            <Button disabled={submitting} className="bg-green-600 hover:bg-green-700" onClick={() => decide("approved")}>
+            {/* Disabled while editing: approving with an unsaved draft would apply the
+                ORIGINAL intent and silently discard the correction. */}
+            <Button disabled={submitting || editing} className="bg-green-600 hover:bg-green-700" onClick={() => decide("approved")}>
               {submitting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
               {submitting
                 ? t("admin.proposals.deciding", "Working…")
                 : t("admin.proposals.approve", "Approve & apply")}
             </Button>
-            <Button disabled={submitting} variant="outline" className="text-red-600 hover:bg-red-50" onClick={() => decide("rejected")}>
+            <Button disabled={submitting || editing} variant="outline" className="text-red-600 hover:bg-red-50" onClick={() => decide("rejected")}>
               <X className="mr-1 h-4 w-4" /> {t("admin.proposals.reject", "Reject")}
             </Button>
             <span className="ml-auto inline-flex items-center gap-1 text-[11px] text-slate-400">
@@ -396,15 +475,6 @@ function IntentBody({ intent }: { intent: Intent }) {
         </div>
       );
     }
-    case "set_status":
-      return (
-        <div className="flex items-center gap-2 text-sm">
-          <code className="rounded bg-slate-200 px-1.5 py-0.5 font-mono text-xs">{intent.from ?? "—"}</code>
-          <ArrowRight className="h-4 w-4 text-slate-400" />
-          <code className="rounded bg-green-100 px-1.5 py-0.5 font-mono text-xs text-green-800">{intent.to}</code>
-          <span className="text-xs text-slate-400">({intent.field})</span>
-        </div>
-      );
     case "link_material":
       return (
         <div className="space-y-1 text-sm">

--- a/src/components/casework/ProposalQueue.tsx
+++ b/src/components/casework/ProposalQueue.tsx
@@ -214,6 +214,7 @@ function ProposalRow({ p, active, onClick }: { p: CaseUpdateProposal; active: bo
 function DetailPane({
   p,
   onDecision,
+  onEditIntent,
 }: {
   p: CaseUpdateProposal;
   onDecision?: (id: string, d: Decision, notes: string) => void | Promise<void>;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1758,8 +1758,6 @@
       "detectedBy": "Detected by",
       "sourceLabel": "Source",
       "dedupKey": "Dedup key",
-      "supersedes": "Supersedes",
-      "supersedesShort": "supersedes",
       "linkedRecords": "Linked records",
       "notesPlaceholder": "Review note (optional)…",
       "approve": "Approve & apply",
@@ -1779,12 +1777,19 @@
       "toastDetail": "{{intent}} on “{{title}}”.",
       "opCount_one": "{{count}} op",
       "opCount_other": "{{count}} ops",
+      "edit": "Edit",
+      "editIntentLabel": "Proposed change as JSON",
+      "editHint": "Only the proposed change is editable — provenance and confidence record where the fact came from and stay as filed.",
+      "saveEdit": "Save change",
+      "cancelEdit": "Cancel",
+      "invalidJson": "That isn't valid JSON: {{message}}",
+      "intentNeedsType": "The change must be an object with a `type`.",
+      "editFailed": "Could not save the change.",
       "filters": {
         "all": "All",
         "pending": "Pending",
         "approved": "Approved",
-        "rejected": "Rejected",
-        "superseded": "Superseded"
+        "rejected": "Rejected"
       },
       "band": {
         "high": "High",
@@ -1800,21 +1805,18 @@
       },
       "intents": {
         "append_timeline_entry": "Add timeline entry",
-        "set_status": "Change status",
         "link_material": "Link material",
         "raw_patch": "Raw patch"
       },
       "effects": {
         "append_timeline_entry": "Appends this entry to the case's public timeline.",
-        "set_status": "Sets the case {{field}} field to “{{to}}”.",
         "link_material": "Attaches an existing document to the case (no new document is created).",
         "raw_patch": "Applies these RFC-6902 operations to the case record."
       },
       "statuses": {
         "pending": "Pending",
         "approved": "Approved",
-        "rejected": "Rejected",
-        "superseded": "Superseded"
+        "rejected": "Rejected"
       }
     },
     "caseForm": {

--- a/src/i18n/locales/ne.json
+++ b/src/i18n/locales/ne.json
@@ -1730,8 +1730,6 @@
       "detectedBy": "पहिचान गर्ने",
       "sourceLabel": "स्रोत",
       "dedupKey": "दोहोरोपन कुञ्जी",
-      "supersedes": "प्रतिस्थापित प्रस्ताव",
-      "supersedesShort": "प्रतिस्थापन",
       "linkedRecords": "सम्बन्धित अभिलेख",
       "notesPlaceholder": "समीक्षा टिप्पणी (वैकल्पिक)…",
       "approve": "स्वीकृत गरी लागू गर्नुहोस्",
@@ -1751,12 +1749,19 @@
       "toastDetail": "“{{title}}” मा {{intent}}।",
       "opCount_one": "{{count}} कार्य",
       "opCount_other": "{{count}} कार्यहरू",
+      "edit": "सम्पादन",
+      "editIntentLabel": "प्रस्तावित परिवर्तन (JSON)",
+      "editHint": "प्रस्तावित परिवर्तन मात्र सम्पादन गर्न सकिन्छ — स्रोत र विश्वसनीयता तथ्य कहाँबाट आयो भन्ने अभिलेख हुनाले दर्ता भएअनुसार यथावत् रहन्छ।",
+      "saveEdit": "परिवर्तन सुरक्षित गर्नुहोस्",
+      "cancelEdit": "रद्द गर्नुहोस्",
+      "invalidJson": "यो मान्य JSON होइन: {{message}}",
+      "intentNeedsType": "परिवर्तनमा `type` सहितको वस्तु हुनुपर्छ।",
+      "editFailed": "परिवर्तन सुरक्षित गर्न सकिएन।",
       "filters": {
         "all": "सबै",
         "pending": "विचाराधीन",
         "approved": "स्वीकृत",
-        "rejected": "अस्वीकृत",
-        "superseded": "प्रतिस्थापित"
+        "rejected": "अस्वीकृत"
       },
       "band": {
         "high": "उच्च",
@@ -1772,21 +1777,18 @@
       },
       "intents": {
         "append_timeline_entry": "समयरेखामा प्रविष्टि थप्नुहोस्",
-        "set_status": "स्थिति परिवर्तन गर्नुहोस्",
         "link_material": "सामग्री जोड्नुहोस्",
         "raw_patch": "प्रत्यक्ष प्याच"
       },
       "effects": {
         "append_timeline_entry": "यो प्रविष्टि मुद्दाको सार्वजनिक समयरेखामा थपिनेछ।",
-        "set_status": "मुद्दाको {{field}} फिल्ड “{{to}}” मा राखिनेछ।",
         "link_material": "पहिले नै रहेको कागजात मुद्दासँग जोडिनेछ (नयाँ कागजात बन्दैन)।",
         "raw_patch": "यी RFC-6902 कार्यहरू मुद्दाको अभिलेखमा लागू गरिनेछन्।"
       },
       "statuses": {
         "pending": "विचाराधीन",
         "approved": "स्वीकृत",
-        "rejected": "अस्वीकृत",
-        "superseded": "प्रतिस्थापित"
+        "rejected": "अस्वीकृत"
       }
     },
     "caseForm": {

--- a/src/lib/proposal-ui.tsx
+++ b/src/lib/proposal-ui.tsx
@@ -63,8 +63,6 @@ export function statusPill(s: ProposalStatus): string {
       return "bg-blue-100 text-blue-800 border-blue-200";
     case "rejected":
       return "bg-red-100 text-red-700 border-red-200";
-    case "superseded":
-      return "bg-slate-100 text-slate-500 border-slate-200";
   }
 }
 
@@ -114,7 +112,6 @@ const STATUS_FALLBACK: Record<ProposalStatus, string> = {
   pending: "Pending",
   approved: "Approved",
   rejected: "Rejected",
-  superseded: "Superseded",
 };
 
 export function statusLabel(s: ProposalStatus, t: TFunction): string {
@@ -125,7 +122,6 @@ export function statusLabel(s: ProposalStatus, t: TFunction): string {
 
 const INTENT_FALLBACK: Record<IntentType, string> = {
   append_timeline_entry: "Add timeline entry",
-  set_status: "Change status",
   link_material: "Link material",
   raw_patch: "Raw patch",
 };
@@ -139,8 +135,6 @@ export function intentSummary(i: Intent, t: TFunction): string {
   switch (i.type) {
     case "append_timeline_entry":
       return i.entry.title;
-    case "set_status":
-      return `${i.from ?? "—"} → ${i.to}`;
     case "link_material":
       return `${i.relation}: ${shortIri(i.material)}`;
     case "raw_patch": {
@@ -161,12 +155,6 @@ export function applyEffect(i: Intent, t: TFunction): string {
         "admin.proposals.effects.append_timeline_entry",
         "Appends this entry to the case's public timeline.",
       );
-    case "set_status":
-      return t("admin.proposals.effects.set_status", {
-        defaultValue: "Sets the case {{field}} field to “{{to}}”.",
-        field: i.field,
-        to: i.to,
-      });
     case "link_material":
       return t(
         "admin.proposals.effects.link_material",

--- a/src/pages/CaseworkProposals.tsx
+++ b/src/pages/CaseworkProposals.tsx
@@ -8,11 +8,12 @@ import CaseworkLayout from "@/components/CaseworkLayout";
 import ProposalQueue from "@/components/casework/ProposalQueue";
 import {
   approveProposal,
+  editProposalIntent,
   listProposals,
   proposalErrorMessage,
   rejectProposal,
 } from "@/services/proposals-api";
-import type { CaseUpdateProposal } from "@/types/proposals";
+import type { CaseUpdateProposal, Intent } from "@/types/proposals";
 import { intentLabel } from "@/lib/proposal-ui";
 import { toast } from "@/hooks/use-toast";
 
@@ -71,6 +72,21 @@ export default function CaseworkProposals() {
     }
   };
 
+  // Deliberately RE-THROWS: ProposalQueue shows the reason inline next to the JSON
+  // it rejected, which is where the reviewer is looking. A toast here would move the
+  // explanation away from the text that caused it and let the editor close as if the
+  // save had worked.
+  const onEditIntent = async (id: string, intent: Intent) => {
+    try {
+      const updated = await editProposalIntent(id, intent);
+      setProposals((prev) => prev.map((p) => (p.id === id ? updated : p)));
+    } catch (e) {
+      throw new Error(
+        proposalErrorMessage(e, t("admin.proposals.editFailed", "Could not save the change.")),
+      );
+    }
+  };
+
   return (
     <CaseworkLayout>
       {loading ? (
@@ -80,7 +96,7 @@ export default function CaseworkProposals() {
       ) : err ? (
         <p className="text-sm text-red-600">{err}</p>
       ) : (
-        <ProposalQueue proposals={proposals} onDecision={onDecision} />
+        <ProposalQueue proposals={proposals} onDecision={onDecision} onEditIntent={onEditIntent} />
       )}
     </CaseworkLayout>
   );

--- a/src/services/proposals-api.test.ts
+++ b/src/services/proposals-api.test.ts
@@ -27,12 +27,13 @@ vi.mock("axios", () => {
   const instance = {
     get: record("get"),
     post: record("post"),
+    patch: record("patch"),
     interceptors: { request: { use: () => undefined } },
   };
   return { default: { create: () => instance } };
 });
 
-import { listProposals } from "./proposals-api";
+import { editProposalIntent, listProposals } from "./proposals-api";
 
 // Minimal wire row — only the fields adapt() reads are needed.
 function row(id: number) {
@@ -47,7 +48,6 @@ function row(id: number) {
     source: "",
     detected_by: "consumer:proposal-builder",
     dedup_key: `docket:${id}`,
-    supersedes: null,
     origin_subject: "",
     origin_msg_id: "",
     subject_refs: [],
@@ -121,13 +121,30 @@ describe("listProposals pagination", () => {
     expect(out.length).toBeLessThanOrEqual(50);
   });
 
-  it("normalises nullable reviewer / notes / supersedes", async () => {
+  it("normalises nullable reviewer / notes", async () => {
     responses.get = [page([1], null)];
 
     const [p] = await listProposals();
 
     expect(p.review.reviewer).toBeNull();
     expect(p.review.notes).toBe("");
-    expect(p.provenance.supersedes).toBeUndefined();
+  });
+});
+
+describe("editProposalIntent", () => {
+  it("PATCHes the intent sub-resource and adapts the response", async () => {
+    const corrected = {
+      type: "append_timeline_entry" as const,
+      entry: { date: "2026-08-19", title: "Corrected" },
+    };
+    responses.patch = [{ data: { ...row(7), intent: corrected } }];
+
+    const out = await editProposalIntent("7", corrected);
+
+    expect(calls).toEqual([
+      { method: "patch", url: "/api/case-update-proposals/7/intent/", config: undefined },
+    ]);
+    expect(out.id).toBe("7");
+    expect(out.intent).toEqual(corrected);
   });
 });

--- a/src/services/proposals-api.ts
+++ b/src/services/proposals-api.ts
@@ -25,7 +25,6 @@ interface ApiRow {
   dedup_key: string;
   // Nullable on the wire (blank CharFields / an unset reviewer); adapt() below
   // normalises each into the shape the UI wants.
-  supersedes: string | null;
   origin_subject: string;
   origin_msg_id: string;
   subject_refs: string[];
@@ -50,7 +49,6 @@ function adapt(row: ApiRow): CaseUpdateProposal {
       source: row.source,
       detected_by: row.detected_by,
       dedup_key: row.dedup_key,
-      supersedes: row.supersedes || undefined,
     },
     origin_event: {
       subject: row.origin_subject,
@@ -120,6 +118,16 @@ export async function listProposals(params?: {
     if (!page) break;
   }
   return rows.map(adapt);
+}
+
+// Correct a PENDING proposal's proposed change before approving it. Only the
+// intent is editable server-side; provenance and confidence are immutable.
+export async function editProposalIntent(
+  id: string,
+  intent: CaseUpdateProposal["intent"],
+): Promise<CaseUpdateProposal> {
+  const { data } = await client.patch<ApiRow>(`${BASE}/${id}/intent/`, { intent });
+  return adapt(data);
 }
 
 export async function approveProposal(id: string, notes = ""): Promise<CaseUpdateProposal> {

--- a/src/types/proposals.ts
+++ b/src/types/proposals.ts
@@ -1,8 +1,7 @@
-// PROTOTYPE — types for the caseworker "case update proposal" review queue.
-// Mirrors work/2026-07-27-case-enrichment-events/DESIGN.md §9 + PROPOSAL-EXAMPLES.md.
-// This is a design prototype fed by mock data; no backend endpoint exists yet.
+// Types for the caseworker "case update proposal" review queue, mirroring the
+// CaseUpdateProposal model served by /api/case-update-proposals/.
 
-export type ProposalStatus = "pending" | "approved" | "rejected" | "superseded";
+export type ProposalStatus = "pending" | "approved" | "rejected";
 
 // Where the raw signal came from — a UI convenience classification (in the real
 // system this is derived from provenance.source / the subject it arrived on).
@@ -35,9 +34,11 @@ export interface JsonPatchOp {
 
 // The tagged-union "change intent" — typed intents for the common cases + a raw
 // RFC-6902 patch escape hatch. This is the ONLY part the LLM (`claude -p`) emits.
+// Must stay in step with SUPPORTED_INTENT_TYPES on the backend, which accepts and
+// applies exactly these three (`set_status` was dropped: a Case has no legal-status
+// field, so status facts go in the timeline and raw_patch covers the rest).
 export type Intent =
   | { type: "append_timeline_entry"; entry: TimelineEntry }
-  | { type: "set_status"; field: string; from?: string; to: string }
   | { type: "link_material"; material: string; relation: string }
   | { type: "raw_patch"; patch: JsonPatchOp[] };
 
@@ -47,7 +48,6 @@ export interface Provenance {
   source: string;
   detected_by: string; // "consumer:proposal-builder" | "caseworker:<id>"
   dedup_key: string;
-  supersedes?: string;
 }
 
 export interface OriginEvent {


### PR DESCRIPTION
Reviewer-facing half of edit-before-approve, plus the UI side of the same trim. Backend: JawafdehiAPI#390 (**merge that first**).

## Edit
The detail pane can now open a pending proposal's change as JSON, correct it, and save via `PATCH .../intent/` before approving — so a nearly-right draft gets fixed instead of rejected.

- JSON is parsed **locally first**, so an obvious typo is a caught mistake rather than a 400 round-trip. The backend re-validates the shape regardless.
- A server rejection (unknown type, missing `entry.date`, already-decided) is shown **inline next to the JSON that caused it**, not as a toast. `onEditIntent` deliberately re-throws for this reason — a toast would move the explanation away from the text the reviewer is looking at and let the editor close as though the save had worked.
- **Approve and reject are disabled while the editor is open.** Approving with an unsaved draft would apply the *original* intent and silently discard the correction — the one way this feature could lose a reviewer's work.
- `onEditIntent` is optional, so a read-only viewer simply gets no editor.

## Drops
`set_status` leaves the `Intent` union; `superseded`/`supersedes` leave the status type, the provenance type, the API adapter, the row and detail panes, and both locale files. None was reachable — the backend never applied `set_status`, had no producer for `supersedes`, and never set the `superseded` status. The union now carries a note that it must track `SUPPORTED_INTENT_TYPES`, since the two are only correct together.

## Verification
- `tsc` clean, eslint clean.
- **6 service tests pass** (added one asserting the PATCH hits the `intent/` sub-resource and adapts the response).
- **en/ne at parity, 65 keys each** (verified programmatically). Nepali reuses the app's existing terminology rather than coining new terms.
- Full suite: 265 pass. The 3 failures in `tests/ssr/worker.*` are **pre-existing and unrelated** (an undici/AbortSignal artifact — confirmed identical with these changes stashed, and they pass in CI).

Note: I edited the locale files with targeted edits rather than a JSON round-trip — `json.dump` reformats unrelated compact blocks elsewhere in these files, which I caught and reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline JSON editing for pending proposal changes, with validation and save/cancel actions.
  * Updated proposals immediately after a successful edit.
* **Changes**
  * Removed superseded proposal statuses and supersedes details from the interface.
  * Removed support for the set-status intent from proposal descriptions.
* **Bug Fixes**
  * Added clear inline feedback for invalid JSON, missing intent types, and save failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->